### PR TITLE
fix(UploadZone): add aria-label to hidden file input

### DIFF
--- a/apps/web/src/pages/import/UploadZone.tsx
+++ b/apps/web/src/pages/import/UploadZone.tsx
@@ -103,6 +103,7 @@ export function UploadZone({ onFilesAdded }: UploadZoneProps) {
         multiple
         accept=".csv,.pdf"
         className="hidden"
+        aria-label="Upload CSV or PDF files"
         onChange={handleChange}
       />
     </div>


### PR DESCRIPTION
## Summary

Add `aria-label` to the hidden file input in `UploadZone`.

## Fix

```tsx
<input
  ...
  aria-label="Upload CSV or PDF files"
  ...
/>
```

## Why

The UploadZone has good keyboard/screen reader foundations (`role="button"`, `tabIndex={0}`, `onKeyDown`). But the hidden `<input type="file">` had no `aria-label` — screen readers would announce "file" or "no label", giving users no context.

## Testing

TypeScript compiles without errors. No visual change to the UI.

Closes #3