### PR TITLE
test(StorageManager): add unit tests for persistence and export tracking

### DIFF
--- a/apps/web/src/lib/db/StorageManager.test.ts
+++ b/apps/web/src/lib/db/StorageManager.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { StorageManager } from './StorageManager'
+import { db } from './db'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+vi.mock('./db', () => ({
+  db: {
+    settings: {
+      put: vi.fn(),
+    },
+  },
+}))
+
+const mockPersist = vi.fn()
+const mockPersisted = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('navigator', {
+    storage: {
+      persist: mockPersist,
+      persisted: mockPersisted,
+    },
+  })
+})
+
+// ─── initPersistence ─────────────────────────────────────────────────────
+
+describe('StorageManager.initPersistence()', () => {
+  it('returns early when navigator.storage.persist is not available', async () => {
+    vi.stubGlobal('navigator', { storage: undefined })
+    await expect(StorageManager.initPersistence()).resolves.toBeUndefined()
+    // No db.settings.put should be called
+    expect(db.settings.put).not.toHaveBeenCalled()
+  })
+
+  it('sets permission to granted when already persisted', async () => {
+    mockPersisted.mockResolvedValue(true)
+    await StorageManager.initPersistence()
+    expect(mockPersist).not.toHaveBeenCalled()
+    expect(db.settings.put).toHaveBeenCalledWith({
+      key: 'storagePermission',
+      value: 'granted',
+    })
+  })
+
+  it('requests persistence and stores granted=true when successful', async () => {
+    mockPersisted.mockResolvedValue(false)
+    mockPersist.mockResolvedValue(true)
+    await StorageManager.initPersistence()
+    expect(db.settings.put).toHaveBeenCalledWith({
+      key: 'storagePermission',
+      value: 'granted',
+    })
+  })
+
+  it('requests persistence and stores granted=false when denied', async () => {
+    mockPersisted.mockResolvedValue(false)
+    mockPersist.mockResolvedValue(false)
+    await StorageManager.initPersistence()
+    expect(db.settings.put).toHaveBeenCalledWith({
+      key: 'storagePermission',
+      value: 'denied',
+    })
+  })
+
+  it('stores error on exception', async () => {
+    mockPersisted.mockRejectedValue(new Error('Storage API unavailable'))
+    await StorageManager.initPersistence()
+    expect(db.settings.put).toHaveBeenCalledWith({
+      key: 'storagePermission',
+      value: 'error',
+    })
+  })
+})
+
+// ─── recordExportEvent ───────────────────────────────────────────────────
+
+describe('StorageManager.recordExportEvent()', () => {
+  it('stores the current ISO timestamp as lastExportedAt', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-25T12:00:00.000Z'))
+
+    await StorageManager.recordExportEvent()
+
+    expect(db.settings.put).toHaveBeenCalledWith({
+      key: 'lastExportedAt',
+      value: '2026-03-25T12:00:00.000Z',
+    })
+
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary

Adds unit tests for the actual StorageManager methods:
- `initPersistence()` — requests browser persistent storage
- `recordExportEvent()` — records export timestamp

**Note**: Issue #13 described localStorage methods (getItem/setItem), but the actual StorageManager uses IndexedDB via Dexie. Tests were written for the real code.

## Test Coverage

### initPersistence()
| Scenario | Expected |
|----------|----------|
| Storage API unavailable | No-op, no DB write |
| Already persisted | Sets `storagePermission=granted`, does not call persist |
| Persistence granted | Sets `storagePermission=granted` |
| Persistence denied | Sets `storagePermission=denied` |
| Exception thrown | Sets `storagePermission=error` |

### recordExportEvent()
| Scenario | Expected |
|----------|----------|
| Always | Writes current ISO timestamp to `lastExportedAt` |

## Test Results

```
✓ src/lib/db/StorageManager.test.ts (6 tests)
```

Closes #13