### PR TITLE
feat(web): portfolio hub phase 2 — FX rates, fund details, portfolio pages

### DIFF
--- a/.agents/skills/atomic-commit/SKILL.md
+++ b/.agents/skills/atomic-commit/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: atomic-commit
+description: |
+  Review unstaged changes and construct atomic git commits using conventional commit convention.
+  Groups changes by logical boundaries, produces conventional commit messages (type(scope): description),
+  and waits for user approval before executing. Enforces breaking change markers (! + BREAKING CHANGE footer).
+metadata:
+  author: lokfi
+  version: "1.0.0"
+  openclaw:
+    requires:
+      bins:
+        - git
+---
+
+# Atomic Conventional Commit
+
+Creates well-structured, atomic git commits following the [Conventional Commits](https://www.conventionalcommits.org/) specification. Use when you need to commit changes with proper messaging and logical separation.
+
+## Workflow
+
+Perform the following steps carefully:
+
+1. **Review Unstaged Changes**: Run `git status`, `git diff`, and `git diff --cached` to thoroughly analyze the current state of modified, deleted, or added files.
+
+2. **Logically Group Changes**: Identify logical, highly cohesive boundaries between modified features. Strive to separate files such that a single commit solves one and only one problem. For instance, separate data model refactoring from documentation updates.
+
+3. **Determine Conventional Commit Structure**: Based on the conventional commit specification, structure a commit message for each group.
+   - Format: `<type>(scope): <description>`
+   - Scope must match the package name — e.g. changes in `@lokfi/parser-core` → `feat(parser-core): ...`. If changes do not belong to any package, scope = `root`.
+   - Common types: `feat` (new feature), `fix` (bug fix), `docs` (documentation), `style` (formatting), `refactor` (code refactoring), `test` (tests), `chore` (maintenance).
+   - **Breaking changes**: If a change introduces a breaking API, interface, or behavioral change:
+     - Append `!` after the type/scope: `feat(parser-core)!: remove legacy parse method`
+     - Add a `BREAKING CHANGE:` footer in the commit body describing what broke and how to migrate:
+       ```
+       feat(parser-core)!: remove legacy parse method
+
+       BREAKING CHANGE: `parse()` has been removed. Use `parseAsync()` instead.
+       ```
+     - Both `!` and the footer are required when a change is breaking — do not use one without the other.
+
+4. **Preview Commits**: Present each atomic group with its proposed commit message to the user.
+
+5. **Wait for Approval**: Wait for explicit user approval before executing any `git add` + `git commit` commands.
+
+## Rules
+
+- Never commit without explicit user approval
+- Never skip `BREAKING CHANGE:` footer for breaking changes
+- Group by logical concern, not by file type or chronology
+- Prefer multiple focused commits over one large commit

--- a/.agents/skills/session-end/SKILL.md
+++ b/.agents/skills/session-end/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: session-end
+description: |
+  Review what was accomplished this session and update relevant docs, memory files, and TODOs.
+  Examines conversation history, updates architecture docs, memory/rule files, and resolves completed TODOs.
+metadata:
+  author: lokfi
+  version: "1.0.0"
+  openclaw:
+    requires:
+      bins:
+        - git
+---
+
+# Session End
+
+Reviews the current session's work, updates project documentation and memory files, and resolves completed TODOs. Use at the end of a working session to keep project state consistent and documented.
+
+## Workflow
+
+Perform the following steps carefully:
+
+1. **Review Session Progress**: Review the conversation history to understand the tasks completed and code changed during this session.
+
+2. **Update Project Documents**: Identify relevant project documentation in `docs/` (architecture docs, setup guides, data schemas, etc.) and update any information that has become outdated based on recent changes.
+
+3. **Update Memory Files**: Inspect memory and configuration files in `.claude/` (e.g. `MEMORY.md`, `RULES.md`, memory files under `.claude/projects/`). Update any rules, context, or definitions that reflect the new state of the project.
+
+4. **Update TODOs**: Search the project for TODO items (in `TODO.md` or inline code comments). Mark as done or remove any that were completed this session.
+
+5. **Summarize Session**: Provide a concise summary detailing what was accomplished, which documents and memory files were updated, and which TODOs were resolved.
+
+## Rules
+
+- Only update docs/memory that have actually changed — don't touch everything
+- Mark TODOs as done, don't just delete them (preserves audit trail)
+- The summary should be brief and factual, not a rehash of the conversation

--- a/.agents/skills/tigeropen-typescript/SKILL.md
+++ b/.agents/skills/tigeropen-typescript/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: tigeropen-typescript
+description: |
+  Tiger Brokers OpenAPI TypeScript SDK — complete skills for AI coding tools. Covers SDK setup, market data queries, trading, and real-time push subscriptions. Use when building trading applications in TypeScript/Node.js, querying market data, placing orders, or integrating Tiger Brokers API.
+  老虎证券 OpenAPI TypeScript SDK 完整技能集。涵盖 SDK 配置、行情查询、交易、实时推送订阅。适用于用 TypeScript/Node.js 构建交易应用、查询行情数据、下单交易。
+  用户提到以下关键词时自动使用 / Auto-activate on these keywords: 行情、报价、K线、买入、卖出、下单、撤单、交易、持仓、资金、账户、订单、期权、期货、推送、订阅、TypeScript SDK、tigeropen typescript、quote、price、K-line、order、buy、sell、trade、position、asset、option、future、push
+license: MIT
+compatibility: Requires Node.js 16+, supports ESM and CommonJS
+metadata:
+  author: tigerbrokers
+  version: "0.1.0"
+  language: zh_CN, en_US
+---
+
+# Tiger Open API TypeScript SDK
+
+> 老虎量化开放平台 TypeScript SDK 完整技能集 / Complete AI skill set for Tiger Brokers OpenAPI (TypeScript)
+
+> **安全警告 / Safety Warning**: 交易涉及真实资金。生成交易代码时默认使用**模拟账户**，除非用户明确要求实盘。实盘下单前必须与用户确认订单详情。
+> Trading involves real money. Default to **Paper Trading** when generating trading code. Always confirm order details before live orders.
+
+- Docs: https://docs.itigerup.com/docs/prepare
+- npm: `npm install tigeropen` | Node.js 16+, ESM/CommonJS
+
+## Language Rules / 语言规则
+
+根据用户输入语言自动回复。技术术语（代码、API 名称、参数名）保持原文不翻译。
+Reply in the user's language. Keep technical terms (code, API names, parameters) as-is.
+
+## Reference Guides
+
+- **[Quickstart](references/quickstart.md)** — SDK install, config, client setup, error handling
+- **[Market Data](references/quote.md)** — Real-time quotes, K-lines, depth, options, futures
+- **[Trading](references/trade.md)** — Place/modify/cancel orders, positions, assets
+- **[Real-time Push](references/push.md)** — WebSocket push for quotes, orders, positions
+- **[Account Management](references/account.md)** — Account list, assets, positions, fund transfer, deposit/withdrawal
+- **[Options Trading](references/option.md)** — Option chain, expirations, Greeks, multi-leg strategies
+
+## Quick Start
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/client/http-client';
+import { QuoteClient } from 'tigeropen/quote/quote-client';
+import { TradeClient } from 'tigeropen/trade/trade-client';
+
+// 1. 创建配置 / Create config
+const config = createClientConfig({
+  tigerId: 'your_tiger_id',
+  privateKey: 'your_rsa_private_key',
+  account: 'your_account',
+});
+
+// 2. 查询行情 / Query quotes
+const httpClient = new HttpClient(config);
+const qc = new QuoteClient(httpClient);
+const quotes = await qc.getBrief(['AAPL', 'TSLA']);
+console.log(quotes);
+
+// 3. 交易操作 / Trading
+const tc = new TradeClient(httpClient, config.account);
+const orders = await tc.getOrders();
+console.log(orders);
+```
+
+## When to Use Each Reference
+
+| Task | Reference |
+|------|-----------|
+| First time setup, SDK install, auth config | [quickstart.md](references/quickstart.md) |
+| Get stock/option/future quotes, K-lines | [quote.md](references/quote.md) |
+| Place/modify/cancel orders, check positions/assets | [trade.md](references/trade.md) |
+| Real-time streaming data via WebSocket | [push.md](references/push.md) |
+| Account info, assets, fund transfer, deposit/withdrawal | [account.md](references/account.md) |
+| Option chain, Greeks, expirations, multi-leg orders | [option.md](references/option.md) |
+
+## Common Symbols / 常见标的速查
+
+### 港股 HK
+
+| 常见称呼 | 代码 Symbol |
+|---------|------------|
+| 腾讯 | 00700 |
+| 阿里巴巴 | 09988 |
+| 美团 | 03690 |
+| 小米 | 01810 |
+
+### 美股 US
+
+| 常见称呼 | 代码 Symbol |
+|---------|------------|
+| 苹果 / Apple | AAPL |
+| 特斯拉 / Tesla | TSLA |
+| 英伟达 / NVIDIA | NVDA |
+| 微软 / Microsoft | MSFT |
+| 谷歌 / Google | GOOGL |
+| 亚马逊 / Amazon | AMZN |
+| Meta | META |
+| 老虎证券 / TIGR | TIGR |
+| 标普500 ETF / SPY | SPY |
+| 纳指 ETF / QQQ | QQQ |

--- a/.agents/skills/tigeropen-typescript/references/account.md
+++ b/.agents/skills/tigeropen-typescript/references/account.md
@@ -1,0 +1,240 @@
+
+# Tiger OpenAPI TypeScript SDK — 账户管理 / Account Management
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/accounts
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/dist/esm/client/http-client.js';
+import { TradeClient } from 'tigeropen/dist/esm/trade/trade-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+
+const httpClient = new HttpClient(config);
+const tc = new TradeClient(httpClient, config.account);
+```
+
+---
+
+## 账户列表 / Account List
+
+```typescript
+// 不传 account 返回所有账号（综合、环球、模拟）
+// Omit account to return all accounts
+const result = await tc.accounts({});
+console.log(result);
+
+// 返回字段 / Response fields:
+// account     - 账户号（综合5~10位数字，模拟17位，环球以U开头）
+// capability  - CASH / RegTMargin / PMGRN
+// status      - Funded / Open / Pending / Rejected / Closed
+// accountType - STANDARD / GLOBAL / PAPER
+```
+
+---
+
+## 账户资产 / Account Assets
+
+### 环球账户 / Global Account
+
+```typescript
+const result = await tc.assets({
+  account: 'DU000001',
+  segment: true,       // 按证券/期货分类
+  market_value: true   // 按市场分市值（仅环球账户）
+});
+
+// 主要返回字段 / Key response fields:
+// netLiquidation  - 净清算值
+// availableFunds  - 可用资金
+// buyingPower     - 购买力
+// cashValue       - 现金
+// initMarginReq   - 初始保证金要求
+// maintMarginReq  - 维持保证金要求
+// unrealizedPnl   - 浮动盈亏
+// realizedPnl     - 已实现盈亏
+// segments        - 按交易品种（S=证券, C=期货）分类
+// marketValues    - 按市场（USD/HKD）分类
+```
+
+### 综合/模拟账号 / Standard/Paper Account
+
+```typescript
+const result = await tc.primeAssets({
+  account: '123456',
+  base_currency: 'USD',
+  consolidated: true   // SEC+FUND聚合显示
+});
+
+// segments 数组主要字段 / Segment key fields:
+// category              - S（证券）/ C（期货）/ F（基金）/ D（数字货币）
+// capability            - RegTMargin / Cash
+// buyingPower           - 最大购买力（保证金账户日内4倍，隔夜2倍）
+// cashAvailableForTrade - 可用资金
+// cashBalance           - 现金余额
+// netLiquidation        - 净清算值
+// initMargin            - 初始保证金
+// maintainMargin        - 维持保证金（低于此值会强平）
+// unrealizedPL          - 浮动盈亏
+// currencyAssets        - 按币种（USD/HKD/SGD/CNH）细分
+```
+
+---
+
+## 账户持仓 / Account Positions
+
+```typescript
+const result = await tc.positions({
+  account: '123456',
+  sec_type: 'STK',   // STK/OPT/FUT，默认STK
+  currency: 'ALL',   // ALL/USD/HKD/CNH
+  market: 'ALL'      // ALL/US/HK/CN
+});
+
+if (Array.isArray(result)) {
+  result.forEach(pos => {
+    console.log(`${pos.symbol}: qty=${pos.positionQty}, pnl=${pos.unrealizedPnl}`);
+  });
+}
+
+// 主要持仓字段 / Key position fields:
+// symbol        - 股票代码
+// positionQty   - 持仓数量
+// averageCost   - 平均成本（FIFO）
+// marketValue   - 市值
+// unrealizedPnl - 浮动盈亏
+// secType       - 证券类型
+// market        - 市场
+// currency      - 币种
+```
+
+### 期权持仓 / Option Positions
+
+```typescript
+const result = await tc.positions({
+  account: '123456',
+  sec_type: 'OPT'
+});
+// 期权持仓额外字段 / Option-specific fields:
+// strike - 行权价, expiry - 到期日, right - CALL/PUT
+```
+
+---
+
+## 历史资产分析 / Asset Analytics (PnL History)
+
+```typescript
+const result = await tc.primeAnalyticsAsset({
+  account: '123456',
+  start_date: '2024-01-01',
+  end_date: '2024-01-31',
+  seg_type: 'SEC',   // SEC / FUT
+  currency: 'USD'
+});
+
+// summary 字段 / Summary fields:
+// pnl                - 盈亏金额
+// pnlPercentage      - 收益率
+// annualizedReturn   - 年化收益率
+
+// history 数组每项字段 / History item fields:
+// date               - 日期时间戳（毫秒）
+// asset              - 总资产
+// pnl                - 当日盈亏
+// cashBalance        - 现金余额
+// grossPositionValue - 持仓市值
+// deposit            - 入金
+// withdrawal         - 出金
+```
+
+---
+
+## 最大可交易数量 / Estimate Tradable Quantity
+
+```typescript
+const result = await tc.estimateTradableQuantity({
+  account: '123456',
+  symbol: 'AAPL',
+  sec_type: 'STK',
+  action: 'BUY',
+  order_type: 'LMT',
+  limit_price: 150.0
+});
+
+console.log(`Can buy: ${result?.tradableQuantity} shares`);
+
+// 返回字段 / Response fields:
+// tradableQuantity          - 现金可买/卖数量
+// financingQuantity         - 融资融券可买/卖数量
+// positionQuantity          - 持仓数量
+// tradablePositionQuantity  - 持仓可交易数量
+```
+
+---
+
+## 资金转账（Segment 间）/ Segment Fund Transfer
+
+### 查询可转出金额 / Query Available Amount
+
+```typescript
+const result = await tc.segmentFundAvailable({
+  account: '123456',
+  from_segment: 'SEC',   // SEC / FUT
+  currency: 'USD'
+});
+// 返回 fromSegment, currency, amount
+```
+
+### 发起转账 / Transfer
+
+```typescript
+const result = await tc.segmentFundTransfer({
+  account: '123456',
+  from_segment: 'SEC',
+  to_segment: 'FUT',
+  currency: 'USD',
+  amount: 1000.0
+});
+// 转账状态 status: NEW / PROC / SUCC / FAIL / CANC
+```
+
+---
+
+## 出入金记录 / Deposit & Withdrawal Records
+
+```typescript
+const result = await tc.depositWithdraw({
+  account: '123456'
+});
+
+if (Array.isArray(result)) {
+  result.forEach(r => {
+    console.log(`${r.typeDesc}: ${r.currency} ${r.amount} on ${r.businessDate}`);
+  });
+}
+
+// 每条记录字段 / Record fields:
+// type         - 1(入金) / 3(出金) / 20(出金费用) 等
+// typeDesc     - 类型描述
+// currency     - 币种
+// amount       - 金额
+// businessDate - 业务日期
+// completedStatus - 是否完成
+```
+
+---
+
+## 注意事项 / Notes
+
+- 环球账户(Global)用 `assets()`，综合/模拟账户(Standard/Paper)用 `primeAssets()`
+- Segment 分类：S=证券, C=期货, F=基金, D=数字货币
+- 持仓使用 `positionQty` 字段，旧字段 `position`+`positionScale` 已废弃
+- `maintainMargin` 低于 0 时会触发强制平仓
+- 机构用户额外传 `secret_key` 字段
+- 所有方法均为 async，需要 `await`
+- 子路径导入需使用 `tigeropen/dist/esm/...` 路径（参见 quickstart.md）

--- a/.agents/skills/tigeropen-typescript/references/option.md
+++ b/.agents/skills/tigeropen-typescript/references/option.md
@@ -1,0 +1,429 @@
+
+# Tiger OpenAPI TypeScript SDK — 期权 / Options Trading
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/quote-option
+
+## 期权操作工作流 / Option Workflow
+
+当用户提到期权时，按以下流程操作 / When user mentions options, follow this workflow:
+
+### 查询期权 / Query Options
+
+1. **查到期日 Get expirations**: `qc.optionExpirations()` → 获取可选到期日列表
+2. **查期权链 Get chain**: `qc.optionChain()` → 获取指定到期日的所有合约
+3. **查行情 Get quotes**: `qc.optionBriefs()` → 获取期权实时行情和 Greeks
+
+### 港股期权特殊处理 / HK Option Special Handling
+
+- 港股期权标的代码不同于正股 / HK option underlyings differ from stock codes: `00700` → `TCH`（腾讯）
+- 使用 `qc.optionSymbols()` 查询港股期权代码映射
+
+---
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/dist/esm/client/http-client.js';
+import { QuoteClient } from 'tigeropen/dist/esm/quote/quote-client.js';
+import { TradeClient } from 'tigeropen/dist/esm/trade/trade-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+
+const httpClient = new HttpClient(config);
+const qc = new QuoteClient(httpClient);
+const tc = new TradeClient(httpClient, config.account);
+```
+
+---
+
+## 期权到期日 / Option Expirations
+
+```typescript
+const result = await qc.optionExpirations({
+  symbols: ['AAPL'],
+  market: 'US',   // 'US' | 'HK'
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// symbol     - 股票代码
+// count      - 到期日数量
+// dates      - 到期日数组 (e.g. "2024-06-28")
+// timestamps - 到期日时间戳数组（毫秒，纽约时间）
+// periodTags - 周期标签: "m"=月期权, "w"=周期权, "q"=季度
+```
+
+---
+
+## 期权链 / Option Chain
+
+```typescript
+const result = await qc.optionChain({
+  symbol: 'AAPL',
+  expiry: '2025-08-29',
+  market: 'US',
+  returnGreekValue: true,   // 返回希腊字母 / Return Greeks
+  // 可选筛选 / Optional filters:
+  // inTheMoney: true,
+  // impliedVolatilityMin: 0.15,
+  // impliedVolatilityMax: 0.80,
+  // deltaMin: 0.2,
+  // deltaMax: 0.8,
+  // openInterestMin: 100,
+});
+console.log(result);
+
+// 返回字段 / Response fields (items[].call / items[].put):
+// identifier   - 期权完整代码 (e.g. "AAPL  250829C00150000")
+// strike       - 行权价
+// right        - "CALL" / "PUT"
+// askPrice     - 卖价
+// bidPrice     - 买价
+// latestPrice  - 最新价
+// volume       - 成交量
+// openInterest - 持仓量
+// impliedVol   - 隐含波动率
+// delta/gamma/theta/vega/rho - 希腊字母（需 returnGreekValue=true）
+```
+
+---
+
+## 港股期权代码映射 / HK Option Symbol Mapping
+
+```typescript
+const result = await qc.optionSymbols({
+  market: 'HK',
+  lang: 'en_US',   // 'en_US' | 'zh_CN' | 'zh_TW'
+});
+
+if (Array.isArray(result)) {
+  // 查找腾讯 / Find Tencent (00700 -> TCH.HK)
+  const tencent = result.find(s => s.underlyingSymbol === '00700');
+  console.log(`Option symbol: ${tencent?.symbol}`);
+}
+
+// 返回字段 / Response fields:
+// symbol           - 期权 symbol (e.g. "TCH.HK")
+// name             - 标的名称
+// underlyingSymbol - 正股代码 (e.g. "00700")
+```
+
+---
+
+## 期权实时行情 / Option Brief (Real-time Quotes)
+
+```typescript
+const result = await qc.optionBriefs({
+  market: 'US',
+  optionBasic: [
+    {
+      symbol: 'AAPL',
+      right: 'CALL',
+      expiry: '2025-08-29',   // yyyy-MM-dd
+      strike: '150.0',         // 小数位须和期权链一致
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// identifier    - 期权完整代码
+// symbol        - 标的代码
+// bidPrice/askPrice/latestPrice
+// volume/openInterest
+// high/low/open/preClose
+// change        - 涨跌额
+// midPrice      - 中间价
+// markPrice     - 标记价格
+// sellingReturn - 卖出年化收益率
+```
+
+---
+
+## 期权深度行情 / Option Depth Quotes
+
+```typescript
+const result = await qc.optionDepth({
+  market: 'US',
+  optionBasic: [
+    {
+      symbol: 'AAPL',
+      right: 'PUT',
+      expiry: '2024-06-28',
+      strike: '210.0',
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// ask[]/bid[] - 卖/买盘挂单列表
+//   price    - 委托价
+//   volume   - 委托量
+//   code     - 交易所代码 (CBOE, PHLX 等)
+//   timestamp - 交易所时间
+```
+
+---
+
+## 期权逐笔成交 / Option Trade Ticks
+
+```typescript
+// 仅支持美股期权 / US market only
+
+const result = await qc.optionTradeTicks({
+  optionBasic: [
+    {
+      symbol: 'AAPL',
+      right: 'PUT',
+      expiry: '2024-03-08',
+      strike: '185.0',
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// items[] - 逐笔成交列表
+//   price  - 成交价
+//   volume - 成交量
+//   time   - 成交时间（毫秒）
+```
+
+---
+
+## 期权K线 / Option K-line
+
+```typescript
+const result = await qc.optionKline({
+  market: 'US',
+  optionQuery: [
+    {
+      symbol: 'AAPL',
+      right: 'CALL',
+      expiry: '2024-06-28',
+      strike: '170.0',
+      beginTime: '2024-06-26',
+      endTime: '2024-06-26 23:59:59',
+      period: '1min',   // 'day' | '1min' | '5min' | '30min' | '60min'
+      limit: 10,
+      sortDir: 'DESC',
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// items[] - K线数据点列表
+//   open/high/low/close - 开高低收
+//   volume              - 成交量
+//   time                - 时间戳（毫秒）
+//   openInterest        - 持仓量（仅日K线）
+```
+
+---
+
+## 期权分时数据 / Option Timeline
+
+```typescript
+// 目前仅支持港股期权 / HK market only currently
+
+const result = await qc.optionTimeline({
+  market: 'HK',
+  optionList: [
+    {
+      symbol: 'ALB.HK',
+      right: 'CALL',
+      expiry: 1753878054000,   // 毫秒时间戳
+      strike: '117.50',
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// preClose   - 昨日收盘价
+// minutes[]  - 分时数据点
+//   price    - 最新价
+//   avgPrice - 均价
+//   volume   - 成交量
+//   time     - 时间戳（毫秒）
+```
+
+---
+
+## 期权分析 / Option Analysis
+
+```typescript
+const result = await qc.optionAnalysis({
+  symbols: [
+    {
+      symbol: 'AAPL',
+      period: '52week',   // '3year' | '52week' | '26week' | '13week'
+      requireVolatilityList: true,   // 返回IV/HV历史时序
+    },
+  ],
+  market: 'US',
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// symbol           - 标的代码
+// impliedVol30Days - 30日隐含波动率
+// hisVolatility    - 历史波动率（30天）
+// ivHisVRatio      - IV/HV 比率
+// callPutRatio     - Call/Put 比率
+// impliedVolMetric:
+//   percentile  - IV百分位（0%-100%）
+//   rank        - IV排名（0-1）
+//   period      - 分析周期
+```
+
+---
+
+## 期权指标计算 / Option Indicator Calculation
+
+```typescript
+// 查询单个期权的盘中实时指标（Greeks、IV、杠杆等）
+const result = await qc.optionIndicator({
+  symbol: 'BABA',
+  right: 'CALL',
+  strike: '205.0',
+  expiry: '2019-11-01',   // yyyy-MM-dd
+});
+console.log(`delta: ${result?.delta}, iv: ${result?.volatility}%`);
+
+// 返回字段 / Response fields:
+// delta/gamma/theta/vega/rho - 希腊字母
+// insideValue      - 内在价值
+// timeValue        - 时间价值
+// leverage         - 杠杆率
+// openInterest     - 未平仓量
+// historyVolatility - 历史波动率（百分比，如24.38表示24.38%）
+// volatility       - 隐含波动率（百分比）
+// premiumRate      - 溢价率（百分比）
+// profitRate       - 买入盈利率（百分比）
+```
+
+---
+
+## 单腿期权下单 / Single-leg Option Order
+
+```typescript
+// 买入看涨期权 / Buy call option
+const result = await tc.placeOrder({
+  account: config.account,
+  contract: {
+    symbol: 'AAPL',
+    secType: 'OPT',
+    expiry: '20250829',   // YYYYMMDD
+    strike: 150.0,
+    right: 'CALL',
+    currency: 'USD',
+  },
+  action: 'BUY',
+  orderType: 'LMT',
+  limitPrice: 5.0,
+  quantity: 1,             // 1张 = 100股
+});
+console.log(`order id: ${result?.id}, status: ${result?.status}`);
+```
+
+---
+
+## 多腿组合策略 / Multi-leg Combo Strategies
+
+```typescript
+// 牛市看涨价差 / Bull Call Spread (VERTICAL)
+const result = await tc.placeComboOrder({
+  account: config.account,
+  comboType: 'VERTICAL',
+  action: 'BUY',
+  orderType: 'LMT',
+  limitPrice: 3.0,
+  quantity: 1,
+  legs: [
+    {
+      symbol: 'AAPL',
+      secType: 'OPT',
+      expiry: '20250829',
+      strike: 145.0,
+      right: 'CALL',
+      action: 'BUY',
+      ratio: 1,
+    },
+    {
+      symbol: 'AAPL',
+      secType: 'OPT',
+      expiry: '20250829',
+      strike: 155.0,
+      right: 'CALL',
+      action: 'SELL',
+      ratio: 1,
+    },
+  ],
+});
+```
+
+### 其他策略示例 / Other Strategy Examples
+
+```typescript
+// 跨式策略 / Straddle — comboType: 'STRADDLE'，同行权价 Call+Put
+// Iron Condor — comboType: 'CUSTOM'，4腿：Put spread + Call spread
+// 备兑策略 / Covered Call — comboType: 'COVERED'
+//   Leg1: secType='STK', action='BUY', ratio=100
+//   Leg2: secType='OPT', action='SELL', ratio=1
+```
+
+### 组合策略类型总览 / Combo Strategy Types
+
+| comboType | 策略 Strategy | 说明 Description |
+|-----------|--------------|-----------------|
+| `VERTICAL` | 垂直价差 | 同到期日不同行权价 Same expiry, different strikes |
+| `STRADDLE` | 跨式 | 同行权价同到期日 Call+Put, same strike & expiry |
+| `STRANGLE` | 宽跨式 | 不同行权价同到期日 Different strikes, same expiry |
+| `CALENDAR` | 日历价差 | 同行权价不同到期日 Same strike, different expiries |
+| `DIAGONAL` | 对角线价差 | 不同行权价不同到期日 Different strikes & expiries |
+| `COVERED` | 备兑 | 持有股票+卖Call Long stock + short call |
+| `PROTECTIVE` | 保护性 | 持有股票+买Put Long stock + long put |
+| `SYNTHETIC` | 合成 | 合成多/空头 Synthetic long/short |
+| `CUSTOM` | 自定义 | 4条腿组合（Iron Condor等） |
+
+---
+
+## 查询期权持仓 / Query Option Positions
+
+```typescript
+const result = await tc.positions({
+  account: config.account,
+  sec_type: 'OPT',
+});
+
+if (Array.isArray(result)) {
+  result.forEach(pos => {
+    console.log(`${pos.symbol} ${pos.expiry} ${pos.strike} ${pos.right}: `
+      + `qty=${pos.positionQty}, pnl=${pos.unrealizedPnl}`);
+  });
+}
+
+// 期权持仓额外字段 / Option-specific position fields:
+// strike - 行权价
+// expiry - 到期日
+// right  - CALL/PUT
+```
+
+---
+
+## 注意事项 / Notes
+
+- 港股期权需先用 `optionSymbols()` 获取代码映射 / HK options require symbol mapping
+- 期权每张合约通常代表100股标的 / Each contract = 100 shares
+- 期权链返回的 Greeks 为上一交易日收盘值，盘中请用 `optionIndicator()` / Chain Greeks are from previous close
+- 行权价小数位须和期权链一致 / Strike decimals must match the option chain
+- 期权行情需要期权行情权限 / Option quotes require option quote permission
+- 所有方法均为 async，需要 `await`
+- 子路径导入需使用 `tigeropen/dist/esm/...` 路径（参见 quickstart.md）

--- a/.agents/skills/tigeropen-typescript/references/push.md
+++ b/.agents/skills/tigeropen-typescript/references/push.md
@@ -1,0 +1,155 @@
+# Tiger OpenAPI TypeScript SDK — Real-time Push / 实时推送
+
+> TypeScript SDK 实时推送 API 参考 / Push API Reference
+<!-- 当用户提到"推送"、"实时"、"订阅"、"WebSocket"、"push"、"subscribe"时 -->
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { PushClient } from 'tigeropen/dist/esm/push/push-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+const pc = new PushClient(config);
+```
+
+---
+
+## 完整示例 / Full Example
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { PushClient } from 'tigeropen/dist/esm/push/push-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+
+const pc = new PushClient(config);
+
+// 设置回调 / Set callbacks
+// ⚠️ 订阅必须在 onConnect 回调中执行 / Subscriptions MUST be placed inside onConnect callback
+pc.setCallbacks({
+  onQuote: (data) => {
+    console.log(`[行情] ${data.symbol} 最新价: ${data.latestPrice} 量: ${data.volume}`);
+  },
+  onOrder: (data) => {
+    console.log(`[订单] ${data.symbol} 状态: ${data.status}`);
+  },
+  onAsset: (data) => {
+    console.log(`[资产] 账户: ${data.account} 净资产: ${data.netLiquidation}`);
+  },
+  onPosition: (data) => {
+    console.log(`[持仓] ${data.symbol} 数量: ${data.quantity}`);
+  },
+  onConnect: () => {
+    console.log('推送连接成功');
+    // ⚠️ 在此处执行订阅 / Subscribe here after connection established
+    // 重连后订阅不会自动恢复，需在此重新订阅 / Subscriptions NOT auto-restored on reconnect
+    pc.subscribeQuote(['AAPL', 'TSLA']);
+    pc.subscribeAsset();
+    pc.subscribeOrder();
+    pc.subscribePosition();
+  },
+  onDisconnect: () => console.log('推送连接断开'),
+  onError: (err) => console.error('推送错误:', err),
+});
+
+// 连接 / Connect
+await pc.connect();
+
+// 等待退出 / Keep running
+process.on('SIGINT', () => {
+  pc.unsubscribeQuote(['AAPL', 'TSLA']);
+  pc.disconnect();
+  process.exit(0);
+});
+```
+
+---
+
+## 回调函数 / Callbacks
+
+| 回调 Callback | 触发时机 | 数据类型 |
+|--------------|---------|---------|
+| `onQuote` | 行情更新时 | `QuoteData` |
+| `onOrder` | 订单状态变化时 | `OrderData` |
+| `onAsset` | 账户资产变动时 | `AssetData` |
+| `onPosition` | 持仓变动时 | `PositionData` |
+| `onConnect` | WebSocket 连接成功时 | - |
+| `onDisconnect` | 连接断开时 | - |
+| `onError` | 发生错误时 | `Error` |
+
+---
+
+## 订阅方法 / Subscribe Methods
+
+```typescript
+// 行情订阅 / Quote subscription
+pc.subscribeQuote(['AAPL', 'TSLA', '00700']);
+pc.unsubscribeQuote(['TSLA']);
+
+// 账户推送 / Account push
+pc.subscribeAsset();       // 资产变动
+pc.subscribeOrder();       // 订单状态
+pc.subscribePosition();    // 持仓变动
+pc.unsubscribeAsset();
+pc.unsubscribeOrder();
+pc.unsubscribePosition();
+
+// 断开连接 / Disconnect
+pc.disconnect();
+```
+
+---
+
+## QuoteData 字段 / QuoteData Fields
+
+| 字段 Field | 说明 |
+|-----------|------|
+| `symbol` | 标的代码 |
+| `latestPrice` | 最新价 |
+| `volume` | 成交量 |
+| `askPrice` | 卖一价 |
+| `bidPrice` | 买一价 |
+| `change` | 涨跌额 |
+| `changeRatio` | 涨跌幅 |
+| `timestamp` | 时间戳（毫秒） |
+
+---
+
+## AssetData 字段 / AssetData Fields
+
+| 字段 Field | 说明 |
+|-----------|------|
+| `account` | 账户号 |
+| `netLiquidation` | 净资产 |
+| `cashBalance` | 现金余额 |
+| `buyingPower` | 购买力 |
+| `currency` | 计价货币 |
+
+---
+
+## PositionData 字段 / PositionData Fields
+
+| 字段 Field | 说明 |
+|-----------|------|
+| `account` | 账户号 |
+| `symbol` | 标的代码 |
+| `quantity` | 持仓数量 |
+| `averageCost` | 平均成本 |
+| `marketPrice` | 最新价格 |
+| `marketValue` | 市值 |
+| `unrealizedPnl` | 浮动盈亏 |
+
+---
+
+## 注意事项 / Notes
+
+- **在 `onConnect` 回调中执行订阅**，连接成功后才能订阅
+- SDK 自动处理断线重连，无需手动重连
+- ⚠️ **断线重连后订阅不会自动恢复**，必须在 `onConnect` 回调中重新订阅 / Subscriptions NOT auto-restored after reconnect; re-subscribe in `onConnect`
+- 心跳保活由 SDK 自动维护
+- 同一个 `PushClient` 实例只能有一个活跃连接

--- a/.agents/skills/tigeropen-typescript/references/quickstart.md
+++ b/.agents/skills/tigeropen-typescript/references/quickstart.md
@@ -1,0 +1,156 @@
+# Tiger OpenAPI TypeScript SDK — Quickstart
+
+> TypeScript SDK 快速入门 / Quick Start for TypeScript SDK
+> npm: https://www.npmjs.com/package/tigeropen
+
+## 安装 / Installation
+
+```bash
+npm install tigeropen
+# 或 / or
+yarn add tigeropen
+# 或 / or
+pnpm add tigeropen
+```
+
+要求 / Requirements: Node.js 16+，支持 ESM 和 CommonJS
+
+---
+
+## 配置 / Configuration
+
+### 方式一：代码直接设置 / Method 1: Direct config
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+
+const config = createClientConfig({
+  tigerId: 'your_tiger_id',
+  privateKey: 'your_rsa_private_key',   // PEM 格式私钥字符串
+  account: 'your_account',
+});
+```
+
+### 方式二：从 properties 文件加载 / Method 2: Properties file
+
+```typescript
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+```
+
+配置文件格式 / Config file format:
+```properties
+tiger_id=your_tiger_id
+private_key=your_rsa_private_key
+account=your_account
+```
+
+### 方式三：环境变量 / Method 3: Environment variables
+
+```bash
+export TIGEROPEN_TIGER_ID=your_tiger_id
+export TIGEROPEN_PRIVATE_KEY=your_rsa_private_key
+export TIGEROPEN_ACCOUNT=your_account
+```
+
+> 优先级：环境变量 > 代码设置 > properties 文件
+
+### 配置项说明 / Config Options
+
+| 配置项 | 说明 | 必填 | 默认值 |
+|--------|------|------|--------|
+| `tigerId` | 开发者 ID | ✅ | - |
+| `privateKey` | RSA 私钥 PEM 字符串 | ✅ | - |
+| `account` | 交易账户号 | - | - |
+| `propertiesFilePath` | .properties 文件路径 | - | - |
+| `language` | `zh_CN` / `en_US` | - | `zh_CN` |
+| `timeout` | 请求超时（秒） | - | 15 |
+| `sandboxDebug` | 使用沙箱环境 | - | `false` |
+
+---
+
+## 客户端创建 / Create Clients
+
+```typescript
+// ⚠️ 包只导出根路径，子路径导入需指定 dist 路径 / Package only exports root, sub-path imports need dist paths
+import { createClientConfig } from 'tigeropen';
+// ESM sub-path imports (tigeropen@0.1.0 doesn't expose sub-path exports):
+import { HttpClient } from 'tigeropen/dist/esm/client/http-client.js';
+import { QuoteClient } from 'tigeropen/dist/esm/quote/quote-client.js';
+import { TradeClient } from 'tigeropen/dist/esm/trade/trade-client.js';
+import { PushClient } from 'tigeropen/dist/esm/push/push-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+
+const httpClient = new HttpClient(config);
+
+const qc = new QuoteClient(httpClient);                 // 行情客户端
+const tc = new TradeClient(httpClient, config.account); // 交易客户端
+const pc = new PushClient(config);                      // 推送客户端
+```
+
+> ⚠️ **注意 / Note**: `tigeropen@0.1.0` 包 `exports` 字段仅暴露根路径 `.`，`tigeropen/client/http-client` 等子路径会报 `ERR_PACKAGE_PATH_NOT_EXPORTED` 错误。需直接使用 `tigeropen/dist/esm/...` 路径。CJS 环境同理使用 `tigeropen/dist/cjs/...`。
+
+---
+
+## ESM 和 CommonJS / ESM and CommonJS
+
+```typescript
+// ESM (see note above about sub-path exports)
+import { createClientConfig } from 'tigeropen';
+import { QuoteClient } from 'tigeropen/dist/esm/quote/quote-client.js';
+
+// CommonJS
+const { createClientConfig } = require('tigeropen');
+const { QuoteClient } = require('tigeropen/dist/cjs/quote/quote-client.js');
+```
+
+---
+
+## 通用 API 调用 / Generic API Call
+
+当 SDK 未封装某个 API 时：
+
+```typescript
+const resp = await httpClient.execute(
+  'market_state',
+  JSON.stringify({ market: 'US' })
+);
+console.log(resp);
+```
+
+---
+
+## 错误处理 / Error Handling
+
+```typescript
+try {
+  const data = await qc.getBrief(['AAPL']);
+  console.log(data);
+} catch (error) {
+  if (error instanceof Error) {
+    console.error('API 错误:', error.message);
+  }
+}
+```
+
+---
+
+## 前置条件 / Prerequisites
+
+1. 老虎证券账户 + 开发者 API 权限：https://developer.itigerup.com/
+2. 准备好 `tigerId`、RSA 私钥、`account`
+3. 行情数据需要对应的行情权限；期权行情需要期权行情权限
+
+---
+
+## FAQ
+
+**Q: 私钥如何生成?**
+参考官方文档 https://docs.itigerup.com/docs/prepare，使用 RSA-2048 生成密钥对，上传公钥到开发者后台。
+
+**Q: 模拟账户和实盘账户区别?**
+模拟账户在开发者后台申请，`sandboxDebug: true` 连接沙箱环境；实盘账户直接使用生产域名。

--- a/.agents/skills/tigeropen-typescript/references/quote.md
+++ b/.agents/skills/tigeropen-typescript/references/quote.md
@@ -1,0 +1,144 @@
+# Tiger OpenAPI TypeScript SDK — Market Data / 行情查询
+
+> TypeScript SDK 行情 API 参考 / Quote API Reference
+<!-- 当用户提到"行情"、"报价"、"K线"、"价格"、"深度"、"quote"、"kline"、"price"时 -->
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/client/http-client';
+import { QuoteClient } from 'tigeropen/quote/quote-client';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+const httpClient = new HttpClient(config);
+const qc = new QuoteClient(httpClient);
+```
+
+---
+
+## 市场状态 / Market State
+
+```typescript
+// market: 'US' / 'HK' / 'CN' / 'SG'
+const data = await qc.getMarketState('US');
+// 返回 [{market, status, openTime, closeTime, ...}]
+```
+
+---
+
+## 实时报价 / Real-time Quotes
+<!-- 当用户提到"实时报价"、"最新价"、"real-time"时 -->
+
+```typescript
+const data = await qc.getBrief(['AAPL', 'TSLA']);
+// 每个元素包含: symbol, latestPrice, askPrice, bidPrice, volume, change, changeRatio 等
+```
+
+---
+
+## K 线 / Kline
+<!-- 当用户提到"K线"、"kline"、"bar"、"日线"时 -->
+
+```typescript
+// period: 'day'/'week'/'month'/'year'/'1min'/'3min'/'5min'/'10min'/'15min'/'30min'/'60min'
+const data = await qc.getKline('AAPL', 'day');
+// 返回数组，每个元素: time, open, high, low, close, volume
+```
+
+---
+
+## 分时 / Timeline
+
+```typescript
+const data = await qc.getTimeline(['AAPL', 'TSLA']);
+// 返回分时数据: time, price, volume, avgPrice
+```
+
+---
+
+## 深度行情 / Quote Depth
+<!-- 当用户提到"买卖盘"、"深度"、"depth"时 -->
+
+```typescript
+const data = await qc.getQuoteDepth('AAPL');
+// 返回 {asks: [{price, volume},...], bids: [{price, volume},...]}
+```
+
+---
+
+## 逐笔成交 / Trade Ticks
+
+```typescript
+const data = await qc.getTradeTick(['AAPL']);
+// 返回逐笔: time, price, volume, direction
+```
+
+---
+
+## 期权到期日 / Option Expirations
+
+```typescript
+const data = await qc.getOptionExpiration('AAPL');
+// 返回到期日列表: dates, timestamps, periodTag ("m"=月度/"w"=周度)
+```
+
+---
+
+## 期权链 / Option Chain
+
+```typescript
+const data = await qc.getOptionChain('AAPL', '2025-08-29');
+// 返回 call/put 合约: identifier, strike, bid/ask, volume, openInterest, impliedVol, delta, gamma 等
+```
+
+---
+
+## 期权报价 / Option Brief
+
+```typescript
+const data = await qc.getOptionBrief(['AAPL  250829C00150000']);
+// 期权代码格式: 标的(6位右空格填充) + YYMMDD + C/P + 行权价*1000(8位)
+// 返回: identifier, strike, putCall, latestPrice, bid/ask, impliedVol, delta, gamma, theta, vega 等
+```
+
+---
+
+## 期货 / Futures
+
+```typescript
+// 获取交易所列表
+const exchanges = await qc.getFutureExchange();
+
+// 获取期货合约
+const contracts = await qc.getFutureContracts('CME');
+
+// 期货实时报价
+const data = await qc.getFutureRealTimeQuote(['CL2509']);
+```
+
+---
+
+## 直接调用 API / Raw API Call
+
+当以上方法不满足需求时：
+
+```typescript
+import { HttpClient } from 'tigeropen/client/http-client';
+
+const resp = await httpClient.execute(
+  'quote_real_time',
+  JSON.stringify({ symbols: ['AAPL', 'TSLA'] })
+);
+```
+
+---
+
+## 注意事项 / Notes
+
+- 所有方法返回 `Promise`，需 `await`
+- 行情数据需要对应市场的行情权限
+- 期权行情需要单独开通期权行情权限
+- 港股期权代码格式：`TCH.HK 230616C00550000`（与美股不同）

--- a/.agents/skills/tigeropen-typescript/references/trade.md
+++ b/.agents/skills/tigeropen-typescript/references/trade.md
@@ -1,0 +1,197 @@
+# Tiger OpenAPI TypeScript SDK — Trading / 交易
+
+> TypeScript SDK 交易 API 参考 / Trade API Reference
+<!-- 当用户提到"下单"、"买入"、"卖出"、"撤单"、"改单"、"持仓"、"资产"、"order"、"trade"时 -->
+
+## 安全规范 / Safety Rules
+
+> ⚠️ **默认使用模拟账户。Default to Paper Trading.**
+
+实盘下单前，**必须执行**以下流程：
+1. 与用户确认：标的代码、方向（买/卖）、数量、价格、账户
+2. 先调用 `previewOrder()` 查看预估佣金和保证金
+3. 用户确认后再调用 `placeOrder()`
+4. 下单后通过 `getOrders()` 确认订单状态
+
+---
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/client/http-client';
+import { TradeClient } from 'tigeropen/trade/trade-client';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+const httpClient = new HttpClient(config);
+const tc = new TradeClient(httpClient, config.account);
+```
+
+---
+
+## 下单 / Place Orders
+<!-- 当用户提到"下单"、"买入"、"卖出"、"buy"、"sell"、"order"时 -->
+
+### 构造订单 / Build Order
+
+```typescript
+// 限价单 / Limit order
+const order = {
+  symbol: 'AAPL',
+  secType: 'STK',
+  action: 'BUY',
+  orderType: 'LMT',
+  totalQuantity: 100,
+  limitPrice: 150.0,
+  timeInForce: 'DAY',
+};
+
+// 市价单 / Market order
+const order = {
+  symbol: 'AAPL',
+  secType: 'STK',
+  action: 'BUY',
+  orderType: 'MKT',
+  totalQuantity: 100,
+};
+
+// 止损限价单 / Stop-limit order
+const order = {
+  symbol: 'AAPL',
+  secType: 'STK',
+  action: 'SELL',
+  orderType: 'STP_LMT',
+  totalQuantity: 100,
+  limitPrice: 145.0,   // 限价
+  auxPrice: 148.0,     // 触发价
+};
+
+// 盘后交易 / After-hours trading
+const order = {
+  symbol: 'AAPL',
+  secType: 'STK',
+  action: 'BUY',
+  orderType: 'LMT',
+  totalQuantity: 100,
+  limitPrice: 150.0,
+  outsideRth: true,   // 允许盘前盘后
+  timeInForce: 'GTC',
+};
+```
+
+### 预览订单 / Preview Order
+
+```typescript
+const preview = await tc.previewOrder(order);
+// 返回预估保证金和佣金信息
+```
+
+### 提交下单 / Submit Order
+
+```typescript
+const result = await tc.placeOrder(order);
+// 返回 {id, orderId, status: 'PendingSubmit', ...}
+```
+
+### 修改订单 / Modify Order
+
+```typescript
+const modified = { ...order, limitPrice: 155.0 };
+await tc.modifyOrder(orderId, modified);  // orderId: number
+```
+
+### 取消订单 / Cancel Order
+
+```typescript
+await tc.cancelOrder(orderId);  // orderId: number
+```
+
+---
+
+## 查询订单 / Query Orders
+<!-- 当用户提到"订单"、"委托"、"orders"时 -->
+
+```typescript
+// 所有订单 / All orders
+const orders = await tc.getOrders();
+
+// 待成交订单 / Active (pending) orders
+const active = await tc.getActiveOrders();
+
+// 已成交订单 / Filled orders
+const filled = await tc.getFilledOrders();
+
+// 已撤销订单 / Inactive (cancelled) orders
+const inactive = await tc.getInactiveOrders();
+
+// 订单成交明细 / Order transactions
+const transactions = await tc.getOrderTransactions(orderId);
+```
+
+---
+
+## 持仓查询 / Query Positions
+<!-- 当用户提到"持仓"、"仓位"、"positions"时 -->
+
+```typescript
+const positions = await tc.positions();
+// ⚠️ 返回 JSON 字符串，需手动解析 / Returns JSON string, parse manually:
+// const items = JSON.parse(positions).items;
+// 每个元素包含 / each item has:
+// symbol, secType, positionQty, averageCost, marketPrice/latestPrice, marketValue, unrealizedPnl
+```
+
+---
+
+## 资产查询 / Query Assets
+<!-- 当用户提到"资产"、"资金"、"余额"、"assets"时 -->
+
+```typescript
+// 普通账户资产 / Standard account assets
+const assets = await tc.assets();
+// ⚠️ 返回 JSON 字符串，需手动解析 / Returns JSON string, parse manually
+
+// 综合账户（Prime）资产 / Prime account assets
+const prime = await tc.primeAssets();
+// 返回: netLiquidation, cashBalance, buyingPower, unrealizedPl, initMargin, maintMargin 等
+```
+
+---
+
+## 合约查询 / Contract Query
+
+```typescript
+// 单个合约
+const contract = await tc.contract('AAPL', 'STK');
+
+// 批量合约
+const contracts = await tc.contracts(['AAPL', 'TSLA'], 'STK');
+
+// secType: 'STK'(股票)/'OPT'(期权)/'FUT'(期货)/'CASH'(外汇)
+```
+
+---
+
+## 订单字段说明 / Order Fields
+
+| 字段 | 类型 | 说明 |
+|-----|------|------|
+| `symbol` | string | 标的代码，如 `'AAPL'` |
+| `secType` | string | `'STK'` / `'OPT'` / `'FUT'` |
+| `action` | string | `'BUY'` / `'SELL'` |
+| `orderType` | string | `'LMT'` / `'MKT'` / `'STP'` / `'STP_LMT'` |
+| `totalQuantity` | number | 数量 |
+| `limitPrice` | number | 限价（LMT/STP_LMT 必填） |
+| `auxPrice` | number | 止损价（STP/STP_LMT 必填） |
+| `timeInForce` | string | `'DAY'` / `'GTC'` / `'GTD'` |
+| `outsideRth` | boolean | 是否允许盘前盘后交易 |
+
+---
+
+## 注意事项 / Notes
+
+- `placeOrder()` 返回成功仅表示订单**已提交**，不代表已成交
+- 需通过 `getOrders()` 或推送回调确认最终成交状态
+- 期权下单需先通过 `qc.getOptionChain()` 获取 identifier，并设置 `expiry`/`strike`/`right` 字段

--- a/.agents/skills/tigeropen/SKILL.md
+++ b/.agents/skills/tigeropen/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: tigeropen
+description: |
+  Tiger Brokers OpenAPI Python SDK — complete skills for AI coding tools. Covers SDK setup, market data queries, stock/futures/options trading, real-time push subscriptions, CLI command-line tool, and MCP server integration. Use when building trading applications, querying market data, placing orders, using the tigeropen CLI, or integrating Tiger Brokers API with AI editors.
+  老虎证券 OpenAPI Python SDK 完整技能集。涵盖 SDK 配置、行情查询、股票/期货/期权交易、实时推送订阅、CLI 命令行工具、MCP Server 集成。适用于构建交易应用、查询行情数据、下单交易、使用 tigeropen CLI、或将老虎 API 集成到 AI 编辑器。
+  用户提到以下关键词时自动使用 / Auto-activate on these keywords: 行情、报价、价格、K线、快照、买卖盘、深度、买入、卖出、下单、撤单、改单、交易、持仓、资金、账户、订单、委托、期权、期权链、到期日、期货、推送、订阅、选股、筛选、tigeropen、tiger API、quote、price、K-line、order、buy、sell、trade、position、asset、account、option、future、push、scanner
+license: Apache-2.0
+compatibility: Requires Python 3.8+, pip, and a Tiger Brokers developer account
+metadata:
+  author: tigerbrokers
+  version: "3.5.6"
+  language: zh_CN, en_US
+  openclaw:
+    requires:
+      env:
+        - TIGEROPEN_TIGER_ID
+        - TIGEROPEN_PRIVATE_KEY
+        - TIGEROPEN_ACCOUNT
+      bins:
+        - pip
+        - python
+    primaryEnv: TIGEROPEN_TIGER_ID
+---
+
+# Tiger Open API Python SDK
+
+> 老虎量化开放平台 Python SDK 完整技能集 / Complete AI skill set for Tiger Brokers OpenAPI
+
+> **安全警告 / Safety Warning**: 交易涉及真实资金。生成交易代码时默认使用**模拟账户**（Paper Trading），除非用户明确要求实盘。实盘下单前必须与用户确认订单详情。
+> Trading involves real money. Default to **Paper Trading** account when generating trading code unless the user explicitly requests live trading. Always confirm order details with the user before live orders.
+
+- Docs: https://docs.itigerup.com/docs/prepare
+- GitHub: https://github.com/tigerfintech/openapi-python-sdk
+- SDK: `pip install tigeropen` | Python 3.8 - 3.14
+
+## Language Rules / 语言规则
+
+根据用户输入语言自动回复。用户使用英文提问则用英文回复，使用中文提问则用中文回复。技术术语（代码、API 名称、参数名）保持原文不翻译。
+Reply in the user's language. Keep technical terms (code, API names, parameters) as-is.
+
+## Reference Guides
+
+This skill is organized into focused reference files. Load the relevant guide based on your task:
+
+- **[Quickstart](references/quickstart.md)** — SDK install, authentication, client setup, enums/objects, error codes, FAQ
+- **[Market Data](references/quote.md)** — Real-time quotes, K-lines, depth, ticks, capital flow, fundamentals, scanner
+- **[Trading](references/trade.md)** — Place orders (market/limit/stop/algo), order management, assets, positions, fund transfers
+- **[Options](references/option.md)** — Option chains, Greeks, single-leg/multi-leg combos, option calculator
+- **[Real-time Push](references/push.md)** — Subscribe to quote/depth/tick/K-line/order/position/asset changes via PushClient
+- **[CLI Tool](references/cli.md)** — Command-line interface: config, quote, trade, account, push commands with table/json/csv output
+- **[MCP Server](references/mcp.md)** — Expose Tiger API as MCP tools for Cursor, Claude Code, Kiro, Trae
+
+## Quick Start
+
+```python
+from tigeropen.common.consts import Language, Market
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.common.util.signature_utils import read_private_key
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.trade.trade_client import TradeClient
+
+# 1. Configure / 配置
+# 方式一：配置文件(推荐) / Method 1: Config file (recommended)
+config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+
+# 方式二：代码赋值 / Method 2: Code assignment
+# config = TigerOpenClientConfig()
+# config.tiger_id = 'your_tiger_id'
+# config.private_key = read_private_key('/path/to/your_private_key.pem')
+# config.account = 'your_account'
+# config.language = Language.en_US
+
+# 2. Query quotes / 查询行情
+quote_client = QuoteClient(config)
+quote = quote_client.get_market_status(Market.US)
+
+# 3. Place order / 下单
+trade_client = TradeClient(config)
+# See references/trade.md for order examples
+```
+
+## When to Use Each Reference
+
+| Task | Reference |
+|------|-----------|
+| First time setup, SDK install, auth config | [quickstart.md](references/quickstart.md) |
+| Get stock/option/future quotes, K-lines, screener | [quote.md](references/quote.md) |
+| Place/modify/cancel orders, check positions/assets | [trade.md](references/trade.md) |
+| Option chains, Greeks, combo strategies | [option.md](references/option.md) |
+| Real-time streaming data via WebSocket | [push.md](references/push.md) |
+| CLI commands: query data, manage orders from terminal | [cli.md](references/cli.md) |
+| Set up MCP Server for AI editor integration | [mcp.md](references/mcp.md) |
+
+## Common Symbols / 常见标的速查
+
+当用户使用中文名称或英文简称时，按下表映射。不在表中的标的根据上下文判断。
+Map user's natural language to symbols. For unlisted symbols, infer from context.
+
+### 港股 HK
+
+| 常见称呼 | 代码 Symbol |
+|---------|------------|
+| 腾讯 | 00700 |
+| 阿里巴巴、阿里 | 09988 |
+| 美团 | 03690 |
+| 小米 | 01810 |
+| 京东 | 09618 |
+| 比亚迪 | 01211 |
+| 快手 | 01024 |
+| 百度 | 09888 |
+| 网易 | 09999 |
+| 中芯国际 | 00981 |
+| MINIMAX | 00100 |
+| 智谱 | 02513 |
+
+### 美股 US
+
+| 常见称呼 | 代码 Symbol |
+|---------|------------|
+| 苹果 / Apple | AAPL |
+| 特斯拉 / Tesla | TSLA |
+| 英伟达 / NVIDIA | NVDA |
+| 微软 / Microsoft | MSFT |
+| 谷歌 / Google | GOOGL |
+| 亚马逊 / Amazon | AMZN |
+| Meta | META |
+| 台积电 / TSM | TSM |
+| AMD | AMD |
+| 老虎证券 / Tiger / TIGR | TIGR |
+| 阿里巴巴（美股）/ BABA | BABA |
+| 京东（美股）/ JD | JD |
+| 拼多多 / PDD | PDD |
+| 标普500 ETF / SPY | SPY |
+| 纳指 ETF / QQQ | QQQ |

--- a/.agents/skills/tigeropen/references/cli.md
+++ b/.agents/skills/tigeropen/references/cli.md
@@ -1,0 +1,586 @@
+
+# Tiger Open API CLI 命令行工具 / CLI Tool
+
+> 中文 | English — 双语技能，代码通用。Bilingual skill with shared code examples.
+> 官方 CLI 入口: `tigeropen` (安装 SDK 后自动可用 / Available after SDK install)
+
+## 概述 / Overview
+
+TigerOpen CLI 是基于 click 框架的命令行工具，安装 `tigeropen` SDK 后自动获得 `tigeropen` 命令。
+无需编写 Python 代码即可查询行情、管理订单、查看账户信息。
+The TigerOpen CLI is a click-based command-line tool, available automatically after installing the `tigeropen` SDK.
+Query market data, manage orders, and view account info without writing Python code.
+
+- 入口命令 Entry point: `tigeropen`
+- 安装 Install: `pip install tigeropen`
+- Python: 3.8 - 3.14
+
+---
+
+## 配置 / Configuration
+
+### 初始化配置 / Initialize Config
+
+```bash
+# 交互式配置（会引导输入 tiger_id, account, private_key）
+# Interactive setup (prompts for tiger_id, account, private_key)
+tigeropen config init
+```
+
+配置文件默认保存到 `~/.tigeropen/tiger_openapi_config.properties`。
+Config file is saved to `~/.tigeropen/tiger_openapi_config.properties` by default.
+
+### 查看配置 / Show Config
+
+```bash
+# 查看当前配置（私钥已脱敏）/ Show config (private key masked)
+tigeropen config show
+```
+
+### 修改配置 / Set Config Value
+
+```bash
+# 设置单个配置项 / Set a single config value
+tigeropen config set tiger_id your_tiger_id
+tigeropen config set account your_account
+```
+
+### 查看配置路径 / Show Config Path
+
+```bash
+tigeropen config path
+```
+
+### 指定配置目录 / Specify Config Directory
+
+```bash
+# 使用 --config-path 或 -c 指定配置文件路径（全局选项）
+# Use --config-path or -c to specify config path (global option)
+tigeropen -c /path/to/config/ quote briefs AAPL
+```
+
+---
+
+## 全局选项 / Global Options
+
+所有命令均支持以下全局选项。These global options apply to all commands.
+
+| 选项 Option | 短写 Short | 说明 Description | 默认 Default |
+|-------------|-----------|-----------------|-------------|
+| `--config-path` | `-c` | 配置文件路径 Config file path | `~/.tigeropen/` |
+| `--format` | `-f` | 输出格式 Output format: `table` / `json` / `csv` | `table` |
+| `--language` | `-l` | 语言 Language: `en_US` / `zh_CN` / `zh_TW` | `en_US` |
+| `--verbose` | `-v` | 调试日志 Enable debug logging | `false` |
+
+### 输出格式示例 / Output Format Examples
+
+```bash
+# 表格输出（默认）/ Table output (default)
+tigeropen quote briefs AAPL
+
+# JSON 输出 / JSON output
+tigeropen -f json quote briefs AAPL
+
+# CSV 输出 / CSV output
+tigeropen --format csv quote bars AAPL --limit 5
+```
+
+---
+
+## 版本 / Version
+
+```bash
+tigeropen version
+```
+
+---
+
+## 行情命令 / Quote Commands
+
+### 实时报价 / Real-time Quotes
+
+```bash
+# 获取一个或多个股票的实时行情 / Get real-time quotes for one or more symbols
+tigeropen quote briefs AAPL TSLA GOOG
+
+# 包含盘前盘后数据 / Include pre/after market data
+tigeropen quote briefs AAPL --hour-trading
+```
+
+### K 线数据 / Candlestick (Bars) Data
+
+```bash
+# 日 K 线 / Daily bars
+tigeropen quote bars AAPL
+
+# 指定周期和数量 / Specify period and limit
+tigeropen quote bars AAPL --period 5min --limit 20
+
+# 指定时间范围 / Specify time range
+tigeropen quote bars AAPL --begin-time 2026-01-01 --end-time 2026-03-01
+
+# 可选周期 / Available periods:
+# day, week, month, year, 1min, 3min, 5min, 10min, 15min, 30min, 60min
+```
+
+### 分时数据 / Intraday Timeline
+
+```bash
+# 今日分时 / Today's timeline
+tigeropen quote timeline AAPL
+
+# 指定日期 / Specific date
+tigeropen quote timeline AAPL --date 2026-03-20
+```
+
+### 逐笔成交 / Tick Data
+
+```bash
+tigeropen quote ticks AAPL
+
+# 限制条数 / Limit results
+tigeropen quote ticks AAPL --limit 50
+
+# 指定范围 / Specify range
+tigeropen quote ticks AAPL --begin-index 0 --end-index 100
+```
+
+### 盘口深度 / Order Book Depth
+
+```bash
+# --market 为必选参数 / --market is required
+tigeropen quote depth AAPL --market US
+tigeropen quote depth 00700 --market HK
+```
+
+### 市场状态 / Market Status
+
+```bash
+# 所有市场 / All markets
+tigeropen quote market-status
+
+# 指定市场 / Specific market
+tigeropen quote market-status --market US
+tigeropen quote market-status --market HK
+
+# 可选: US, HK, CN, ALL
+```
+
+### 股票列表 / Symbol List
+
+```bash
+# 美股列表 / US stock list
+tigeropen quote symbols
+
+# 港股列表 / HK stock list
+tigeropen quote symbols --market HK
+```
+
+---
+
+## 期权命令 / Option Commands
+
+```bash
+# 期权到期日列表 / Option expiration dates
+tigeropen quote option expirations AAPL
+
+# 期权链（需指定标的和到期日）/ Option chain (symbol + expiry)
+tigeropen quote option chain AAPL 2026-06-19
+
+# 期权报价（需期权标识符）/ Option quotes (by identifier)
+tigeropen quote option briefs "AAPL  260619C00150000"
+
+# 期权 K 线 / Option bars
+tigeropen quote option bars "AAPL  260619C00150000" --period day --limit 10
+```
+
+> 期权标识符格式 / Option identifier format: `SYMBOL  YYMMDDCSSSSSSSS` (C=Call, P=Put, S=Strike*1000)
+
+---
+
+## 期货命令 / Futures Commands
+
+```bash
+# 期货交易所列表 / Futures exchanges
+tigeropen quote future exchanges
+
+# 交易所合约列表 / Contracts for an exchange
+tigeropen quote future contracts CME
+
+# 期货报价 / Futures quotes
+tigeropen quote future briefs ES2606 CL2509
+
+# 期货 K 线 / Futures bars
+tigeropen quote future bars CL2509 --period day --limit 20
+```
+
+---
+
+## 资金流向 / Capital Flow
+
+```bash
+# 资金流向数据 / Capital flow
+tigeropen quote capital flow AAPL --market US --period day
+
+# 可选 period: intraday, day, week, month
+```
+
+### 资金分布 / Capital Distribution
+
+```bash
+tigeropen quote capital distribution AAPL --market US
+```
+
+---
+
+## 基本面数据 / Fundamental Data
+
+### 财务报告 / Financial Reports
+
+```bash
+# 年度营收和净利润 / Annual revenue and net income
+tigeropen quote fundamental financial AAPL --fields total_revenue,net_income
+
+# 季度数据 / Quarterly data
+tigeropen quote fundamental financial AAPL --period-type QUARTERLY
+
+# 指定时间范围 / Specify date range
+tigeropen quote fundamental financial AAPL --begin-date 2024-01-01 --end-date 2026-01-01
+
+# 可选 period-type: ANNUAL, QUARTERLY, LTM
+```
+
+### 分红数据 / Dividend Data
+
+```bash
+tigeropen quote fundamental dividend AAPL --begin-date 2024-01-01 --end-date 2026-01-01
+```
+
+### 财报日历 / Earnings Calendar
+
+```bash
+tigeropen quote fundamental earnings --begin-date 2026-03-01 --end-date 2026-03-31
+tigeropen quote fundamental earnings --market HK --begin-date 2026-03-01 --end-date 2026-03-31
+```
+
+---
+
+## 交易命令 / Trade Commands
+
+### 订单管理 / Order Management
+
+```bash
+# 订单列表 / List orders
+tigeropen trade order list
+
+# 按状态筛选 / Filter by status
+tigeropen trade order list --status Filled
+tigeropen trade order list --status Submitted
+
+# 按标的筛选 / Filter by symbol
+tigeropen trade order list --symbol AAPL
+
+# 按市场筛选 / Filter by market
+tigeropen trade order list --market US
+
+# 限制数量 / Limit results
+tigeropen trade order list --limit 20
+
+# 查看订单详情 / Order details
+tigeropen trade order get 12345678
+```
+
+### 预览订单 / Preview Order
+
+```bash
+# 预览限价买单 / Preview a limit buy order
+tigeropen trade order preview --symbol AAPL --action BUY --quantity 100 --limit-price 150
+
+# 预览市价卖单 / Preview a market sell order
+tigeropen trade order preview --symbol AAPL --action SELL --quantity 50 --order-type MKT
+
+# 可选参数 / Options:
+#   --symbol       标的代码 Symbol (required)
+#   --action       BUY/SELL (required)
+#   --quantity     数量 Quantity (required)
+#   --order-type   LMT/MKT/STP/STP_LMT (default: LMT)
+#   --limit-price  限价 Limit price (LMT/STP_LMT)
+#   --sec-type     STK/OPT/FUT (default: STK)
+```
+
+### 下单 / Place Order
+
+```bash
+# 下单（默认需要确认）/ Place order (confirmation required by default)
+tigeropen trade order place --symbol AAPL --action BUY --quantity 100 --limit-price 150
+
+# 跳过确认 / Skip confirmation
+tigeropen trade order place --symbol AAPL --action BUY --quantity 100 --limit-price 150 -y
+```
+
+> 下单前建议先 preview 预览订单。Preview order before placing.
+
+### 修改订单 / Modify Order
+
+```bash
+# 修改限价 / Modify limit price
+tigeropen trade order modify 12345678 --limit-price 155
+
+# 修改数量 / Modify quantity
+tigeropen trade order modify 12345678 --quantity 200
+
+# 修改辅助价 / Modify aux price
+tigeropen trade order modify 12345678 --aux-price 140
+
+# 跳过确认 / Skip confirmation
+tigeropen trade order modify 12345678 --limit-price 155 -y
+```
+
+### 撤销订单 / Cancel Order
+
+```bash
+# 撤销订单（需确认）/ Cancel order (confirmation required)
+tigeropen trade order cancel 12345678
+
+# 跳过确认 / Skip confirmation
+tigeropen trade order cancel 12345678 -y
+```
+
+---
+
+## 持仓命令 / Position Commands
+
+```bash
+# 所有股票持仓 / All stock positions
+tigeropen trade position list
+
+# 按证券类型 / By security type
+tigeropen trade position list --sec-type OPT
+tigeropen trade position list --sec-type FUT
+
+# 按市场 / By market
+tigeropen trade position list --market US
+tigeropen trade position list --market HK
+
+# 按标的 / By symbol
+tigeropen trade position list --symbol AAPL
+
+# 可选 sec-type: STK, OPT, FUT, WAR
+# 可选 market: US, HK, ALL
+```
+
+---
+
+## 成交记录 / Transaction Records
+
+```bash
+# 所有成交记录 / All transactions
+tigeropen trade transaction list
+
+# 按标的筛选 / Filter by symbol
+tigeropen trade transaction list --symbol AAPL
+
+# 按时间范围 / Filter by time range
+tigeropen trade transaction list --start-time 2026-01-01 --end-time 2026-03-31
+
+# 限制条数 / Limit results
+tigeropen trade transaction list --limit 50
+```
+
+---
+
+## 账户命令 / Account Commands
+
+```bash
+# 账户信息 / Account info
+tigeropen account info
+
+# 资产概览 / Asset summary
+tigeropen account assets
+
+# 按币种 / By currency
+tigeropen account assets --currency USD
+
+# 资产分析 / Asset analytics
+tigeropen account analytics
+tigeropen account analytics --start-date 2026-01-01 --end-date 2026-03-31
+```
+
+---
+
+## 推送命令 / Push Commands (Real-time Streaming)
+
+推送命令使用 WebSocket 连接，持续输出直到 Ctrl+C。
+Push commands use WebSocket connections, streaming until Ctrl+C.
+
+```bash
+# 实时行情推送 / Real-time quote streaming
+tigeropen push quote AAPL TSLA
+
+# 订单状态推送 / Order status updates
+tigeropen push order
+
+# 持仓变动推送 / Position updates
+tigeropen push position
+
+# 资产变动推送 / Asset updates
+tigeropen push asset
+```
+
+> 同一 `tiger_id` 只能有一个推送连接，新连接会踢掉旧连接。
+> Only one push connection per `tiger_id`; new connection kicks the old one.
+
+---
+
+## 命令总览 / Command Reference
+
+```
+tigeropen [全局选项 Global Options]
+├── version                             # SDK 版本 Version
+├── config                              # 配置管理 Configuration
+│   ├── init                            # 交互式配置 Interactive setup
+│   ├── show                            # 查看配置（脱敏）Show config (masked)
+│   ├── set <KEY> <VALUE>               # 设置配置项 Set config value
+│   └── path                            # 配置路径 Config path
+├── quote                               # 行情数据 Market Data
+│   ├── briefs <SYMBOLS...>             # 实时报价 Real-time quotes
+│   ├── bars <SYMBOLS...>               # K 线 Candlestick
+│   ├── timeline <SYMBOLS...>           # 分时 Intraday timeline
+│   ├── ticks <SYMBOLS...>              # 逐笔 Tick data
+│   ├── depth <SYMBOLS...>              # 盘口 Order book depth
+│   ├── market-status                   # 市场状态 Market status
+│   ├── symbols                         # 股票列表 Symbol list
+│   ├── option                          # 期权 Options
+│   │   ├── expirations <SYMBOL>        # 到期日 Expiration dates
+│   │   ├── chain <SYMBOL> <EXPIRY>     # 期权链 Option chain
+│   │   ├── briefs <IDENTIFIERS...>     # 期权报价 Option quotes
+│   │   └── bars <IDENTIFIERS...>       # 期权 K 线 Option bars
+│   ├── future                          # 期货 Futures
+│   │   ├── exchanges                   # 交易所 Exchanges
+│   │   ├── contracts <EXCHANGE>        # 合约列表 Contract list
+│   │   ├── briefs <IDENTIFIERS...>     # 期货报价 Futures quotes
+│   │   └── bars <IDENTIFIER>           # 期货 K 线 Futures bars
+│   ├── capital                         # 资金 Capital
+│   │   ├── flow <SYMBOL>               # 资金流向 Capital flow
+│   │   └── distribution <SYMBOL>       # 资金分布 Capital distribution
+│   └── fundamental                     # 基本面 Fundamental
+│       ├── financial <SYMBOLS...>      # 财务报告 Financial reports
+│       ├── dividend <SYMBOLS...>       # 分红 Dividends
+│       └── earnings                    # 财报日历 Earnings calendar
+├── trade                               # 交易 Trading
+│   ├── order                           # 订单 Orders
+│   │   ├── list                        # 订单列表 Order list
+│   │   ├── get <ORDER_ID>              # 订单详情 Order details
+│   │   ├── preview                     # 预览 Preview
+│   │   ├── place                       # 下单 Place order
+│   │   ├── modify <ORDER_ID>           # 改单 Modify order
+│   │   └── cancel <ORDER_ID>           # 撤单 Cancel order
+│   ├── position                        # 持仓 Positions
+│   │   └── list                        # 持仓列表 Position list
+│   └── transaction                     # 成交 Transactions
+│       └── list                        # 成交记录 Transaction list
+├── account                             # 账户 Account
+│   ├── info                            # 账户信息 Account info
+│   ├── assets                          # 资产 Assets
+│   └── analytics                       # 分析 Analytics
+└── push                                # 推送 Push (Streaming)
+    ├── quote <SYMBOLS...>              # 行情推送 Quote streaming
+    ├── order                           # 订单推送 Order streaming
+    ├── position                        # 持仓推送 Position streaming
+    └── asset                           # 资产推送 Asset streaming
+```
+
+---
+
+## 常用场景 / Common Workflows
+
+### 快速查看行情 / Quick Quote Check
+
+```bash
+tigeropen quote briefs AAPL TSLA GOOG --format json
+```
+
+### 查看持仓盈亏 / Check Position P&L
+
+```bash
+tigeropen trade position list --format table
+tigeropen account assets
+```
+
+### 下单完整流程 / Full Order Workflow
+
+```bash
+# 1. 查看实时行情 / Check current price
+tigeropen quote briefs AAPL
+
+# 2. 预览订单 / Preview order
+tigeropen trade order preview --symbol AAPL --action BUY --quantity 100 --limit-price 150
+
+# 3. 下单 / Place order
+tigeropen trade order place --symbol AAPL --action BUY --quantity 100 --limit-price 150
+
+# 4. 查看订单状态 / Check order status
+tigeropen trade order list --symbol AAPL --status Submitted
+
+# 5. 如需撤单 / Cancel if needed
+tigeropen trade order cancel <ORDER_ID>
+```
+
+### 导出数据 / Export Data
+
+```bash
+# 导出 K 线到 CSV 文件 / Export bars to CSV file
+tigeropen -f csv quote bars AAPL --period day --limit 100 > aapl_bars.csv
+
+# 导出持仓为 JSON / Export positions as JSON
+tigeropen -f json trade position list > positions.json
+
+# 导出成交记录 / Export transactions
+tigeropen -f csv trade transaction list --symbol AAPL > aapl_transactions.csv
+```
+
+### 实时监控 / Real-time Monitoring
+
+```bash
+# 监控行情（Ctrl+C 停止）/ Monitor quotes (Ctrl+C to stop)
+tigeropen push quote AAPL TSLA
+
+# 监控订单状态 / Monitor order updates
+tigeropen push order
+```
+
+---
+
+## 错误处理 / Error Handling
+
+CLI 自动捕获 API 异常并显示错误代码和消息。
+The CLI automatically catches API exceptions and displays error codes and messages.
+
+```bash
+# 启用详细日志查看完整调用栈 / Enable verbose for full stack trace
+tigeropen -v quote briefs INVALID_SYMBOL
+```
+
+常见错误 / Common errors:
+
+| 错误 Error | 说明 Description |
+|-----------|-----------------|
+| `API Error [4]` | 访问被拒绝（检查凭证/权限）Access forbidden (check credentials) |
+| `API Error [5]` | 频率限制（稍后重试）Rate limited (retry later) |
+| `Config file not found` | 运行 `tigeropen config init` 初始化配置 / Run config init |
+| `No quote data found` | 无数据（检查标的代码/市场状态）No data (check symbol/market status) |
+
+---
+
+## 注意事项 / Notes
+
+- CLI 复用 SDK 的 `TigerOpenClientConfig` 配置体系，支持配置文件、环境变量、`--config-path` 参数
+  CLI reuses SDK's `TigerOpenClientConfig`, supports config file, env vars, and `--config-path`
+- 下单/改单/撤单操作默认需要交互确认，`-y` 跳过
+  Place/modify/cancel require confirmation by default; use `-y` to skip
+- 推送命令使用 WebSocket 长连接，Ctrl+C 断开
+  Push commands use WebSocket; Ctrl+C to disconnect
+- 行情权限需单独购买，API 与 App 独立
+  Quote permissions require separate purchase; API and App are independent
+- 全部输出支持 `--format json` 用于管道和脚本处理
+  All output supports `--format json` for piping and scripting

--- a/.agents/skills/tigeropen/references/mcp.md
+++ b/.agents/skills/tigeropen/references/mcp.md
@@ -1,0 +1,192 @@
+
+# Tiger MCP Server
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/mcp
+
+Tiger MCP Server 将老虎 OpenAPI 暴露为 MCP (Model Context Protocol) 工具，集成到 Cursor、Claude Code、Kiro、Trae 等 AI 编辑器。
+Tiger MCP Server exposes Tiger OpenAPI as MCP tools for AI editors like Cursor, Claude Code, Kiro, and Trae.
+
+## 安装 / Installation
+
+```bash
+pip install tigermcp
+# 或推荐使用 uvx / Or recommended:
+uvx tigermcp
+```
+
+### 前置：安装 uv / Prerequisites: Install uv
+
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+## 配置 / Configuration
+
+### 方式一：配置文件 / Config File
+
+```bash
+export TIGEROPEN_PROPS_PATH="/path/to/config/"  # 配置文件所在目录 / Directory containing config file
+```
+
+### 方式二：环境变量 / Environment Variables
+
+```bash
+export TIGEROPEN_TIGER_ID="your_tiger_id"
+export TIGEROPEN_PRIVATE_KEY="your_private_key"  # 私钥内容或文件路径 / Key content or file path
+export TIGEROPEN_ACCOUNT="your_account"
+```
+
+### 可选配置 / Optional
+
+```bash
+export TIGERMCP_READONLY=true   # 只读模式，禁止交易 / Read-only mode, disable trading
+export TIGERMCP_DEBUG=true      # 调试模式 / Debug mode
+```
+
+## 运行 / Run
+
+```bash
+uvx tigermcp
+```
+
+## AI 编辑器集成 / AI Editor Integration
+
+### 个人用户 / Individual Users
+
+在编辑器的 MCP 配置中添加 / Add to editor's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "tigermcp": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "tigermcp"],
+      "env": {
+        "TIGEROPEN_TIGER_ID": "your_tiger_id",
+        "TIGEROPEN_PRIVATE_KEY": "your_private_key",
+        "TIGEROPEN_ACCOUNT": "your_account",
+        "TIGERMCP_READONLY": true
+      }
+    }
+  }
+}
+```
+
+> 也可使用 `TIGEROPEN_PROPS_PATH` 指定配置文件路径，代替 `TIGEROPEN_TIGER_ID` 等配置。
+> You can also use `TIGEROPEN_PROPS_PATH` to specify config file path instead of individual env vars.
+
+### 机构用户 / Institutional Users
+
+```json
+{
+  "mcpServers": {
+    "tigermcp": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "tigermcp"],
+      "env": {
+        "TIGEROPEN_TIGER_ID": "your_tiger_id",
+        "TIGEROPEN_PRIVATE_KEY": "your_private_key",
+        "TIGEROPEN_ACCOUNT": "your_account",
+        "TIGEROPEN_SECRET_KEY": "your_secret_key",
+        "TIGEROPEN_SIGN_TYPE": "TBHK",
+        "TIGERMCP_TOKEN": "your_2fa_token"
+      }
+    }
+  }
+}
+```
+
+### 只读模式(推荐初次使用) / Read-only Mode (Recommended for First-time Use)
+
+```json
+{
+  "mcpServers": {
+    "tigermcp": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "tigermcp"],
+      "env": {
+        "TIGEROPEN_PROPS_PATH": "/path/to/config/",
+        "TIGERMCP_READONLY": true
+      }
+    }
+  }
+}
+```
+
+### 编辑器配置文件位置 / Editor Config File Locations
+
+| 编辑器 Editor | 配置路径 Config Path |
+|--------------|---------------------|
+| Cursor | `.cursor/mcp.json` (项目级) 或 `~/.cursor/mcp.json` (全局) |
+| Claude Code | `.claude/settings.local.json` 或 `~/.claude/settings.json` |
+| Trae | `.trae/mcp.json` |
+| Kiro | `.kiro/settings/mcp.json` (项目级) 或 `~/.kiro/settings/mcp.json` (全局) |
+
+## 可用 MCP 工具 / Available MCP Tools
+
+### 行情工具 / Quote Tools
+
+| 工具 Tool | 功能 Function |
+|----------|--------------|
+| `get_realtime_quote` | 股票/期权/期货实时行情 Real-time stock/option/future quotes |
+| `get_depth_quote` | 深度盘口 Level 2 order book |
+| `get_ticks` | 逐笔成交 Trade ticks |
+| `get_bars` | K线数据 K-line candlestick data |
+| `get_timeline` | 分时数据 Intraday timeline |
+| `get_capital_flow` | 资金流向 Capital flow |
+| `get_capital_distribution` | 资金分布 Capital distribution |
+| `get_stock_broker` | 港股经纪商数据 HK broker seat data |
+| `get_option_expirations` | 期权到期日 Option expiration dates |
+| `get_option_chain` | 期权链 Option chain with Greeks |
+| `get_hk_option_symbols` | 港股期权代码映射 HK option symbol mapping |
+| `get_market_status` | 市场状态 Market status |
+
+### 交易工具 / Trade Tools
+
+| 工具 Tool | 功能 Function |
+|----------|--------------|
+| `place_order` | 下单 Place order (只读模式禁用 disabled in read-only) |
+| `cancel_order` | 撤单 Cancel order (只读模式禁用 disabled in read-only) |
+| `preview_order` | 预览订单 Preview order |
+| `get_orders` | 查询订单列表 Query orders |
+| `get_order` | 订单详情 Order details |
+| `get_transactions` | 成交记录 Transaction records |
+| `get_positions` | 持仓查询 Position query |
+| `get_assets` | 资产查询 Asset query |
+| `get_analytics_asset` | 资产分析 Asset analytics |
+| `get_contract` | 合约信息 Contract info |
+
+## 常见问题 / Troubleshooting
+
+### macOS 12 及以下 `realpath: command not found`
+
+```bash
+brew install coreutils
+```
+
+### Homebrew 未安装 / Homebrew Not Installed
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### 连接问题 / Connection Issues
+
+- 确保网络可访问 Tiger API 服务器 / Ensure network can reach Tiger API servers
+- 检查 tiger_id/private_key/account 是否正确 / Verify credentials
+- 检查私钥格式为 PKCS#1 / Ensure private key is PKCS#1 format
+
+## 注意事项 / Notes
+
+- `TIGERMCP_READONLY=true` 启用只读模式，禁止 `place_order` 和 `cancel_order`，初次使用建议开启
+- MCP Server 通过 stdio 模式运行 / Runs in stdio mode
+- 需要 `tigeropen>=3.4.8` 和 `mcp[cli]>=1.13.0`
+- 也可使用 `TIGEROPEN_PROPS_PATH` 指定配置文件路径，代替单独配置各环境变量
+- Tiger MCP 是 AI 连接 Tiger API 的工具，输出取决于 AI/LLM 能力
+- 用户承担所有投资决策风险 / Users bear all investment decision risks
+- 免责声明 / Disclaimer: https://docs.itigerup.com/docs/mcp

--- a/.agents/skills/tigeropen/references/option.md
+++ b/.agents/skills/tigeropen/references/option.md
@@ -1,0 +1,978 @@
+
+# Tiger Open API 期权 / Options Trading
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/quote-option
+
+## 期权操作工作流 / Option Workflow
+<!-- 当用户提到 "期权"、"期权链"、"到期日"、"行权价"、"Greeks"、"Call"、"Put"、"看涨"、"看跌"、"option"、"option chain"、"expiration"、"strike" 时 -->
+
+当用户提到期权时，按以下流程操作 / When user mentions options, follow this workflow:
+
+### 查询期权 / Query Options
+
+1. **查到期日 Get expirations**: `get_option_expirations()` → 获取可选到期日列表 / Get available expiration dates
+2. **查期权链 Get chain**: `get_option_chain()` → 获取指定到期日的所有合约，可用 `OptionFilter` 筛选 / Get all contracts for a given expiry, filter with `OptionFilter`
+3. **查行情 Get quotes**: `get_option_briefs()` → 获取期权实时行情和希腊字母 / Get real-time quotes and Greeks
+
+### 期权交易 / Option Trading
+
+1. **构造合约 Build contract**: `option_contract_by_symbol(symbol, expiry, strike, put_call, currency)`
+2. **预览订单 Preview**: `preview_order()` → 确认保证金和佣金 / Confirm margin and commission
+3. **下单 Place order**: `place_order()` → 期权数量单位为"张" / Option quantity is in "contracts"
+
+### 港股期权特殊处理 / HK Option Special Handling
+
+- 港股期权标的代码不同于正股 / HK option underlyings differ from stock codes: `00700` → `TCH`（腾讯）
+- 使用 `get_option_symbols()` 查询港股期权代码映射 / Use `get_option_symbols()` for HK option symbol mapping
+
+---
+
+## 初始化 / Initialize
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.trade.trade_client import TradeClient
+
+client_config = TigerOpenClientConfig(props_path='/path/to/your/tiger_openapi_config.properties')
+quote_client = QuoteClient(client_config=client_config)
+trade_client = TradeClient(client_config=client_config)
+```
+
+---
+
+## 期权到期日 / Option Expirations
+
+```python
+expirations = quote_client.get_option_expirations(symbols=['AAPL'], market='US')
+# 返回 DataFrame / Returns DataFrame
+# 列: symbol, option_symbol, date, timestamp, period_tag
+# period_tag: "m"=月度期权(monthly), "w"=周期权(weekly)
+# 也支持 symbols=['AAPL', 'TSLA'] 批量查询
+```
+
+## 期权链 / Option Chain
+
+```python
+from tigeropen.quote.domain.filter import OptionFilter
+
+# 基础期权链 / Basic chain
+chain = quote_client.get_option_chain(symbol='AAPL', expiry='2025-08-29', market='US')
+# 返回 DataFrame，包含 call/put 的行权价、价格、成交量、持仓量等
+
+# 带筛选和希腊字母 / With filters and Greeks
+option_filter = OptionFilter(
+    implied_volatility_min=0.3,
+    implied_volatility_max=0.8,
+    delta_min=0.2,
+    delta_max=0.8,
+    gamma_min=0.005,
+    theta_max=-0.05,
+    open_interest_min=100,
+    volume_min=50,
+    in_the_money=True
+)
+chain = quote_client.get_option_chain(
+    symbol='AAPL', expiry='2025-08-29',
+    option_filter=option_filter,
+    return_greek_value=True,  # 返回 delta/gamma/theta/vega/rho
+    market='US')
+```
+
+### OptionFilter 筛选字段 / Filter Fields
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `implied_volatility_min/max` | 隐含波动率范围 IV range |
+| `delta_min/max` | Delta 范围 |
+| `gamma_min/max` | Gamma 范围 |
+| `theta_min/max` | Theta 范围 |
+| `vega_min/max` | Vega 范围 |
+| `open_interest_min/max` | 持仓量范围 Open interest |
+| `volume_min/max` | 成交量范围 Volume |
+| `in_the_money` | 是否实值 In the money (True/False) |
+
+**get_option_chain 返回字段 / Return Fields** (pandas.DataFrame, 21列):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期权完整代码 (e.g. `AAPL  250829C00150000`) |
+| `symbol` | 标的代码 Underlying symbol |
+| `expiry` | 到期日毫秒时间戳 Expiration timestamp (ms) |
+| `strike` | 行权价 Strike price |
+| `put_call` | `CALL`(看涨) / `PUT`(看跌) |
+| `multiplier` | 乘数（美股通常100） Option multiplier |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 |
+| `pre_close` | 前收盘价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `volume` | 成交量 Volume |
+| `open_interest` | 未平仓合约数 Open interest |
+| `last_timestamp` | 最后交易时间戳（毫秒） Last trade time (ms) |
+| `implied_vol` | 隐含波动率 Implied volatility |
+| `delta` | Delta（需 `return_greek_value=True`）|
+| `gamma` | Gamma |
+| `theta` | Theta（每日时间价值损耗，通常为负值） |
+| `vega` | Vega（波动率敏感度） |
+| `rho` | Rho（利率敏感度） |
+
+---
+
+## 港股期权 / HK Options
+
+港股期权标的代码与股票代码不同，需先映射。
+HK option underlying symbols differ from stock codes; map first.
+
+```python
+# 获取映射 / Get mapping (e.g. 00700 -> TCH.HK)
+# 返回 DataFrame: columns=['symbol'(期权代码), 'name', 'underlying_symbol'(正股代码)]
+hk_symbols_df = quote_client.get_option_symbols(market='HK')
+# 查找腾讯 / Find Tencent:
+tencent = hk_symbols_df[hk_symbols_df['underlying_symbol'] == '00700'].iloc[0]
+option_symbol = tencent['symbol']  # e.g. 'TCH.HK'
+
+# 使用映射后的代码 / Use mapped symbol
+expirations = quote_client.get_option_expirations(symbols=['TCH.HK'], market='HK')
+chain = quote_client.get_option_chain(symbol='TCH.HK', expiry='2025-06-18', market='HK')
+```
+
+---
+
+## 期权行情 / Option Quotes
+
+```python
+# 实时行情 / Real-time quotes
+briefs = quote_client.get_option_briefs(identifiers=['AAPL  250829C00150000'])
+
+# K线 / K-lines (支持周期: day, 1min, 5min, 30min, 60min)
+bars = quote_client.get_option_bars(identifiers=['AAPL  250829C00150000'], period='day')
+# 可选参数: sort_dir (SortDirection.ASC/DESC), limit, begin_time, end_time
+
+# 深度行情 / Depth quotes
+depth = quote_client.get_option_depth(identifiers=['AAPL  250829C00150000'], market='US')
+
+# 逐笔成交 / Trade ticks
+ticks = quote_client.get_option_trade_ticks(identifiers=['AAPL  250829C00150000'])
+
+# 分时 / Timeline (支持 US 和 HK 市场 / Supports US and HK markets)
+timeline = quote_client.get_option_timeline(identifiers=['AAPL  250829C00150000'])
+# HK 期权: quote_client.get_option_timeline(identifiers=['TCH.HK250828C00610000'], market='HK')
+```
+
+**get_option_briefs 返回字段 / Return Fields** (pandas.DataFrame, 27列):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期权完整代码 Full option identifier |
+| `symbol` | 标的代码 Underlying symbol |
+| `expiry` | 到期日毫秒时间戳 |
+| `strike` | 行权价 Strike price |
+| `put_call` | `CALL` / `PUT` |
+| `multiplier` | 乘数 Option multiplier |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 Ask size |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 Bid size |
+| `pre_close` | 前收价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `latest_time` | 最新交易时间 Latest trade time |
+| `volume` | 成交量 Volume |
+| `open_interest` | 未平仓数量 Open interest |
+| `open` | 开盘价 Open price |
+| `high` | 最高价 High price |
+| `low` | 最低价 Low price |
+| `change` | 价格变动 Price change |
+| `volatility` | 历史波动率 Historical volatility |
+| `rates_bonds` | 无风险利率 Risk-free interest rate |
+| `mid_price` | 买卖中间价 Mid price (ask+bid)/2 |
+| `mid_timestamp` | 中间价时间戳 Mid price timestamp (ms) |
+| `mark_price` | 标记价格 Mark price |
+| `mark_timestamp` | 标记价格时间戳 Mark price timestamp (ms) |
+| `pre_mark_price` | 前标记价格 Previous mark price |
+| `selling_return` | 卖出收益率 Selling return (for covered call/cash-secured put) |
+
+### 期权代码格式 / Option Symbol Format
+
+- 美股 US: `'AAPL  250829C00150000'`
+  - 格式: `标的` + 空格填充至6位 + `YYMMDD` + `C/P` + 行权价*1000(8位)
+  - Format: symbol padded to 6 chars + YYMMDD + C/P + strike*1000 (8 digits)
+- 港股 HK: `'TCH.HK 230616C00550000'`
+  - 注意使用映射后的代码 / Use mapped symbol
+
+---
+
+## 期权分析 / Option Analysis
+
+```python
+from tigeropen.common.consts import OptionAnalysisPeriod
+
+# 基础用法(默认52周) / Basic usage (default 52-week)
+analysis = quote_client.get_option_analysis(symbols=['AAPL'])
+
+# 指定分析周期 / Specify analysis period
+analysis = quote_client.get_option_analysis(
+    symbols=['AAPL'],
+    period=OptionAnalysisPeriod.TWENTY_SIX_WEEK)
+
+# 每个标的不同周期 / Per-symbol periods
+analysis = quote_client.get_option_analysis(
+    symbols=[
+        'AAPL',  # 使用默认周期
+        {'symbol': 'TSLA', 'period': '26week'},  # 指定26周
+    ])
+
+# 返回 List[OptionAnalysis]，属性:
+# - symbol: 标的代码
+# - implied_vol_30_days: 30日隐含波动率
+# - his_volatility: 历史波动率
+# - iv_his_v_ratio: IV/HV 比率
+# - call_put_ratio: 看涨/看跌比率
+# - iv_metric: IVMetric 对象，包含:
+#     - period: 分析周期
+#     - percentile: IV 百分位
+#     - rank: IV 排名
+```
+
+### OptionAnalysisPeriod 分析周期
+
+| 周期 Period | 值 Value | 说明 Description |
+|------------|---------|-----------------|
+| `THREE_YEAR` | `3year` | 3年 / 3 years |
+| `FIFTY_TWO_WEEK` | `52week` | 52周(1年，默认) / 52 weeks (default) |
+| `TWENTY_SIX_WEEK` | `26week` | 26周(6个月) / 26 weeks |
+| `THIRTEEN_WEEK` | `13week` | 13周(3个月) / 13 weeks |
+
+---
+
+## 期权合约 / Option Contracts
+
+```python
+from tigeropen.common.util.contract_utils import option_contract_by_symbol
+
+# 本地构造 / Local construction
+opt = option_contract_by_symbol(
+    symbol='AAPL', expiry='20250829',
+    strike=150.0, put_call='CALL', currency='USD')
+
+# 远程获取 / Remote fetch
+opt = trade_client.get_contract(
+    symbol='AAPL', sec_type='OPT',
+    expiry='20250829', strike=150.0, put_call='CALL')
+```
+
+---
+
+## 单腿期权下单 / Single-leg Option Order
+
+```python
+from tigeropen.common.util.order_utils import limit_order
+
+# 买入看涨期权 / Buy call
+order = limit_order(account=client_config.account, contract=opt,
+                    action='BUY', quantity=1, limit_price=5.0)
+trade_client.place_order(order)
+
+# 卖出看跌期权 / Sell put
+put_contract = option_contract_by_symbol(
+    symbol='AAPL', expiry='20250829', strike=140.0, put_call='PUT', currency='USD')
+order = limit_order(account=client_config.account, contract=put_contract,
+                    action='SELL', quantity=1, limit_price=3.0)
+trade_client.place_order(order)
+```
+
+> 期权1张合约 = 100股标的。1 option contract = 100 shares of underlying.
+
+---
+
+## 多腿组合策略 / Multi-leg Combo Strategies
+
+```python
+from tigeropen.common.util.order_utils import combo_order, contract_leg
+```
+
+### 牛市看涨价差 / Bull Call Spread (VERTICAL)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=145.0, put_call='CALL', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=155.0, put_call='CALL', action='SELL', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='VERTICAL', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=3.0)
+trade_client.place_order(order)
+```
+
+### 跨式策略 / Straddle (STRADDLE)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='CALL', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='PUT', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='STRADDLE', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=8.0)
+trade_client.place_order(order)
+```
+
+### 宽跨式策略 / Strangle (STRANGLE)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=160.0, put_call='CALL', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=140.0, put_call='PUT', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='STRANGLE', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=5.0)
+trade_client.place_order(order)
+```
+
+### 日历价差 / Calendar Spread (CALENDAR)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='CALL', action='SELL', ratio=1),  # 近月卖
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20251219',
+                 strike=150.0, put_call='CALL', action='BUY', ratio=1),   # 远月买
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='CALENDAR', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=2.0)
+trade_client.place_order(order)
+```
+
+### 对角线价差 / Diagonal Spread (DIAGONAL)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=155.0, put_call='CALL', action='SELL', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20251219',
+                 strike=145.0, put_call='CALL', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='DIAGONAL', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=5.0)
+trade_client.place_order(order)
+```
+
+### 备兑策略 / Covered Call (COVERED)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='STK', action='BUY', ratio=100),  # 买100股
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=160.0, put_call='CALL', action='SELL', ratio=1),     # 卖1张call
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='COVERED', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=145.0)
+trade_client.place_order(order)
+```
+
+### 保护性看跌 / Protective Put (PROTECTIVE)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='STK', action='BUY', ratio=100),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=140.0, put_call='PUT', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='PROTECTIVE', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=152.0)
+trade_client.place_order(order)
+```
+
+### 熊市看跌价差 / Bear Put Spread (VERTICAL)
+
+方向性策略，预期股价下跌，有限盈利有限亏损。
+
+```python
+# 买高行权价Put，卖低行权价Put（净支出）
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=155.0, put_call='PUT', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=145.0, put_call='PUT', action='SELL', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='VERTICAL', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=4.0)
+trade_client.place_order(order)
+```
+
+---
+
+### 牛市看跌价差（信用价差）/ Bull Put Spread (Credit Spread)
+
+卖出实值Put，买入更低行权价Put保护，收取权利金净信用，预期股价维持或上涨。
+
+```python
+# 卖高行权价Put，买低行权价Put（净收入信用）
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=145.0, put_call='PUT', action='SELL', ratio=1),  # 卖Put收信用
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=135.0, put_call='PUT', action='BUY', ratio=1),   # 买Put限风险
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='VERTICAL', action='SELL',
+                    quantity=1, order_type='LMT', limit_price=2.50)
+# limit_price 为净收入信用（正值），max_loss = (145-135)*100 - 250 = 750
+trade_client.place_order(order)
+```
+
+---
+
+### 熊市看涨价差（信用价差）/ Bear Call Spread (Credit Spread)
+
+卖出虚值Call，买入更高行权价Call保护，预期股价维持或下跌。
+
+```python
+# 卖低行权价Call，买高行权价Call
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=165.0, put_call='CALL', action='SELL', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=175.0, put_call='CALL', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='VERTICAL', action='SELL',
+                    quantity=1, order_type='LMT', limit_price=2.00)
+trade_client.place_order(order)
+```
+
+---
+
+### 铁鹰策略 / Iron Condor
+
+同时卖出 Bull Put Spread + Bear Call Spread，适合区间震荡行情，收取双边权利金。
+
+```python
+# Iron Condor = Bull Put Spread + Bear Call Spread（4条腿，用 CUSTOM）
+legs = [
+    # Put spread（下方保护）
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=140.0, put_call='PUT', action='BUY', ratio=1),   # 买低Put
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='PUT', action='SELL', ratio=1),  # 卖高Put
+    # Call spread（上方保护）
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=165.0, put_call='CALL', action='SELL', ratio=1), # 卖低Call
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=175.0, put_call='CALL', action='BUY', ratio=1),  # 买高Call
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='CUSTOM', action='SELL',
+                    quantity=1, order_type='LMT', limit_price=3.50)
+# limit_price = 净收入信用（正值）
+# max_profit = 350（股价到期在 150-165 区间内）
+# max_loss = (165-150)*100 - 350 = 1150（突破任一侧边界）
+trade_client.place_order(order)
+```
+
+---
+
+### 铁蝴蝶策略 / Iron Butterfly
+
+卖出同行权价的 Straddle，再分别买入两侧保护，适合极低波动率预期，比 Iron Condor 收入更高但区间更窄。
+
+```python
+atm_strike = 155.0  # ATM 行权价（接近当前股价）
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=145.0, put_call='PUT', action='BUY', ratio=1),   # 买下方Put
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=atm_strike, put_call='PUT', action='SELL', ratio=1),  # 卖ATM Put
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=atm_strike, put_call='CALL', action='SELL', ratio=1), # 卖ATM Call
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=165.0, put_call='CALL', action='BUY', ratio=1),  # 买上方Call
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='CUSTOM', action='SELL',
+                    quantity=1, order_type='LMT', limit_price=6.00)
+trade_client.place_order(order)
+```
+
+---
+
+### 穷人备兑开仓 / Poor Man's Covered Call (PMCC)
+
+用深度实值的长期 LEAPS Call 替代持有正股，成本更低，结构类似 Covered Call。
+
+```python
+# 买入远期深度实值Call（LEAPS，delta ~0.7-0.9），替代持股
+# 卖出近期虚值Call收取权利金
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20270117',  # 远期 ~1.5年
+                 strike=120.0, put_call='CALL', action='BUY', ratio=1),  # 深度实值
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',  # 近期 ~1个月
+                 strike=165.0, put_call='CALL', action='SELL', ratio=1), # 虚值
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='DIAGONAL', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=28.0)
+# 注意: 近月Call行权价必须 > 远月Call行权价，否则存在最大亏损为负的风险
+trade_client.place_order(order)
+```
+
+---
+
+### 合成股票 / Synthetic Stock (SYNTHETIC)
+
+买Call卖同行权价Put，经济效果等同于持有100股，资金占用更少。
+
+```python
+# 合成多头（等同于持股）: 买Call + 卖Put，同行权价同到期日
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='CALL', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='PUT', action='SELL', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='SYNTHETIC', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=0.50)
+# 合成空头: 两腿 action 均改为相反（卖Call+买Put）
+trade_client.place_order(order)
+```
+
+---
+
+### 常用策略对比速查 / Strategy Quick Reference
+
+| 策略 Strategy | 方向 Bias | 盈亏结构 | 风险 Risk | 典型用途 Use Case |
+|--------------|-----------|---------|-----------|-----------------|
+| Bull Call Spread | 温和看涨 | 有限盈亏 | 有限（净支出） | 方向性，控制成本 |
+| Bear Put Spread | 温和看跌 | 有限盈亏 | 有限（净支出） | 方向性下行保护 |
+| Bull Put Spread | 温和看涨/中性 | 有限盈亏 | 有限（净收入） | 收取权利金，高胜率 |
+| Bear Call Spread | 温和看跌/中性 | 有限盈亏 | 有限（净收入） | 收取权利金，高胜率 |
+| Iron Condor | 中性区间震荡 | 有限盈亏 | 有限 | 低波动率环境，双边收费 |
+| Iron Butterfly | 极度中性 | 有限盈亏 | 有限 | 极低波动预期，权利金最高 |
+| Straddle（买） | 高波动预期 | 无限盈利 | 有限（净支出） | 财报/事件驱动 |
+| Strangle（买） | 高波动预期 | 无限盈利 | 有限（更低成本） | 财报/事件驱动 |
+| Covered Call | 温和看涨/持股 | 有限盈利 | 持股风险 | 持股增收 |
+| Sell Put / CSP | 温和看涨 | 有限盈利 | 较大（行权买股） | 目标价买入+收费 |
+| PMCC | 温和看涨 | 有限盈利 | 有限 | 低成本备兑替代 |
+| Wheel Strategy | 温和看涨 | 稳定收租 | 行权买股 | 长期稳定增收 |
+| Calendar Spread | 中性/轻方向 | 有限盈亏 | 有限 | 时间价值套利 |
+| Diagonal Spread | 轻方向 | 有限盈亏 | 有限 | 方向性时间套利 |
+| Synthetic Stock | 强方向 | 无限盈亏 | 较大 | 杠杆替代持股 |
+
+---
+
+### 组合策略类型总览 / Combo Strategy Types
+
+| ComboType | 策略 Strategy | 说明 Description |
+|-----------|--------------|-----------------|
+| `VERTICAL` | 垂直价差 | 同到期日不同行权价 Same expiry, different strikes |
+| `STRADDLE` | 跨式 | 同行权价同到期日 Call+Put Same strike & expiry |
+| `STRANGLE` | 宽跨式 | 不同行权价同到期日 Call+Put Different strikes, same expiry |
+| `CALENDAR` | 日历价差 | 同行权价不同到期日 Same strike, different expiries |
+| `DIAGONAL` | 对角线价差 | 不同行权价不同到期日 Different strikes & expiries |
+| `COVERED` | 备兑 | 持有股票+卖Call Long stock + short call |
+| `PROTECTIVE` | 保护性 | 持有股票+买Put Long stock + long put |
+| `SYNTHETIC` | 合成 | 合成多/空头 Synthetic long/short |
+| `CUSTOM` | 自定义 | 自定义组合 Custom combination |
+
+### contract_leg 参数 / contract_leg Parameters
+
+| 参数 Parameter | 说明 Description | 必填 |
+|---------------|-----------------|------|
+| `symbol` | 标的代码 Symbol | ✅ |
+| `sec_type` | `OPT` / `STK` | ✅ |
+| `expiry` | 到期日 YYYYMMDD (期权) | OPT |
+| `strike` | 行权价 Strike (期权) | OPT |
+| `put_call` | `CALL` / `PUT` (期权) | OPT |
+| `action` | `BUY` / `SELL` | ✅ |
+| `ratio` | 比率 Ratio (STK用100, OPT用1) | ✅ |
+
+---
+
+## 查询期权持仓 / Query Option Positions
+
+```python
+from tigeropen.common.consts import SecurityType
+
+opt_positions = trade_client.get_positions(sec_type=SecurityType.OPT)
+for p in opt_positions:
+    c = p.contract
+    print(f"{c.symbol} {c.expiry} {c.strike} {c.put_call}: "
+          f"qty={p.qty}, cost={p.average_cost}, value={p.market_value}, pnl={p.unrealized_pnl}")
+```
+
+---
+
+## 期权计算工具 / Option Calculator Tools
+
+> 需安装 `pip install quantlib==1.40`
+
+### 期权定价与希腊字母 / Option Pricing & Greeks
+
+```python
+from tigeropen.examples.option_helpers.helpers import (
+    FDAmericanDividendOptionHelper,   # 美式期权(美股/港股/ETF) American options
+    FDEuropeanDividendOptionHelper,   # 欧式期权(指数期权) European options
+)
+
+# 计算期权价格 / Calculate option price
+helper = FDAmericanDividendOptionHelper(
+    option_type='CALL',    # CALL/PUT
+    expiry='2025-08-29',   # 到期日
+    settlement='2025-03-18',  # 结算日
+    strike=150.0,          # 行权价
+    underlying=155.0,      # 标的价格
+    rate=0.05,             # 无风险利率
+    volatility=0.25,       # 波动率
+)
+result = helper.calculate()
+# result: npv(期权价格), delta, gamma, theta, vega, rho
+
+# 从期权价格反算隐含波动率 / Calculate implied volatility from price
+helper = FDAmericanDividendOptionHelper(
+    option_type='CALL', expiry='2025-08-29', settlement='2025-03-18',
+    strike=150.0, underlying=155.0, rate=0.05,
+    option_price=8.5,  # 期权市场价格
+)
+iv = helper.implied_volatility()
+```
+
+### 期权指标计算器 / Option Metrics Calculator
+
+```python
+from tigeropen.examples.option_helpers.util import OptionUtil
+
+option_util = OptionUtil(client_config=client_config)
+
+# 计算期权指标 / Calculate option metrics
+# 输入期权代码，自动查询市场数据计算
+metrics = option_util.calculate('TSLA 260220C00385000')
+# 返回: Greeks, profit_probability(盈利概率), annualized_return_for_selling(卖出年化收益率), leverage_ratio(杠杆比率)
+```
+
+---
+
+## 复杂业务场景 / Advanced Strategy Scenarios
+
+### Wheel Strategy（车轮策略）概述
+
+Wheel Strategy = **Sell Put → 被行权后持有股票 → Sell Covered Call → 反复循环**
+
+```
+阶段1: Sell Cash-Secured Put
+  └── 若未被行权 → 收保证金，重复卖Put
+  └── 若被行权   → 以行权价买入股票
+         |
+阶段2: Sell Covered Call
+  └── 若未被行权 → 收权利金，重复卖Call
+  └── 若被行权   → 以行权价卖出股票，回到阶段1
+```
+
+**策略目标**: 持续通过卖出期权收取权利金，降低实际持股成本。
+
+---
+
+### 场景一：扫描股票池的 Sell Put 机会
+
+扫描一组股票，找出近期到期、Delta 合适、权利金收益率高的 Put 合约。
+
+```python
+import pandas as pd
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.quote.domain.filter import OptionFilter
+
+client_config = TigerOpenClientConfig(props_path='/path/to/config/')
+quote_client = QuoteClient(client_config=client_config)
+
+# 1. 定义股票池
+watchlist = ['AAPL', 'MSFT', 'TSLA', 'NVDA', 'AMD']
+
+# 2. 筛选参数（根据策略调整）
+DELTA_MIN = -0.35     # Put delta 为负，-0.35 表示约 35% 被行权概率
+DELTA_MAX = -0.15     # 偏保守，目标 delta 在 -0.15 ~ -0.35
+IV_MIN = 0.20         # 过滤低波动率标的（权利金太少）
+OI_MIN = 100          # 最小持仓量，保证流动性
+VOLUME_MIN = 10
+DAYS_TO_EXPIRY = 30   # 目标到期天数（21-45天最佳）
+
+# 3. 查询各标的的近期到期日
+def get_target_expiry(symbol, target_days=DAYS_TO_EXPIRY):
+    """找距当前最接近目标天数的到期日"""
+    import datetime
+    expirations = quote_client.get_option_expirations(symbols=[symbol], market='US')
+    today = datetime.date.today()
+    target_date = today + datetime.timedelta(days=target_days)
+
+    # 筛选月度期权（period_tag='m'），找最近的
+    monthly = expirations[expirations['period_tag'] == 'm'].copy()
+    monthly['date'] = pd.to_datetime(monthly['date']).dt.date
+    monthly['diff'] = (monthly['date'] - target_date).abs()
+
+    if monthly.empty:
+        return None
+    best = monthly.loc[monthly['diff'].idxmin()]
+    return str(best['date'])
+
+# 4. 扫描每个标的
+opportunities = []
+
+for symbol in watchlist:
+    try:
+        expiry = get_target_expiry(symbol)
+        if not expiry:
+            continue
+
+        # 查询 Put 期权链，按 delta 筛选
+        option_filter = OptionFilter(
+            delta_min=DELTA_MIN,
+            delta_max=DELTA_MAX,
+            implied_volatility_min=IV_MIN,
+            open_interest_min=OI_MIN,
+            volume_min=VOLUME_MIN,
+        )
+        chain = quote_client.get_option_chain(
+            symbol=symbol,
+            expiry=expiry,
+            option_filter=option_filter,
+            return_greek_value=True,
+            market='US'
+        )
+
+        if chain is None or chain.empty:
+            continue
+
+        # 只取 PUT
+        puts = chain[chain['put_call'] == 'PUT'].copy()
+        if puts.empty:
+            continue
+
+        # 计算关键指标
+        puts['mid_price'] = (puts['bid_price'] + puts['ask_price']) / 2
+        puts['bid_ask_spread'] = puts['ask_price'] - puts['bid_price']
+        puts['bid_ask_ratio'] = puts['bid_ask_spread'] / puts['mid_price']
+        # 年化权利金收益率 = 权利金/行权价 * (365/天数)
+        import datetime
+        today = datetime.date.today()
+        expiry_date = datetime.date.fromisoformat(expiry)
+        days_left = (expiry_date - today).days
+        puts['premium_yield'] = (puts['bid_price'] / puts['strike']) * (365 / max(days_left, 1))
+
+        # 流动性过滤: bid/ask 价差不超过 mid 的 30%
+        liquid = puts[puts['bid_ask_ratio'] < 0.30]
+
+        if liquid.empty:
+            continue
+
+        # 按年化收益率排序，取最优
+        best = liquid.sort_values('premium_yield', ascending=False).head(3)
+        best['underlying'] = symbol
+        best['expiry_date'] = expiry
+        best['days_left'] = days_left
+        opportunities.append(best)
+
+    except Exception as e:
+        print(f"Skip {symbol}: {e}")
+        continue
+
+# 5. 汇总结果
+if opportunities:
+    result = pd.concat(opportunities, ignore_index=True)
+    display_cols = [
+        'underlying', 'expiry_date', 'days_left', 'strike', 'delta',
+        'bid_price', 'ask_price', 'mid_price', 'implied_vol',
+        'open_interest', 'volume', 'premium_yield'
+    ]
+    result = result[display_cols].sort_values('premium_yield', ascending=False)
+    print(result.to_string(index=False))
+else:
+    print("No opportunities found.")
+```
+
+**输出示例 / Sample Output**:
+
+```
+underlying expiry_date  days_left  strike  delta  bid_price  ask_price  mid_price  implied_vol  open_interest  volume  premium_yield
+      NVDA  2025-05-16         38   800.0  -0.28       8.50      9.00       8.75       0.420          1523     312          0.418
+      TSLA  2025-05-16         38   220.0  -0.25       4.20      4.50       4.35       0.510           892     245          0.389
+      AAPL  2025-05-16         38   170.0  -0.22       1.80      2.00       1.90       0.280          2104     567          0.215
+```
+
+---
+
+### 场景二：执行 Sell Put 下单
+
+从扫描结果中选择目标合约并下单：
+
+```python
+from tigeropen.common.util.contract_utils import option_contract_by_symbol
+from tigeropen.common.util.order_utils import limit_order
+from tigeropen.trade.trade_client import TradeClient
+
+trade_client = TradeClient(client_config=client_config)
+
+# ⚠️ 默认使用模拟账户，实盘需用户确认
+account = client_config.account
+
+# 选择目标 Put 合约
+symbol = 'NVDA'
+expiry = '20250516'   # YYYYMMDD 格式
+strike = 800.0
+limit_price = 8.50    # 以 bid 价卖出（保守），或 mid 价（激进）
+quantity = 1          # 1张 = 100股
+
+# 构造合约
+put_contract = option_contract_by_symbol(
+    symbol=symbol,
+    expiry=expiry,
+    strike=strike,
+    put_call='PUT',
+    currency='USD'
+)
+
+# 卖出 Put
+order = limit_order(
+    account=account,
+    contract=put_contract,
+    action='SELL',
+    quantity=quantity,
+    limit_price=limit_price
+)
+
+# 预览（建议先预览确认保证金）
+preview = trade_client.preview_order(order)
+print(f"预估保证金: {preview.init_margin}")
+print(f"预估佣金: {preview.commission}")
+
+# 确认后下单
+result = trade_client.place_order(order)
+print(f"订单ID: {result.id}, 状态: {result.status}")
+```
+
+---
+
+### 场景三：监控持仓并执行 Covered Call（Wheel 第二阶段）
+
+当 Sell Put 被行权，持有正股后，自动寻找 Covered Call 机会：
+
+```python
+from tigeropen.common.consts import SecurityType
+
+# 1. 查询当前期权持仓（监控被行权的 Put）
+opt_positions = trade_client.get_positions(sec_type=SecurityType.OPT)
+assigned_symbols = []
+
+for pos in opt_positions:
+    c = pos.contract
+    # Put 被行权后会消失，但持有对应的正股
+    print(f"期权持仓: {c.symbol} {c.expiry} {c.strike} {c.put_call} qty={pos.qty}")
+
+# 2. 查询正股持仓（被行权后的股票）
+stk_positions = trade_client.get_positions(sec_type=SecurityType.STK)
+
+for pos in stk_positions:
+    symbol = pos.contract.symbol
+    qty = pos.qty
+    avg_cost = pos.average_cost
+
+    if qty < 100:  # 至少持有100股才能卖1张Covered Call
+        continue
+
+    max_contracts = qty // 100  # 可卖的最大张数
+
+    print(f"\n{symbol}: 持有 {qty}股, 均价 ${avg_cost:.2f}, 可卖 {max_contracts} 张 Covered Call")
+
+    # 3. 查询 OTM Call 期权（行权价 > 当前价格，略高于持仓成本）
+    expiry = get_target_expiry(symbol)  # 使用前面定义的函数
+    if not expiry:
+        continue
+
+    call_filter = OptionFilter(
+        delta_min=0.20,   # Call delta 0.20-0.35 （约20-35%被行权概率）
+        delta_max=0.35,
+        open_interest_min=50,
+        volume_min=5,
+    )
+    chain = quote_client.get_option_chain(
+        symbol=symbol, expiry=expiry,
+        option_filter=call_filter,
+        return_greek_value=True, market='US'
+    )
+
+    if chain is None or chain.empty:
+        continue
+
+    calls = chain[chain['put_call'] == 'CALL'].copy()
+    if calls.empty:
+        continue
+
+    # 筛选行权价高于均价（避免亏损卖出股票）
+    calls = calls[calls['strike'] > avg_cost]
+
+    if calls.empty:
+        print(f"  {symbol}: 无合适的 Covered Call 合约（所有行权价低于持仓均价）")
+        continue
+
+    # 按权利金收益率排序
+    calls['mid_price'] = (calls['bid_price'] + calls['ask_price']) / 2
+    calls = calls.sort_values('mid_price', ascending=False)
+
+    best_call = calls.iloc[0]
+    print(f"  推荐 Covered Call: 行权价 ${best_call['strike']:.1f}, "
+          f"Delta={best_call['delta']:.2f}, "
+          f"权利金 bid=${best_call['bid_price']:.2f}")
+```
+
+---
+
+### Wheel Strategy 关键参数选择指南
+
+| 参数 | 保守型 | 平衡型 | 激进型 |
+|------|--------|--------|--------|
+| Put Delta | -0.15 ~ -0.20 | -0.25 ~ -0.30 | -0.35 ~ -0.40 |
+| Call Delta | 0.20 ~ 0.25 | 0.25 ~ 0.35 | 0.35 ~ 0.45 |
+| 到期天数 DTE | 45-60 天 | 30-45 天 | 14-30 天 |
+| IV 要求 | IV Rank > 30% | IV Rank > 20% | 无特殊要求 |
+| 流动性 | OI > 500 | OI > 100 | OI > 50 |
+
+**止损原则**: 当期权市值达到权利金的 2-3 倍时考虑平仓止损。
+
+```python
+# 检查是否需要止损
+for pos in opt_positions:
+    if pos.qty < 0:  # 持有空头期权（卖出方）
+        entry_credit = abs(pos.average_cost)  # 收到的权利金（每股）
+        current_price = pos.market_price       # 当前期权价格
+        loss_ratio = current_price / entry_credit
+
+        if loss_ratio > 2.0:  # 亏损超过2倍权利金
+            c = pos.contract
+            print(f"⚠️ 止损警告: {c.symbol} {c.strike}{c.put_call} "
+                  f"当前亏损 {loss_ratio:.1f}x 权利金，考虑平仓")
+```
+
+---
+
+## 注意事项 / Notes
+
+- 港股期权需 `get_option_symbols` 获取代码映射 / HK options need symbol mapping
+- 期权每张合约通常代表100股标的 / Each contract = 100 shares
+- 希腊字母通过 `return_greek_value=True` 获取 / Greeks via `return_greek_value=True`
+- 组合策略下单时所有 leg 标的必须一致 / All legs must share same underlying
+- 期权行情需要期权行情权限 / Option quotes require option quote permission
+- 期权计算工具需安装 quantlib / Calculator tools require `pip install quantlib==1.40`
+- 更多期权知识见 / More: https://docs.itigerup.com/docs/quote-option

--- a/.agents/skills/tigeropen/references/push.md
+++ b/.agents/skills/tigeropen/references/push.md
@@ -1,0 +1,488 @@
+
+# Tiger Open API 实时推送 / Real-time Push
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/push-quote
+
+## 创建推送客户端 / Create Push Client
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.push.push_client import PushClient
+
+client_config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+protocol, host, port = client_config.socket_host_port
+push_client = PushClient(host, port, use_ssl=(protocol == 'ssl'), use_protobuf=True, client_config=client_config)
+```
+
+> `client_config` 参数推荐传入，使用 `use_full_tick` 等功能时必须传入。
+> Passing `client_config` is recommended; required for features like `use_full_tick`.
+
+---
+
+## 回调函数 / Callback Functions
+
+### 行情变动 / Quote Change
+
+```python
+def on_quote_changed(frame):
+    """股票/期货行情变动 Stock/future quote change"""
+    # ⚠️ 使用 protobuf 时字段名为 camelCase / protobuf mode fields are camelCase
+    print(f"{frame.symbol}: price={frame.latestPrice}, volume={frame.volume}")
+    # protobuf 字段 / protobuf fields: symbol, latestPrice, volume, amount,
+    #   open, high, low, preClose, latestTime, marketStatus, identifier
+    # 盘前盘后 / Extended hours: hourTradingTag
+```
+
+### 买卖盘口(BBO)变动 / Quote BBO Change
+
+```python
+def on_quote_bbo_changed(frame):
+    """买一卖一盘口变动 Best Bid/Offer change"""
+    print(f"{frame.symbol}: bid={frame.bid_price}x{frame.bid_size}, "
+          f"ask={frame.ask_price}x{frame.ask_size}")
+    # 属性: symbol, bid_price, bid_size, ask_price, ask_size
+```
+
+> `quote_bbo_changed` 与 `quote_changed` 是独立的回调，分别推送盘口和行情数据。
+> `quote_bbo_changed` and `quote_changed` are separate callbacks for BBO and quote data.
+
+### 深度行情 / Depth Quote Change
+
+```python
+def on_depth_quote(frame):
+    """深度盘口变动 Depth quote change"""
+    print(f"{frame.symbol}: asks={frame.asks}, bids={frame.bids}")
+    # asks/bids 各为列表: [price, volume, order_count]
+```
+
+### 逐笔成交 / Tick Change
+
+```python
+def on_tick(frame):
+    """逐笔成交推送 Trade tick push"""
+    print(f"{frame.symbol}: price={frame.price}, volume={frame.volume}, time={frame.time}")
+    # 属性: symbol, price, volume, time, type, sn
+```
+
+### 完整逐笔成交 / Full Tick Change
+
+```python
+def on_full_tick(frame):
+    """完整逐笔成交推送(含历史) Full trade tick push (includes history)"""
+    print(f"{frame.symbol}: price={frame.price}, volume={frame.volume}")
+    # 需要 use_full_tick=True 且传入 client_config
+    # Requires use_full_tick=True and client_config passed to PushClient
+```
+
+### K线推送 / K-line Change
+
+```python
+def on_kline(frame):
+    """分钟K线推送 Minute K-line push"""
+    print(f"{frame.symbol}: open={frame.open}, high={frame.high}, "
+          f"low={frame.low}, close={frame.close}, volume={frame.volume}")
+    # 属性: symbol, time, open, high, low, close, volume
+```
+
+### 订单变动 / Order Change
+
+```python
+def on_order_changed(frame):
+    """订单状态变动 Order status change"""
+    print(f"Order {frame.id}: symbol={frame.symbol}, status={frame.status}, "
+          f"action={frame.action}, filled={frame.filled_quantity}/{frame.quantity}")
+    # 属性: id, order_id, symbol, sec_type, action, order_type, status,
+    #       quantity, filled_quantity, avg_fill_price, limit_price, aux_price,
+    #       trade_time, time_in_force, outside_rth, cancel_status, replace_status
+```
+
+### 持仓变动 / Position Change
+
+```python
+def on_position_changed(frame):
+    """持仓变动 Position change"""
+    print(f"{frame.symbol}: qty={frame.quantity}, cost={frame.average_cost}, "
+          f"price={frame.latest_price}, pnl={frame.unrealized_pnl}")
+    # 属性: symbol, sec_type, market, currency, quantity, average_cost,
+    #       latest_price, market_value, unrealized_pnl, realized_pnl
+```
+
+### 资产变动 / Asset Change
+
+```python
+def on_asset_changed(frame):
+    """资产变动 Asset change"""
+    print(f"Net: {frame.net_liquidation}, Available: {frame.available_funds}")
+    # 属性: net_liquidation, available_funds, excess_liquidity, buying_power,
+    #       cash_balance, init_margin, maintain_margin, realized_pnl, unrealized_pnl
+```
+
+### 成交推送 / Transaction Change
+
+```python
+def on_transaction_changed(frame):
+    """成交推送 Transaction push"""
+    print(f"Order {frame.order_id}: filled {frame.filled_quantity} @ {frame.filled_price}")
+    # 属性: order_id, filled_price, filled_quantity, transact_time
+```
+
+### 数字货币行情 / Crypto Quote Change
+
+```python
+def on_cc_changed(frame):
+    """数字货币行情变动 Crypto quote change"""
+    print(f"{frame.symbol}: price={frame.latest_price}")
+
+def on_cc_bbo_changed(frame):
+    """数字货币盘口变动 Crypto BBO change"""
+    print(f"{frame.symbol}: bid={frame.bid_price}, ask={frame.ask_price}")
+```
+
+### 热门排行 / Top Ranking Change
+
+```python
+def on_stock_top_changed(frame):
+    """股票热门排行变动 Stock top ranking change"""
+    print(frame)
+
+def on_option_top_changed(frame):
+    """期权热门排行变动 Option top ranking change"""
+    print(frame)
+```
+
+### 连接/断开/错误回调 / Connection Callbacks
+
+```python
+def on_connected(frame):
+    """连接成功 Connected — frame 参数必须接收 / frame arg required"""
+    print("Push connected")
+    # ⚠️ 在此处执行订阅 / Subscribe here after connection established
+    push_client.subscribe_quote(['AAPL', 'TSLA'])
+
+def on_disconnected(frame=None):
+    """断开连接 Disconnected (自动重连 auto-reconnects)"""
+    print("Push disconnected, will auto-reconnect")
+    # ⚠️ 重连后订阅不会自动恢复，需在 on_connected 中重新订阅
+    # Subscriptions NOT auto-restored on reconnect; re-subscribe in on_connected
+
+def on_error(frame):
+    """错误 Error"""
+    print(f"Push error: {frame}")
+
+def on_kickout(frame):
+    """被踢出(新连接登录) Kicked out by new connection"""
+    print(f"Kicked out: {frame}")
+```
+
+---
+
+## 注册回调并连接 / Register Callbacks & Connect
+
+```python
+# 注册回调 / Register callbacks
+push_client.quote_changed = on_quote_changed
+push_client.quote_bbo_changed = on_quote_bbo_changed
+push_client.quote_depth_changed = on_depth_quote
+push_client.tick_changed = on_tick
+push_client.full_tick_changed = on_full_tick
+push_client.kline_changed = on_kline
+push_client.order_changed = on_order_changed
+push_client.position_changed = on_position_changed
+push_client.asset_changed = on_asset_changed
+push_client.transaction_changed = on_transaction_changed
+push_client.cc_changed = on_cc_changed
+push_client.cc_bbo_changed = on_cc_bbo_changed
+push_client.stock_top_changed = on_stock_top_changed
+push_client.option_top_changed = on_option_top_changed
+
+# 连接/断开回调 / Connection callbacks
+push_client.connect_callback = on_connected
+push_client.disconnect_callback = on_disconnected
+push_client.error_callback = on_error
+push_client.kickout_callback = on_kickout
+
+# 连接 / Connect
+push_client.connect(client_config.tiger_id, client_config.private_key)
+```
+
+---
+
+## 订阅数据 / Subscribe
+
+### 股票行情 / Stock Quotes
+
+```python
+# 订阅行情变动 / Subscribe quote changes
+push_client.subscribe_quote(['AAPL', 'TSLA', '00700'])
+
+# 取消订阅 / Unsubscribe
+push_client.unsubscribe_quote(['AAPL'])
+```
+
+### 期权行情 / Option Quotes
+
+```python
+# 订阅期权行情(使用 subscribe_option，空格分隔格式)
+# Subscribe option quotes (use subscribe_option, space-separated format)
+push_client.subscribe_option(['AAPL 20250829 150.0 CALL'])
+
+# 也可通过 subscribe_quote 使用 OCC 格式
+# Or via subscribe_quote with OCC format
+push_client.subscribe_quote(['AAPL  250829C00150000'])
+
+push_client.unsubscribe_quote(['AAPL  250829C00150000'])
+```
+
+> 注意: `subscribe_option` 使用空格分隔格式 `'AAPL 20250829 150.0 CALL'`，
+> 而 `subscribe_quote` 使用 OCC 格式 `'AAPL  250829C00150000'`。
+> Note: `subscribe_option` uses space-separated format, while `subscribe_quote` uses OCC format.
+
+### 期货行情 / Future Quotes
+
+```python
+# 订阅期货行情 / Subscribe future quotes
+push_client.subscribe_future(['CL2509'])
+```
+
+### 数字货币行情 / Crypto Quotes
+
+```python
+# 数字货币使用 subscribe_cc / Use subscribe_cc for crypto
+push_client.subscribe_cc(['BTC/USD', 'ETH/USD'])
+push_client.unsubscribe_cc(['BTC/USD'])
+# 回调: cc_changed, cc_bbo_changed / Callbacks: cc_changed, cc_bbo_changed
+```
+
+### 深度盘口 / Depth Quotes
+
+```python
+push_client.subscribe_depth_quote(['AAPL'])  # 需要 L2 权限 / Requires L2
+push_client.unsubscribe_depth_quote(['AAPL'])
+```
+
+### 逐笔成交 / Trade Ticks
+
+```python
+push_client.subscribe_tick(['AAPL'])
+push_client.unsubscribe_tick(['AAPL'])
+
+# 完整逐笔(含历史) / Full tick (includes history)
+# 需在连接前设置，且 PushClient 必须传入 client_config
+# Must set before connect, and PushClient must have client_config
+push_client.use_full_tick = True
+push_client.subscribe_tick(['AAPL'])
+# 回调: full_tick_changed / Callback: full_tick_changed
+```
+
+### K线推送 / K-line Push
+
+```python
+# 订阅分钟K线 / Subscribe minute K-lines
+push_client.subscribe_kline(['AAPL'])
+push_client.unsubscribe_kline(['AAPL'])
+```
+
+### 交易相关 / Trading Events
+
+```python
+# 订单变动 / Order changes (连接后自动推送 / auto-pushed after connect)
+push_client.subscribe_order()
+push_client.unsubscribe_order()
+
+# 持仓变动 / Position changes
+push_client.subscribe_position()
+push_client.unsubscribe_position()
+
+# 资产变动 / Asset changes
+push_client.subscribe_asset()
+push_client.unsubscribe_asset()
+
+# 成交推送 / Transaction changes
+push_client.subscribe_transaction()
+push_client.unsubscribe_transaction()
+```
+
+### 热门排行 / Hot Trading Rank
+
+```python
+from tigeropen.common.consts import StockRankingIndicator, OptionRankingIndicator
+
+# 股票热门排行(需传 market 和可选 indicators) / Stock hot ranking (requires market, optional indicators)
+push_client.subscribe_stock_top('US', indicators=[StockRankingIndicator.Amount, StockRankingIndicator.ChangeRate])
+push_client.unsubscribe_stock_top('US')
+
+# 期权热门排行 / Option hot ranking
+push_client.subscribe_option_top('US', indicators=[OptionRankingIndicator.Volume])
+push_client.unsubscribe_option_top('US')
+```
+
+> `StockRankingIndicator`: ChangeRate, ChangeRate5Min, TurnoverRate, Amount, Volume, Amplitude
+> `OptionRankingIndicator`: BigOrder, Volume, Amount, OpenInt
+
+### 全市场订阅 / Market-wide Subscription
+
+```python
+# 订阅整个市场行情 / Subscribe entire market
+push_client.subscribe_market('US')
+push_client.unsubscribe_market('US')
+```
+
+### 查询已订阅 / Query Subscriptions
+
+```python
+subscribed = push_client.query_subscribed_quote()
+print(f"已订阅: {subscribed}")
+```
+
+---
+
+## 断开连接 / Disconnect
+
+```python
+push_client.disconnect()
+```
+
+---
+
+## 完整示例 / Complete Example
+
+```python
+import time
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.push.push_client import PushClient
+
+config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+protocol, host, port = config.socket_host_port
+push_client = PushClient(host, port, use_ssl=(protocol == 'ssl'), use_protobuf=True, client_config=config)
+
+def on_quote(frame):
+    print(f"{frame.symbol}: {frame.latest_price} ({frame.latest_change_percent}%)")
+
+def on_quote_bbo(frame):
+    print(f"{frame.symbol}: bid={frame.bid_price}, ask={frame.ask_price}")
+
+def on_order(frame):
+    print(f"Order {frame.id}: {frame.status}, filled={frame.filled_quantity}")
+
+def on_position(frame):
+    print(f"{frame.symbol}: qty={frame.quantity}, pnl={frame.unrealized_pnl}")
+
+def on_asset(frame):
+    print(f"Net: {frame.net_liquidation}, Available: {frame.available_funds}")
+
+def on_connected():
+    print("Connected! Subscribing...")
+    push_client.subscribe_quote(['AAPL', 'TSLA', '00700'])
+    push_client.subscribe_order()
+    push_client.subscribe_position()
+    push_client.subscribe_asset()
+
+def on_disconnected():
+    print("Disconnected, will auto-reconnect...")
+
+push_client.quote_changed = on_quote
+push_client.quote_bbo_changed = on_quote_bbo
+push_client.order_changed = on_order
+push_client.position_changed = on_position
+push_client.asset_changed = on_asset
+push_client.connect_callback = on_connected
+push_client.disconnect_callback = on_disconnected
+
+push_client.connect(config.tiger_id, config.private_key)
+
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    push_client.disconnect()
+    print("Disconnected")
+```
+
+---
+
+## 带自动重连的断线处理 / Reconnection with Resubscription
+
+```python
+def on_disconnected():
+    """断线回调，PushClient 会自动重连，重连后需要重新订阅"""
+    print("Disconnected, auto-reconnecting...")
+
+def on_connected():
+    """重连成功后重新订阅"""
+    print("Reconnected, resubscribing...")
+    push_client.subscribe_quote(['AAPL', 'TSLA'])
+    push_client.subscribe_order()
+
+push_client.connect_callback = on_connected
+push_client.disconnect_callback = on_disconnected
+```
+
+---
+
+## STOMP 协议(备选) / STOMP Protocol (Alternative)
+
+```python
+from tigeropen.push.push_client import PushClient
+
+protocol, host, port = client_config.socket_host_port
+stomp_client = PushClient(host, port, use_ssl=(protocol == 'ssl'), use_protobuf=False)
+# 使用方式与 Protobuf PushClient 类似 / Usage similar to Protobuf PushClient
+```
+
+---
+
+## 订阅限制 / Subscription Limits
+
+订阅数量取决于行情权限等级(基于资产/交易量)：
+Subscription limits depend on permission tier (based on assets/volume):
+
+| 等级 Tier | 标准订阅 Standard | 深度订阅 Depth |
+|----------|------------------|---------------|
+| 基础 Base | 20 | 10 |
+| 高级 Advanced ($50K+) | 100 | 50 |
+| 顶级 Top ($1M+) | 2000 | 500 |
+
+---
+
+## 所有回调属性一览 / All Callback Properties
+
+| 回调 Callback | 说明 Description |
+|--------------|-----------------|
+| `quote_changed` | 行情变动(价格/成交量等) Quote changes |
+| `quote_bbo_changed` | 买一卖一盘口变动 Best bid/offer changes |
+| `quote_depth_changed` | 深度盘口变动 Depth quote changes |
+| `tick_changed` | 逐笔成交 Trade ticks |
+| `full_tick_changed` | 完整逐笔(含历史，需 `use_full_tick=True`) Full ticks |
+| `kline_changed` | K线推送 K-line changes |
+| `cc_changed` | 数字货币行情 Crypto quote changes |
+| `cc_bbo_changed` | 数字货币盘口 Crypto BBO changes |
+| `stock_top_changed` | 股票热门排行 Stock top ranking |
+| `option_top_changed` | 期权热门排行 Option top ranking |
+| `order_changed` | 订单变动 Order changes |
+| `position_changed` | 持仓变动 Position changes |
+| `asset_changed` | 资产变动 Asset changes |
+| `transaction_changed` | 成交推送 Transaction changes |
+| `connect_callback` | 连接成功 Connected |
+| `disconnect_callback` | 断开连接 Disconnected |
+| `error_callback` | 错误 Error |
+| `kickout_callback` | 被踢出 Kicked out |
+| `subscribe_callback` | 订阅结果 Subscribe result |
+| `unsubscribe_callback` | 退订结果 Unsubscribe result |
+| `heartbeat_callback` | 心跳 Heartbeat |
+
+---
+
+## 注意事项 / Notes
+
+- 推荐 Protobuf 协议(默认)，性能优于 STOMP / Protobuf (default) recommended over STOMP
+- PushClient 有自动重连机制 / Auto-reconnects after disconnection
+- 同一 tiger_id 只能有一个推送连接 / Only one push connection per tiger_id
+- 新连接会踢掉旧连接(触发 kickout_callback) / New connection kicks old one
+- 订单/持仓/资产变动连接后自动推送 / Trade events auto-pushed after connect
+- 行情推送需对应行情权限 / Quote push requires corresponding permissions
+- 深度推送需 L2 权限 / Depth push requires L2 permission
+- 断线重连后需重新订阅 / Resubscribe after reconnection
+- `use_full_tick = True` 需在连接前设置，且 PushClient 需传入 `client_config` / Set before connect, requires `client_config`
+- `subscribe_option` 使用空格分隔格式，`subscribe_quote` 使用 OCC 格式 / Different symbol formats for option subscription
+- `subscribe_stock_top`/`subscribe_option_top` 需传入 `market` 参数 / Requires `market` parameter

--- a/.agents/skills/tigeropen/references/quickstart.md
+++ b/.agents/skills/tigeropen/references/quickstart.md
@@ -1,0 +1,489 @@
+
+# Tiger Open API Python SDK
+
+> 中文 | English — 本技能双语编写，代码示例通用。This skill is bilingual with shared code examples.
+
+## 概述 / Overview
+
+老虎量化开放平台 Python SDK (tigeropen) 为个人和机构用户提供交易与行情 API，支持美股、港股、A股、新加坡、澳洲市场的股票、期权、期货等品种。
+The Tiger Open Platform Python SDK (tigeropen) provides trading and market data APIs for stocks, options, futures across US, HK, China A-shares, Singapore, and Australia markets.
+
+- 官方文档 / Docs: https://docs.itigerup.com/docs/prepare
+- GitHub: https://github.com/tigerfintech/openapi-python-sdk
+- SDK Version: 3.5.6 | Python: 3.8 - 3.14
+
+### 支持的市场和品种 / Supported Markets
+
+| 市场 Market | 股票/ETF | 期权 Options | 期货 Futures | 窝轮/牛熊证 Warrants/CBBC |
+|-------------|---------|-------------|-------------|--------------------------|
+| 美国 US     | ✅      | ✅          | ✅          | -                        |
+| 香港 HK     | ✅      | ✅          | ✅          | ✅                       |
+| 新加坡 SG   | ✅      | -           | ✅          | -                        |
+| 澳洲 AU    | ✅      | -           | -           | -                        |
+| A股 CN      | ✅      | -           | -           | -                        |
+
+### 支持的订单类型 / Supported Order Types
+
+市价单 MKT, 限价单 LMT, 止损单 STP, 止损限价单 STP_LMT, 跟踪止损单 TRAIL, 附加订单(止盈止损), 算法单 TWAP/VWAP
+
+## 安装 / Installation
+
+```bash
+pip install tigeropen
+
+# 升级 / Upgrade
+pip install tigeropen --upgrade
+
+# 或使用 conda / Or use conda
+conda install tigeropen
+
+# 验证 / Verify
+python -c "import tigeropen; print(tigeropen.__VERSION__)"
+```
+
+## 前置条件 / Prerequisites
+
+1. 开通老虎证券账户并入金 / Open a Tiger Brokers account and fund it
+2. 个人用户访问 https://developer.itigerup.com/profile 激活 API 权限 / Individual users activate API permissions
+   机构用户访问机构账户中心 / Institutional users visit institutional account center
+3. 获取 `tiger_id`、RSA 私钥(PKCS#1格式)和资金账号 / Obtain `tiger_id`, RSA private key (PKCS#1 format), and account
+4. 导出配置文件 `tiger_openapi_config.properties` / Export config file
+
+> 私钥不会保存在服务端，刷新页面后消失，请务必保存。Private key is not stored on server; save it before refreshing the page.
+> Java 使用 PKCS#8 格式，Python 使用 PKCS#1 格式。Java uses PKCS#8, Python uses PKCS#1.
+
+## 账户类型 / Account Types
+
+| 类型 Type | 说明 Description | 推荐 |
+|-----------|-----------------|------|
+| 综合账户 Comprehensive (Live) | 支持所有市场、保证金交易、全品种。**推荐** | ✅ |
+| 环球账户 Global (Live) | 环球账户类型，不支持窝轮/牛熊证 | - |
+| 模拟账户 Paper | 测试用，支持美股/港股/A股/期权，无需真实资金 | 测试推荐 |
+
+## 配置 / Configuration
+
+### 方式一：配置文件(推荐) / Config File (Recommended)
+
+从开发者网站导出配置文件 `tiger_openapi_config.properties`，放入合适的系统路径(请不要修改文件名)。
+Export config file from developer website and place it in a suitable path.
+
+配置文件格式 / Config file format:
+
+```properties
+tiger_id=YOUR_TIGER_ID
+account=12345678
+license=TBHK
+private_key_pk1=MIICXgIBAAKBgQC.....your_pkcs1_private_key
+private_key_pk8=MIICeAIBADANBgk.....your_pkcs8_private_key
+env=PROD
+# 机构用户需额外配置 / Institutional users also need:
+# secret_key=your_secret_key
+```
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+
+# 指定配置文件所在目录 / Specify directory containing config file
+client_config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+# 也可将配置文件放入程序当前目录，SDK 默认取当前路径
+# Or place config file in current directory; SDK defaults to current path
+```
+
+> 港股牌照(TBHK)还需将 `tiger_openapi_token.properties` 放入同一目录。
+> HK license (TBHK) also requires `tiger_openapi_token.properties` in the same directory.
+
+### 方式二：环境变量 / Environment Variables
+
+```bash
+export TIGEROPEN_TIGER_ID="your_tiger_id"
+export TIGEROPEN_PRIVATE_KEY="your_private_key_content"  # 私钥内容或私钥文件路径 / Key content or file path
+export TIGEROPEN_ACCOUNT="your_account"
+# 可选 / Optional:
+# export TIGEROPEN_PROPS_PATH="/path/to/config/"  # 配置文件目录 / Config file directory
+# export TIGEROPEN_LICENSE="TBSG"
+# export TIGEROPEN_SECRET_KEY="your_secret_key"  # 机构用户 / Institutional users
+# export TIGEROPEN_TOKEN="your_2fa_token"  # TBHK 牌照 / TBHK license
+```
+
+```python
+client_config = TigerOpenClientConfig()  # 自动读取环境变量 / Auto-reads env vars
+```
+
+### 方式三：代码赋值 / Code Assignment
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.common.util.signature_utils import read_private_key
+
+client_config = TigerOpenClientConfig()
+client_config.tiger_id = 'your_tiger_id'
+client_config.private_key = read_private_key('/path/to/private_key.pem')  # 读取 PKCS#1 格式 PEM 文件
+# 私钥也可直接填字符串内容 / Or set private key content directly:
+# client_config.private_key = 'MIICWwIBAAKBgQCSW+.....私钥内容'
+client_config.account = 'your_account'
+client_config.license = 'TBSG'  # 牌照信息 / License info
+client_config.language = Language.zh_CN  # 可选，默认英语 / Optional, defaults to English
+# client_config.timezone = 'US/Eastern'  # 可选时区 / Optional timezone
+```
+
+> 优先级 Priority: 代码参数 code > 环境变量 env > 配置文件 config > 默认值 defaults
+
+### 机构用户 / Institutional Users
+
+```python
+client_config.secret_key = 'your_secret_key'  # 在机构中心获取 / Obtain from institutional center
+# 香港机构(TBHK牌照)需额外设置 token / HK institutional (TBHK license) needs token:
+# client_config.token = 'your_2fa_token'
+# token 有效期30天，可配置自动刷新 / Token valid for 30 days, can auto-refresh:
+# client_config.token_refresh_duration = 24 * 60 * 60  # 单位秒 / seconds
+```
+
+## 创建客户端 / Create Clients
+
+```python
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.trade.trade_client import TradeClient
+
+# 行情客户端 / Quote client (建议模块级创建一次并复用 / create once and reuse)
+quote_client = QuoteClient(client_config=client_config)
+# is_grab_permission 默认 True，自动抢占行情权限
+# 多设备同账号时仅最后抢占的设备收到行情
+
+# 交易客户端 / Trade client
+trade_client = TradeClient(client_config=client_config)
+```
+
+## 模拟交易 / Paper Trading
+
+```python
+client_config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+client_config.account = 'your_paper_account'  # 17位数字模拟账号 / 17-digit paper account
+# 模拟账户支持美股/港股/A股/期权
+```
+
+> `sandbox_debug` 参数已废弃，请勿使用。SDK 通过账号自动识别模拟账户。
+> `sandbox_debug` is deprecated. SDK auto-detects paper accounts by account number.
+
+## 完整入门示例 / Complete Quickstart
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.common.consts import Market, BarPeriod
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.trade.trade_client import TradeClient
+
+# 1. 加载配置(推荐使用配置文件) / Load config (config file recommended)
+client_config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+
+# 或代码赋值 / Or code assignment:
+# from tigeropen.common.util.signature_utils import read_private_key
+# client_config = TigerOpenClientConfig()
+# client_config.tiger_id = 'your_tiger_id'
+# client_config.private_key = read_private_key('/path/to/private_key.pem')
+# client_config.account = 'your_account'
+
+# 2. 创建客户端 / Create clients
+quote_client = QuoteClient(client_config=client_config)
+trade_client = TradeClient(client_config=client_config)
+
+# 3. 查看市场状态 / Check market status
+status = quote_client.get_market_status(Market.US)
+for s in status:
+    print(f"Market: {s.market}, Status: {s.trading_status}, Open: {s.open_time}")
+
+# 4. 获取实时行情 / Get real-time quotes
+briefs = quote_client.get_stock_briefs(['AAPL', 'TSLA'])
+# get_stock_briefs returns a pandas DataFrame
+for _, b in briefs.iterrows():
+    print(f"{b['symbol']}: price={b['latest_price']}, change={b['change_percentage']}%")
+
+# 5. 获取K线 / Get K-line data
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, limit=30)
+print(bars.tail())
+
+# 6. 查看账户 / Check account
+assets = trade_client.get_prime_assets(base_currency='USD')
+# Access via segments dict: 'S' = 综合(Standard), 'G' = 环球(Global)
+segment = assets.segments.get('S') or assets.segments.get('G')
+if segment:
+    print(f"Net Liquidation: {segment.net_liquidation}, Available: {segment.cash_available_for_trade}")
+
+# 7. 查看持仓 / Check positions
+positions = trade_client.get_positions()
+for p in positions:
+    print(f"{p.contract.symbol}: qty={p.quantity}, pnl={p.unrealized_pnl}")
+```
+
+## 核心模块 / Core Modules
+
+| 模块 Module | 用途 Purpose | 导入路径 Import |
+|-------------|-------------|----------------|
+| `TigerOpenClientConfig` | 配置管理 / Config | `tigeropen.tiger_open_config` |
+| `QuoteClient` | 行情数据 / Market data | `tigeropen.quote.quote_client` |
+| `TradeClient` | 交易操作 / Trading | `tigeropen.trade.trade_client` |
+| `PushClient` | 实时推送 / Real-time push | `tigeropen.push.push_client` |
+
+## 枚举参考 / Enum Reference
+
+```python
+from tigeropen.common.consts import (
+    Market,        # ALL, US, HK, CN, SG, AU
+    SecurityType,  # STK, OPT, FUT, WAR, IOPT, CASH, FUND, MLEG, CC
+    Currency,      # USD, HKD, CNH, SGD, AUD
+    Language,      # zh_CN, zh_TW, en_US
+    OrderType,     # MKT, LMT, STP, STP_LMT, TRAIL, TWAP, VWAP
+    OrderStatus,   # Initial, PendingSubmit, Submitted, PartiallyFilled, Filled, Cancelled, Inactive, PendingCancel
+    BarPeriod,     # DAY, WEEK, MONTH, YEAR, ONE_MINUTE, THREE_MINUTES, FIVE_MINUTES, TEN_MINUTES,
+                   # FIFTEEN_MINUTES, HALF_HOUR, FORTY_FIVE_MINUTES, ONE_HOUR, TWO_HOURS, THREE_HOURS, FOUR_HOURS, SIX_HOURS
+    QuoteRight,    # BR(前复权/forward), NR(不复权/none)
+    TradingSession,  # PreMarket, Regular, AfterHours
+    TimeInForce,   # DAY, GTC, GTD
+)
+```
+
+### SecurityType 证券类型
+
+| 值 Value | 说明 Description |
+|----------|-----------------|
+| `STK` | 股票/ETF Stock |
+| `OPT` | 期权 Option |
+| `FUT` | 期货 Future |
+| `WAR` | 窝轮 Warrant |
+| `IOPT` | 牛熊证 CBBC/Inline Warrant |
+| `FUND` | 基金 Fund |
+| `CASH` | 外汇 Forex |
+| `CC` | 数字货币 Cryptocurrency |
+| `MLEG` | 组合 Multi-leg Combo |
+
+### OrderStatus 订单状态
+
+| 状态 Status | 说明 Description |
+|------------|-----------------|
+| `Initial` | 初始化 / Created |
+| `PendingSubmit` | 待提交 / Pending submit |
+| `Submitted` | 已提交 / Submitted, awaiting fill |
+| `PartiallyFilled` | 部分成交 / Partially filled |
+| `Filled` | 全部成交 / Fully filled |
+| `Cancelled` | 已取消 / Cancelled |
+| `Inactive` | 已失效 / Rejected by system |
+| `PendingCancel` | 待取消 / Pending cancel |
+
+### BarPeriod K线周期
+
+`day`, `week`, `month`, `year`, `1min`, `3min`, `5min`, `10min`, `15min`, `30min`, `45min`, `60min`, `2hour`, `3hour`, `4hour`, `6hour`
+
+### Market Scanner 相关枚举
+
+```python
+from tigeropen.common.consts import (
+    StockField,       # stockField: Change, ChangeRate, LatestPrice, Volume, Amount, TurnoverRate, FloatShare, FloatMarketValue...
+    AccumulateField,  # accumulateField: ChangeRate, Amount, Volume
+    FinancialField,   # financialField: TotalRevenue, NetIncome, EpsDiluted, ROE, PE_TTM, PB...
+    MultiTagField,    # multiTagField: HasOption, IsETF, IndustryCode, ExchangeCode
+    SortDirection,    # ASC, DESC
+)
+```
+
+## 核心对象参考 / Key Object Reference
+
+### PortfolioAccount 资产对象 (get_prime_assets)
+
+`get_prime_assets()` 返回 `PortfolioAccount` 对象，资产数据在 `segments` 字典中：
+
+```python
+assets = trade_client.get_prime_assets(base_currency='USD')
+# segments 键: 'S' = 综合账户(Standard), 'G' = 环球账户(Global)
+segment = assets.segments.get('S') or assets.segments.get('G')
+print(f"Net: {segment.net_liquidation}, Cash: {segment.cash_balance}")
+```
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `segments` | 账户分组字典 `{'S': ..., 'G': ...}` |
+| `segment.net_liquidation` | 总资产/净清算值 Net liquidation value |
+| `segment.cash_balance` | 现金 Cash balance |
+| `segment.cash_available_for_trade` | 可用资金 Available funds for trading |
+| `segment.buying_power` | 购买力 Buying power |
+| `segment.gross_position_value` | 总持仓价值 Gross position value |
+| `segment.unrealized_pl` | 未实现盈亏 Unrealized P&L |
+| `segment.realized_pl` | 已实现盈亏 Realized P&L |
+| `segment.init_margin` | 初始保证金 Initial margin |
+| `segment.maintain_margin` | 维持保证金 Maintenance margin |
+| `segment.currency_assets` | 多币种资产明细 dict {currency: CurrencyAsset} |
+
+### Position 持仓对象
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `contract` | 合约对象 Contract object |
+| `qty` / `quantity` | 持仓数量 Position quantity |
+| `average_cost` | 持仓均价 Average cost |
+| `market_price` | 市场价 Market price |
+| `market_value` | 市值 Market value |
+| `unrealized_pnl` | 未实现盈亏 Unrealized P&L |
+| `realized_pnl` | 已实现盈亏 Realized P&L |
+| `salable_qty` | 可卖数量 Salable quantity |
+
+### Order 订单对象
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `id` | 全局订单ID Global order ID |
+| `order_id` | 用户订单ID User order ID |
+| `symbol` | 标的代码 Symbol |
+| `action` | BUY/SELL |
+| `order_type` | 订单类型 Order type |
+| `status` | 订单状态 Order status |
+| `quantity` | 下单数量 Order quantity |
+| `filled_quantity` | 成交数量 Filled quantity |
+| `limit_price` | 限价 Limit price |
+| `aux_price` | 触发价/回撤价 Aux price |
+| `avg_fill_price` | 均价 Average fill price |
+| `trade_time` | 交易时间 Trade time |
+| `time_in_force` | 有效期 Time in force |
+| `outside_rth` | 是否盘前盘后 Outside RTH |
+| `order_legs` | 附加订单 Attached orders |
+
+### Contract 合约对象
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `symbol` | 代码 Symbol |
+| `sec_type` | 证券类型 Security type |
+| `currency` | 货币 Currency |
+| `exchange` | 交易所 Exchange |
+| `name` | 名称 Name |
+| `expiry` | 到期日(期权/期货) Expiry |
+| `strike` | 行权价(期权) Strike |
+| `put_call` | 看涨/看跌(期权) Put/Call |
+| `multiplier` | 乘数 Multiplier |
+| `lot_size` | 每手股数 Lot size |
+| `shortable` | 可否卖空 Shortable |
+| `shortable_count` | 可卖空数量 Shortable count |
+| `min_tick` | 最小价格变动 Min tick size |
+
+## 行情权限与限制 / Quote Permissions & Limits
+
+### 权限类型 / Permission Types
+
+- 美股L1 `usQuoteBasic` (Nasdaq Basic), 美股L2 `usStockQuoteLv2Totalview` (40档深度)
+- 港股BMP (手动刷新), 港股L2 `hkStockQuoteLv2` (10档深度, 自动推送)
+- 美期权 `usOptionQuote`, 港期权L2 (随港期货L2)
+- 期货L2: CBOE, HKFE, SGX, OSE
+
+### 配额限制 / Quota Limits (取决于资产/交易量等级)
+
+| 等级 | 历史行情(股票/期货/期权) | 订阅(标准/深度) |
+|------|------------------------|----------------|
+| 基础 | 20/10/10 次 | 20/10 个 |
+| 高级($50K+) | 100/50/100 | 100/50 |
+| 顶级($1M+) | 2000/200/2000 | 2000/500 |
+
+> 行情权限需单独购买，API 与 App 独立。详见 https://docs.itigerup.com/docs/permission
+
+## 请求频率限制 / Rate Limits
+
+60秒滚动窗口 / 60-second rolling window:
+
+| 限制 Limit | 接口 APIs |
+|-----------|----------|
+| 120/min (高频) | 下单/撤单/改单/查询订单, 实时行情, 分时, 逐笔, 期权行情, 期货行情 |
+| 60/min (中频) | 期权链, 深度行情, 合约, K线, 资产, 持仓, 成交 |
+| 10/min (低频) | 行情权限, 市场状态, 代码列表, 股票详情, 期货交易所 |
+
+> 超频返回 code=4/5。持续超频可能导致账户限制。Rate limit exceeded returns code=4/5.
+
+## 错误代码 / Error Codes
+
+| 代码 Code | 说明 Description |
+|-----------|-----------------|
+| 0 | 成功 Success |
+| 1 | 服务器错误 Server error |
+| 2 | 网络超时 Network timeout |
+| 4 | 访问拒绝 Access forbidden (IP白名单/签名失败/订阅超限) |
+| 5 | 频率限制 Rate limit (HTTP 429) |
+| 1000 | 通用参数错误 Common param error |
+| 1010 | 业务参数错误 Business param error |
+| 1100 | 全球账户交易错误 Global account trade error |
+| 1200 | 综合账户交易错误 Comprehensive account trade error |
+| 1300 | 模拟账户交易错误 Paper account trade error |
+| 2100-2300 | 行情数据错误 Market data error |
+| 4000 | 权限不足 Permission denied |
+| 4001 | 被新连接踢出 Kicked out by new connection |
+
+### 频率限制恢复 / Rate Limit Recovery
+
+```python
+import time
+
+def safe_api_call(func, *args, max_retries=3, **kwargs):
+    for attempt in range(max_retries):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            if 'rate limit' in str(e).lower() or '429' in str(e):
+                wait = 2 ** attempt
+                time.sleep(wait)
+            else:
+                raise
+    raise Exception("Max retries exceeded")
+```
+
+## 常见问题 / FAQ
+
+### 私钥格式 / Private Key Format
+
+Python SDK **同时支持 PKCS#1 和 PKCS#8** 格式（DER base64 裸字符串，无 PEM 头尾行）。
+配置文件字段优先级：`private_key_pk1` 先读，若空则读 `private_key_pk8`。
+
+```properties
+# 任选其一即可 / Either format works:
+private_key_pk1=MIICXQIBAAKBgQD...    # PKCS#1 DER base64
+private_key_pk8=MIICdwIBADANBgk...    # PKCS#8 DER base64
+```
+
+如需转换 PEM → DER base64：
+
+```bash
+# PKCS#1 PEM → DER base64
+openssl rsa -in pk1.pem -outform DER | base64 | tr -d '\n'
+
+# PKCS#8 PEM → DER base64
+openssl pkcs8 -topk8 -inform PEM -outform DER -nocrypt -in pk1.pem | base64 | tr -d '\n'
+```
+
+### SSL/证书问题 / SSL Issues
+
+```python
+# macOS 运行 / Run on macOS:
+# /Applications/Python\ 3.x/Install\ Certificates.command
+
+# 或设置环境变量 / Or set env:
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context  # 仅调试 / debug only
+```
+
+### 推送连接问题 / Push Connection Issues
+
+- 同一 tiger_id 只能有一个推送连接，新连接会踢掉旧连接
+- Only one push connection per tiger_id; new connection kicks the old one
+- 断线后 PushClient 自动重连 / Auto-reconnects after disconnection
+
+### Windows 编码问题 / Windows Encoding
+
+```python
+# Windows 终端中文乱码
+import sys, io
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+```
+
+## 注意事项 / Notes
+
+- 认证使用 RSA 签名，Python SDK 支持 PKCS#1 和 PKCS#8 两种格式（DER base64）/ Authentication uses RSA signatures, Python SDK supports both PKCS#1 and PKCS#8 DER base64
+- 私钥可通过 `read_private_key('path/to/pem')` 读取文件，或直接赋值字符串内容 / Private key via `read_private_key()` or direct string
+- `QuoteClient` 应创建一次并复用 / Create once and reuse
+- 行情权限需单独购买，API 与 App 独立 / Quote permissions require separate purchase
+- 交易佣金与 App 一致，无额外 API 费用 / Trading fees same as app
+- `sandbox_debug` 参数已废弃，请勿使用 / `sandbox_debug` is deprecated, do not use
+- 官方文档 / Official docs: https://docs.itigerup.com/docs/prepare
+- 官方支持群 / Support: https://t.me/TigerBrokersAPISupport

--- a/.agents/skills/tigeropen/references/quote.md
+++ b/.agents/skills/tigeropen/references/quote.md
@@ -1,0 +1,883 @@
+
+# Tiger Open API 行情数据 / Market Data
+
+> 中文 | English — 双语技能，代码示例通用。Bilingual skill with shared code examples.
+> 官方文档 Docs: https://docs.itigerup.com/docs/quote-stock
+
+## 初始化 / Initialize
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.quote.quote_client import QuoteClient
+
+client_config = TigerOpenClientConfig(props_path='/path/to/your/tiger_openapi_config.properties')
+quote_client = QuoteClient(client_config=client_config)
+# is_grab_permission 默认 True，自动抢占行情权限 / auto-grabs quote permissions
+# 多设备同账号仅最后抢占的设备收到行情 / last device to grab gets data
+```
+
+> 建议模块级创建一次并复用。Create QuoteClient once and reuse.
+
+---
+
+## 市场状态 / Market Status
+
+```python
+from tigeropen.common.consts import Market
+
+status = quote_client.get_market_status(Market.US)  # US, HK, CN, ALL
+for s in status:
+    print(f"{s.market}: status={s.trading_status}, open={s.open_time}")
+# MarketStatus 属性: market, trading_status, status, open_time
+# trading_status: NOT_YET_OPEN, PRE_HOUR_TRADING, TRADING, MIDDLE_CLOSE, POST_HOUR_TRADING, CLOSING, EARLY_CLOSING
+```
+
+```bash
+# CLI
+tigeropen quote market-status          # 所有市场 / All markets
+tigeropen quote market-status --market US
+tigeropen quote market-status --market HK
+```
+
+## 交易日历 / Trading Calendar
+
+```python
+cal = quote_client.get_trading_calendar(market=Market.US, begin_date='2025-01-01', end_date='2025-12-31')
+# 返回 list[dict] / Returns list of dicts
+# 每项: {'date': '2025-01-02', 'type': 'TRADING'}
+# type: TRADING(交易日) / NON_TRADING(非交易日)
+```
+
+---
+
+## 股票代码与信息 / Stock Symbols & Info
+
+```python
+# 获取所有代码 / Get all symbols
+symbols = quote_client.get_symbols(market=Market.US)  # 返回 symbol 列表
+
+# 获取代码和名称 / Get symbols with names
+names = quote_client.get_symbol_names(market=Market.HK, lang=Language.zh_CN)
+# 返回 DataFrame: symbol, name
+
+# 股票详情 / Stock details
+details = quote_client.get_stock_details(symbols=['AAPL'])
+# 属性: symbol, market, exchange, sec_type, listing_date, float_shares, eps, adr_rate, etf
+```
+
+## 股票基本面 / Stock Fundamentals
+
+```python
+# 基本面指标 / Fundamental indicators
+fundamentals = quote_client.get_stock_fundamental(symbols=['AAPL', 'TSLA'], market='US')
+# 返回 pandas.DataFrame
+```
+
+**get_stock_fundamental 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `symbol` | 股票代码 |
+| `roe` | 净资产收益率 Return on equity |
+| `roa` | 资产收益率 Return on assets |
+| `pb_rate` | 市净率 P/B ratio |
+| `ps_rate` | 市销率 P/S ratio |
+| `divide_rate` | 股息率 Dividend yield |
+| `week52_high` | 52周最高价 52-week high |
+| `week52_low` | 52周最低价 52-week low |
+| `ttm_eps` | TTM每股收益 TTM earnings per share |
+| `lyr_eps` | 上年每股收益 Last year EPS |
+| `volume_ratio` | 量比 Volume ratio |
+| `turnover_rate` | 换手率 Turnover rate |
+| `ttm_pe_rate` | TTM市盈率 TTM P/E ratio |
+| `lyr_pe_rate` | 上年市盈率 Last year P/E ratio |
+| `market_cap` | 总市值 Market capitalization |
+| `float_market_cap` | 流通市值 Float market cap |
+
+> ⚠️ 注意：字段名与 `get_financial_daily` 不同。`get_stock_fundamental` 用 `ttm_pe_rate`，而 `get_financial_daily` 用 `pe_ttm`。
+
+---
+
+## 实时行情 / Real-time Quotes
+
+### 股票 / Stocks
+
+```python
+briefs = quote_client.get_stock_briefs(['AAPL', 'TSLA', '00700'])
+# 返回 pandas.DataFrame / Returns pandas.DataFrame
+for _, row in briefs.iterrows():
+    print(f"{row['symbol']}: price={row['latest_price']}, volume={row['volume']}, "
+          f"open={row['open']}, high={row['high']}, low={row['low']}, pre_close={row['pre_close']}")
+
+# 含盘前盘后 / Include pre/after-hours
+briefs = quote_client.get_stock_briefs(['AAPL'], include_hour_trading=True)
+
+# 延迟行情(无权限时) / Delayed quotes (when no permission)
+delayed = quote_client.get_stock_delay_briefs(symbols=['AAPL'])
+```
+
+**get_stock_briefs 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `symbol` | 股票代码 |
+| `open` | 开盘价 Opening price |
+| `high` | 最高价 Highest price |
+| `low` | 最低价 Lowest price |
+| `close` | 收盘价 Closing price |
+| `pre_close` | 前收价 Previous close |
+| `adj_pre_close` | 复权过的前收价 Adjusted previous close |
+| `latest_price` | 最新价 Latest price |
+| `latest_time` | 最新成交时间（毫秒时间戳） Latest trade time (ms) |
+| `volume` | 成交量 Volume |
+| `ask_price` | 卖一价 Ask price |
+| `ask_size` | 卖一量 Ask size |
+| `bid_price` | 买一价 Bid price |
+| `bid_size` | 买一量 Bid size |
+| `status` | 交易状态: `NORMAL`(正常) / `HALTED`(停牌) / `DELIST`(退市) / `NEW`(新股) / `ALTER`(变更) / `UNKNOWN` |
+| `hour_trading_tag` | 盘前盘后标记（`Pre-Mkt`/`Post-Mkt`） |
+| `hour_trading_latest_price` | 盘前盘后最新价 |
+| `hour_trading_pre_close` | 盘前盘后前收价 |
+| `hour_trading_latest_time` | 盘前盘后最新成交时间 |
+| `hour_trading_volume` | 盘前盘后成交量 |
+| `hour_trading_timestamp` | 盘前盘后时间戳（毫秒） |
+
+> 盘前盘后字段仅在 `include_hour_trading=True` 时有数据。
+```
+
+```bash
+# CLI (需要行情权限 / requires quote permission)
+tigeropen quote briefs AAPL TSLA
+tigeropen quote briefs AAPL --hour-trading   # 含盘前盘后 / include pre/after-hours
+```
+
+### 夜盘行情 / Overnight Quotes
+
+```python
+overnight = quote_client.get_quote_overnight(symbols=['AAPL', 'TSLA'])
+# 返回夜盘交易时段行情 / Returns overnight trading session quotes
+```
+
+### 交易元数据 / Trading Metadata
+
+```python
+metas = quote_client.get_trade_metas(symbols=['AAPL', '00700'])
+# 属性: symbol, market, sec_type, lot_size(每手股数), min_tick(最小价格变动), spread_scale
+```
+
+---
+
+## K线数据 / K-line (Candlestick) Data
+
+```python
+from tigeropen.common.consts import BarPeriod, QuoteRight, TradingSession
+
+# 日K / Daily (返回 DataFrame: symbol, time, open, high, low, close, volume, amount)
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, limit=60)
+
+# 分钟K / Minute
+bars_5m = quote_client.get_bars(['AAPL'], period=BarPeriod.FIVE_MINUTES, limit=100)
+
+# 时间范围 / Time range
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY,
+                              begin_time='2025-01-01', end_time='2025-06-30')
+
+# 复权 / Adjustment: BR(前复权/forward, default), NR(不复权/none)
+bars_nr = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, right=QuoteRight.NR)
+
+# 多股票 / Multiple symbols
+bars = quote_client.get_bars(['AAPL', 'TSLA', 'GOOG'], period=BarPeriod.DAY, limit=30)
+
+# 指定日期的分钟K线 / Minute K-lines for specific date
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.ONE_MINUTE, date='20250618')
+
+# 指定交易时段 / Specific trading session (夜盘 overnight)
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY,
+                              trade_session=TradingSession.OverNight)
+
+# 含基本面数据(PE/换手率) / With fundamental data (PE/turnover)
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, with_fundamental=True)
+
+# 分页(单个标的，使用 page_token) / Pagination (single symbol, via page_token)
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, limit=100)
+next_token = bars['next_page_token'].iloc[0]
+if next_token:
+    bars_next = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, limit=100, page_token=next_token)
+```
+
+### 分页获取大量K线 / Paginated K-line for Large Datasets
+
+```python
+# 自动分页获取(注意: symbol 为单个字符串) / Auto-paginated fetch (note: symbol is a single string)
+bars = quote_client.get_bars_by_page(symbol='AAPL', period=BarPeriod.DAY,
+                                      begin_time='2020-01-01', end_time='2025-01-01',
+                                      total=2000)
+# 也支持 trade_session 和 with_fundamental 参数
+# Also supports trade_session and with_fundamental params
+```
+
+**get_bars 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `symbol` | 股票代码 |
+| `time` | K线时间（毫秒时间戳） Timestamp in milliseconds |
+| `open` | 开盘价 Opening price |
+| `high` | 最高价 Highest price |
+| `low` | 最低价 Lowest price |
+| `close` | 收盘价 Closing price |
+| `volume` | 成交量 Trading volume |
+| `amount` | 成交额 Trading amount |
+| `next_page_token` | 下一页令牌（单标的分页时使用） Next page token (single symbol pagination) |
+
+> `with_fundamental=True` 时额外返回 `pe_ttm`、`turnover_rate` 等字段。
+
+**K线周期 / Bar Periods**: `day/week/month/year/1min/3min/5min/10min/15min/30min/45min/60min/2hour/3hour/4hour/6hour`
+
+```bash
+# CLI
+tigeropen quote bars AAPL                               # 日K，251根
+tigeropen quote bars AAPL --period 5min --limit 100    # 5分钟K线
+tigeropen quote bars AAPL --begin-time 2026-01-01 --end-time 2026-03-31  # 时间范围
+tigeropen quote bars AAPL TSLA                   # 多标的
+```
+
+---
+
+## 深度行情 / Depth Quote (Level 2)
+
+```python
+# 美股深度 / US depth (需要 L2 权限 / requires L2 permission)
+depth = quote_client.get_depth_quote(['AAPL'], market=Market.US)
+# 返回 asks(卖盘) 和 bids(买盘)，每档: price, volume, order_count
+# US: 最多40档 / up to 40 levels
+
+# 港股深度 / HK depth
+depth = quote_client.get_depth_quote(['00700'], market=Market.HK)
+# HK: 最多10档 / up to 10 levels
+```
+
+**get_depth_quote 返回结构 / Return Structure**:
+
+单个标的时返回 dict / Single symbol returns a dict:
+```python
+{
+    'symbol': 'AAPL',
+    'asks': [(ask_price1, ask_volume1, order_count1), (ask_price2, ...)],  # 卖盘，从低到高
+    'bids': [(bid_price1, bid_volume1, order_count1), (bid_price2, ...)],  # 买盘，从高到低
+}
+
+# 访问示例 / Access example:
+asks = depth['asks']  # [(226.50, 300, 2), (226.55, 500, 1), ...]
+bids = depth['bids']  # [(226.45, 400, 3), (226.40, 200, 1), ...]
+for price, volume, order_count in asks[:5]:
+    print(f"Ask: price={price}, vol={volume}, orders={order_count}")
+```
+
+多个标的时返回嵌套 dict / Multiple symbols return nested dict:
+```python
+{
+    'AAPL': {'symbol': 'AAPL', 'asks': [...], 'bids': [...]},
+    'TSLA': {'symbol': 'TSLA', 'asks': [...], 'bids': [...]},
+}
+```
+
+```bash
+# CLI (--market 为必选参数 / --market is required)
+tigeropen quote depth AAPL --market US
+tigeropen quote depth 00700 --market HK
+```
+
+## 逐笔成交 / Trade Ticks
+
+```python
+from tigeropen.common.consts import TradingSession
+
+ticks = quote_client.get_trade_ticks(symbols=['AAPL'], limit=50)
+# 返回 DataFrame: symbol, time, price, volume, direction(+/-), index
+
+# 指定交易时段 / Specific trading session
+ticks = quote_client.get_trade_ticks(symbols=['AAPL'], limit=100,
+                                      trade_session=TradingSession.Regular)
+
+# 分页(使用 begin_index/end_index) / Pagination via begin_index/end_index
+ticks = quote_client.get_trade_ticks(symbols=['AAPL'], begin_index=0, end_index=100)
+```
+
+```bash
+# CLI
+tigeropen quote ticks AAPL
+tigeropen quote ticks AAPL --limit 50
+```
+
+## 分时数据 / Timeline (Intraday)
+
+```python
+# 当日分时 / Today's timeline
+timeline = quote_client.get_timeline(['AAPL'], include_hour_trading=True)
+# 返回 DataFrame: symbol, time, price, avg_price, pre_close, volume, trade_session
+
+# 指定交易时段 / Specific trading session
+timeline = quote_client.get_timeline(['AAPL'], trade_session=TradingSession.OverNight)
+
+# 历史某日分时 / Historical date
+timeline = quote_client.get_timeline_history(['AAPL'], date='2025-06-18')
+# 也支持 trade_session 参数 / Also supports trade_session param
+```
+
+```bash
+# CLI
+tigeropen quote timeline AAPL                     # 今日分时
+tigeropen quote timeline AAPL --date 2026-03-20   # 历史某日
+```
+
+---
+
+## 资金流向 / Capital Flow
+
+```python
+from tigeropen.common.consts import CapitalPeriod
+
+# 资金流向 / Capital flow (使用 CapitalPeriod 枚举)
+flow = quote_client.get_capital_flow(symbol='AAPL', market='US',
+                                      period=CapitalPeriod.DAY,
+                                      begin_time='2025-01-01', end_time='2025-06-30')
+# 返回 DataFrame: time, timestamp, net_inflow, symbol, period
+# CapitalPeriod 可选值: INTRADAY, DAY, WEEK, MONTH, YEAR, QUARTER, HALFAYEAR
+
+# 资金分布 / Capital distribution
+distribution = quote_client.get_capital_distribution(symbol='AAPL', market='US')
+# 属性: net_inflow, super_large_net_inflow, large/middle/small_net_inflow
+```
+
+```bash
+# CLI
+tigeropen quote capital flow AAPL --market US --period day
+tigeropen quote capital distribution AAPL --market US
+```
+
+## 港股经纪商 / HK Broker Data
+
+```python
+# 经纪商席位 / Broker seats (返回 StockBroker 对象)
+broker = quote_client.get_stock_broker('00700', limit=40)
+# broker.bid_broker: 买方经纪商列表(LevelBroker: level, price, broker_count, broker)
+# broker.ask_broker: 卖方经纪商列表
+
+# 经纪商持仓(CCASS) / Broker holdings (CCASS) - 独立方法
+hold = quote_client.get_broker_hold(symbol='00700', limit=40)
+```
+
+## 热门交易排行 / Hot Trading Rank
+
+```python
+rank = quote_client.get_trade_rank(market='US')
+# 返回热门交易标的排行
+```
+
+---
+
+## 基本面数据 / Fundamental Data
+
+### 每日财务指标 / Daily Financial Metrics
+
+```python
+financial = quote_client.get_financial_daily(
+    symbols=['AAPL'],
+    fields=['pe_ttm', 'pb', 'ps_ttm', 'market_value', 'shares_outstanding', 'market_capitalization'],
+    begin_date='2025-01-01', end_date='2025-06-30')
+# 返回 DataFrame: symbol, date, 及所选字段
+# 可选字段: market_value, pe_ttm, pb, ps_ttm, pcf_ttm, market_capitalization,
+#          shares_outstanding, total_share, eps_ttm, dividend_ttm, dividend_rate_ttm
+```
+
+### 财务报告 / Financial Reports
+
+```python
+report = quote_client.get_financial_report(
+    symbols=['AAPL'],
+    fields=['total_revenue', 'net_income', 'eps_diluted', 'gross_profit'],
+    period_type='LTM')  # Annual/Quarterly/LTM/CumulativeQuarterly
+# 可选字段类别:
+# Income: total_revenue, cost_of_revenue, gross_profit, operating_income, net_income, eps_diluted, ebitda...
+# Balance: total_assets, total_liabilities, total_equity, cash_and_equivalents, total_debt...
+# CashFlow: operating_cash_flow, capital_expenditure, free_cash_flow, dividends_paid...
+```
+
+```bash
+# CLI
+tigeropen quote fundamental financial AAPL --fields total_revenue,net_income
+tigeropen quote fundamental financial AAPL --period-type QUARTERLY
+tigeropen quote fundamental financial AAPL --begin-date 2024-01-01 --end-date 2026-01-01
+```
+
+### 分红 / Dividends
+
+```python
+dividends = quote_client.get_corporate_dividend(
+    symbols=['AAPL'], market='US',
+    begin_date='2024-01-01', end_date='2025-12-31')
+# 属性: symbol, announce_date, record_date, pay_date, amount, currency
+```
+
+```bash
+# CLI
+tigeropen quote fundamental dividend AAPL --begin-date 2024-01-01 --end-date 2026-01-01
+```
+
+### 拆合股 / Stock Splits
+
+```python
+splits = quote_client.get_corporate_split(
+    symbols=['AAPL'], market='US',
+    begin_date='2020-01-01', end_date='2025-12-31')
+# 属性: symbol, execute_date, from_factor, to_factor
+```
+
+### 财报日历 / Earnings Calendar
+
+```python
+earnings = quote_client.get_corporate_earnings_calendar(
+    market='US', begin_date='2025-06-01', end_date='2025-06-30')
+# 属性: symbol, name, market, earnings_date, timing(BMO/AMC)
+```
+
+```bash
+# CLI
+tigeropen quote fundamental earnings --begin-date 2026-03-01 --end-date 2026-03-31
+tigeropen quote fundamental earnings --market HK --begin-date 2026-03-01 --end-date 2026-03-31
+```
+
+---
+
+## 期权行情 / Option Quotes
+
+> 详细的期权交易功能见 tigeropen-option 技能 / See tigeropen-option skill for trading
+
+```python
+# 到期日 / Expirations (返回 DataFrame: symbol, option_symbol, date, timestamp, period_tag)
+expirations = quote_client.get_option_expirations(symbols=['AAPL'], market='US')
+# period_tag: "m"=月度期权(monthly), "w"=周期权(weekly)
+
+# 期权链 / Option chain
+from tigeropen.quote.domain.filter import OptionFilter
+chain = quote_client.get_option_chain(symbol='AAPL', expiry='2025-08-29', market='US')
+# 带筛选 / With filters
+option_filter = OptionFilter(implied_volatility_min=0.3, delta_min=0.2, open_interest_min=100, in_the_money=True)
+chain = quote_client.get_option_chain(symbol='AAPL', expiry='2025-08-29',
+                                       option_filter=option_filter, return_greek_value=True, market='US')
+
+# 实时行情 / Real-time quotes
+briefs = quote_client.get_option_briefs(identifiers=['AAPL  250829C00150000'])
+
+# K线 / K-lines (支持: day, 1min, 5min, 30min, 60min; 可选 sort_dir)
+bars = quote_client.get_option_bars(identifiers=['AAPL  250829C00150000'], period='day')
+
+# 深度 / Depth
+depth = quote_client.get_option_depth(identifiers=['AAPL  250829C00150000'], market='US')
+
+# 逐笔 / Ticks
+ticks = quote_client.get_option_trade_ticks(identifiers=['AAPL  250829C00150000'])
+
+# 分时 / Timeline
+timeline = quote_client.get_option_timeline(identifiers=['AAPL  250829C00150000'])
+
+# 港股期权代码映射 / HK option symbol mapping
+hk_symbols = quote_client.get_option_symbols(market='HK')  # e.g. 00700 -> TCH.HK
+```
+
+**get_option_chain 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期权完整代码 Full option identifier |
+| `symbol` | 标的代码 Underlying symbol |
+| `expiry` | 到期日毫秒时间戳 Expiration timestamp (ms) |
+| `strike` | 行权价 Strike price |
+| `put_call` | `CALL`(看涨) / `PUT`(看跌) |
+| `multiplier` | 期权乘数（美股通常100） Option multiplier |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 Ask size |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 Bid size |
+| `pre_close` | 前收盘价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `volume` | 成交量 Volume |
+| `open_interest` | 未平仓合约数 Open interest |
+| `last_timestamp` | 最后交易时间戳 Last trade timestamp (ms) |
+| `implied_vol` | 隐含波动率 Implied volatility |
+| `delta` | Delta 值 |
+| `gamma` | Gamma 值 |
+| `theta` | Theta 值（每日时间价值损耗） |
+| `vega` | Vega 值（波动率敏感度） |
+| `rho` | Rho 值（利率敏感度） |
+
+**get_option_briefs 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期权完整代码 Full option identifier |
+| `symbol` | 标的代码 Underlying symbol |
+| `expiry` | 到期日毫秒时间戳 Expiration timestamp (ms) |
+| `strike` | 行权价 Strike price |
+| `put_call` | `CALL` / `PUT` |
+| `multiplier` | 期权乘数 Option multiplier |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 Ask size |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 Bid size |
+| `pre_close` | 前收盘价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `latest_time` | 最新交易时间 Latest trade time |
+| `volume` | 成交量 Volume |
+| `open_interest` | 未平仓数量 Open interest |
+| `open` | 开盘价 Open price |
+| `high` | 最高价 High price |
+| `low` | 最低价 Low price |
+| `change` | 价格变动 Price change |
+| `volatility` | 历史波动率 Historical volatility |
+| `rates_bonds` | 无风险利率 Risk-free interest rate |
+| `mid_price` | 买卖价中间价 Mid price (ask+bid)/2 |
+| `mid_timestamp` | 中间价时间戳 Mid price timestamp (ms) |
+| `mark_price` | 标记价格 Mark price |
+| `mark_timestamp` | 标记价格时间戳 Mark price timestamp (ms) |
+| `pre_mark_price` | 前标记价格 Previous mark price |
+| `selling_return` | 卖出收益率 Selling return |
+
+### 期权分析 / Option Analysis
+
+```python
+from tigeropen.common.consts import OptionAnalysisPeriod
+
+analysis = quote_client.get_option_analysis(symbols=['AAPL'],
+                                             period=OptionAnalysisPeriod.FIFTY_TWO_WEEK)
+# 返回 List[OptionAnalysis]
+# 属性: symbol, implied_vol_30_days, his_volatility, iv_his_v_ratio, call_put_ratio
+# iv_metric: IVMetric(period, percentile, rank)
+```
+
+**期权代码格式 / Option Symbol Format**:
+- 美股 US: `'AAPL  250829C00150000'` (标的 + YYMMDD + C/P + 行权价*1000)
+- 港股 HK: `'TCH.HK 230616C00550000'`
+
+```bash
+# CLI
+tigeropen quote option expirations AAPL                        # 到期日列表
+tigeropen quote option chain AAPL 2026-06-19                   # 期权链
+tigeropen quote option briefs "AAPL  260619C00150000"          # 实时行情
+tigeropen quote option bars "AAPL  260619C00150000" --period day --limit 10  # K线
+```
+
+---
+
+## 期货行情 / Futures Quotes
+
+```python
+# 期货交易所 / Exchanges
+exchanges = quote_client.get_future_exchanges()
+# CME, NYMEX, COMEX, CBOT, CBOE, HKFE, SGX, OSE
+
+# 交易所合约 / Exchange contracts
+contracts = quote_client.get_future_contracts(exchange='CME')
+
+# 指定合约 / Specific contract
+contract = quote_client.get_future_contract(symbol='CL2509')
+
+# 主力合约 / Current/main contract
+current = quote_client.get_current_future_contract(contract_type='CL')
+
+# 连续合约 / Continuous contracts
+continuous = quote_client.get_future_continuous_contracts(contract_type='CL')
+
+# 所有合约(某品种) / All contracts for a type
+all_contracts = quote_client.get_all_future_contracts(contract_type='CL')
+
+# 交易时间 / Trading times
+times = quote_client.get_future_trading_times(symbol='CL2509')
+
+# 实时行情 / Real-time quotes
+brief = quote_client.get_future_brief(identifiers=['CL2509'])
+
+# 深度行情 / Depth
+depth = quote_client.get_future_depth(identifiers=['CL2509'])
+# 单个合约返回: {'identifier': 'CL2509', 'asks': [{'price': 63.07, 'size': 10}, ...], 'bids': [...]}
+# 多个合约返回: {'CL2509': {'asks': [...], 'bids': [...]}, 'ES2509': {...}}
+
+# 逐笔 / Ticks
+ticks = quote_client.get_future_trade_ticks(identifier='CL2509', limit=50)
+
+# K线 / K-lines
+bars = quote_client.get_future_bars(identifier='CL2509', period=BarPeriod.DAY, limit=60)
+
+# 分页K线 / Paginated K-lines
+bars = quote_client.get_future_bars_by_page(identifier='CL2509', period=BarPeriod.DAY,
+                                             begin_time='2025-01-01', end_time='2025-06-30')
+```
+
+**get_future_brief 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期货合约代码 Contract code (e.g. `CL2509`) |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 Ask size |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 Bid size |
+| `pre_close` | 前收价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `latest_size` | 最新成交量 Latest trade volume |
+| `latest_time` | 最新成交时间（毫秒时间戳） Latest time (ms) |
+| `volume` | 当日累计成交手数 Total volume today |
+| `open_interest` | 未平仓合约数量 Open interest |
+| `open_interest_change` | 未平仓合约变化量 Open interest change |
+| `open` | 开盘价 Open price |
+| `high` | 最高价 High price |
+| `low` | 最低价 Low price |
+| `settlement` | 结算价 Settlement price |
+| `limit_up` | 涨停价 Upper price limit |
+| `limit_down` | 跌停价 Lower price limit |
+| `avg_price` | 均价 Average price |
+
+```bash
+# CLI
+tigeropen quote future exchanges                       # 交易所列表
+tigeropen quote future contracts CME                  # 交易所合约
+tigeropen quote future briefs ES2606 CL2509           # 实时报价
+tigeropen quote future bars CL2509 --period day --limit 20  # K线
+```
+
+---
+
+## 基金行情 / Fund Quotes
+
+> CLI 暂不支持，请使用 Python SDK。No CLI equivalent — use Python SDK.
+
+```python
+# 基金代码 / Fund symbols
+symbols = quote_client.get_fund_symbols()
+
+# 基金合约 / Fund contracts
+contracts = quote_client.get_fund_contracts(symbols=['ARKK'])
+
+# 最新行情 / Latest quote
+quote = quote_client.get_fund_quote(symbols=['ARKK'])
+
+# 历史行情 / Historical quotes
+history = quote_client.get_fund_history_quote(symbols=['ARKK'],
+                                               begin_date='2025-01-01', end_date='2025-06-30')
+```
+
+---
+
+## 数字货币行情 / Cryptocurrency Quotes
+
+> CLI 暂不支持，请使用 Python SDK。No CLI equivalent — use Python SDK.
+
+```python
+from tigeropen.common.consts import SecurityType
+
+# 代码列表 / Symbols
+symbols = quote_client.get_symbols(market=Market.US, sec_type=SecurityType.CC)
+
+# 实时行情 / Real-time quotes
+briefs = quote_client.get_cc_briefs(symbols=['BTC/USD', 'ETH/USD'])
+
+# K线 / K-lines
+bars = quote_client.get_bars(['BTC/USD'], period=BarPeriod.DAY, limit=30, sec_type=SecurityType.CC)
+
+# 分时 / Timeline
+timeline = quote_client.get_timeline(['BTC/USD'], sec_type=SecurityType.CC)
+```
+
+---
+
+## 窝轮/牛熊证行情 / Warrant & CBBC Quotes
+
+> CLI 暂不支持，请使用 Python SDK。No CLI equivalent — use Python SDK.
+
+```python
+# 窝轮筛选器 / Warrant scanner
+warrants = quote_client.get_warrant_filter(
+    symbol='00700', filter_type='warrant',  # warrant/cbbc/inline
+    sort_field='changeRate', sort_dir='DESC')
+
+# 窝轮行情 / Warrant quotes
+briefs = quote_client.get_warrant_briefs(symbols=['12345'])
+```
+
+---
+
+## 选股器 / Market Scanner
+
+### 选股工作流 / Scanner Workflow
+
+```
+1. 确定筛选条件 → 2. 构造 StockFilter 对象列表 → 3. 设置排序 SortFilterData → 4. 调用 market_scanner → 5. 分页读取结果
+```
+
+```python
+from tigeropen.quote.domain.filter import StockFilter, SortFilterData
+from tigeropen.common.consts.filter_fields import (
+    StockField, AccumulateField, FinancialField, MultiTagField,
+    AccumulatePeriod, FinancialPeriod
+)
+from tigeropen.common.consts import Market, SortDirection
+
+# ── 基础筛选: 市值 + PE ─────────────────────────────────────────────────────────
+f_cap   = StockFilter(StockField.MarketValue, filter_min=1e10)          # 总市值 > 100亿
+f_pe    = StockFilter(StockField.PeTTM, filter_max=30)                  # PE TTM < 30
+sort    = SortFilterData(StockField.MarketValue, sort_dir=SortDirection.DESC)
+
+result = quote_client.market_scanner(
+    market=Market.US,
+    filters=[f_cap, f_pe],
+    sort_field_data=sort,
+    page_size=20
+)
+
+print(f"共 {result.total_count} 条 / Total: {result.total_count}")
+for item in result.items:
+    print(f"{item.symbol}: 市值={item[f_cap]:.2e}, PE={item[f_pe]:.1f}")
+
+# ── 分页读取 / Pagination ───────────────────────────────────────────────────────
+cursor_id = result.cursor_id
+while result.page < result.total_page - 1 and cursor_id:
+    result = quote_client.market_scanner(
+        market=Market.US, filters=[f_cap, f_pe],
+        sort_field_data=sort, page_size=20, cursor_id=cursor_id
+    )
+    cursor_id = result.cursor_id
+    for item in result.items:
+        print(item.symbol, item[f_cap])
+```
+
+```python
+# ── 今日涨幅筛选 / Today's gainers ────────────────────────────────────────────
+# 使用 StockField.current_ChangeRate (盘中涨跌幅) 筛选当日涨幅 > 3%
+f_change = StockFilter(StockField.current_ChangeRate, filter_min=3)
+sort     = SortFilterData(StockField.current_ChangeRate, sort_dir=SortDirection.DESC)
+result   = quote_client.market_scanner(market=Market.US, filters=[f_change],
+                                        sort_field_data=sort, page_size=20)
+for item in result.items:
+    print(f"{item.symbol}: +{item[f_change]:.1f}%")
+```
+
+```python
+# ── 高 ROE 筛选 / High ROE (annual) ──────────────────────────────────────────
+# AccumulateField.ROE 需要指定 accumulate_period，返回值为小数 (0.15 = 15%)
+f_roe  = StockFilter(AccumulateField.ROE, filter_min=0.15,
+                     accumulate_period=AccumulatePeriod.ANNUAL)
+sort   = SortFilterData(AccumulateField.ROE, sort_dir=SortDirection.DESC,
+                        period=AccumulatePeriod.ANNUAL)
+result = quote_client.market_scanner(market=Market.US, filters=[f_roe],
+                                      sort_field_data=sort, page_size=20)
+for item in result.items:
+    print(f"{item.symbol}: ROE={item[f_roe]*100:.1f}%")
+```
+
+```python
+# ── FinancialField (LTM 口径) ─────────────────────────────────────────────────
+f_roe_fin = StockFilter(FinancialField.ReturnOnEquityRate, filter_min=0.15,
+                        financial_period=FinancialPeriod.LTM)
+result    = quote_client.market_scanner(market=Market.US, filters=[f_roe_fin], page_size=20)
+
+# ── MultiTagField: 有期权且非 ETF ─────────────────────────────────────────────
+f_opts = StockFilter(MultiTagField.OptionsAvailable, tag_list=['1'])
+f_etf  = StockFilter(MultiTagField.Type, tag_list=['0'])  # 0 = 普通股
+result = quote_client.market_scanner(market=Market.US,
+                                      filters=[f_opts, f_etf], page_size=20)
+```
+
+### 字段类型说明 / Field Types
+
+| 类型 | 导入路径 | 适用场景 | 是否需要 period |
+|------|---------|---------|----------------|
+| `StockField` | `filter_fields.StockField` | 价格、成交量、市值、PE等实时指标 | 否 |
+| `AccumulateField` | `filter_fields.AccumulateField` | ROE、营收增长、涨跌幅（带周期）| 是（`accumulate_period`）|
+| `FinancialField` | `filter_fields.FinancialField` | LTM 财务指标（净利率、ROE等）| 固定 `FinancialPeriod.LTM` |
+| `MultiTagField` | `filter_fields.MultiTagField` | 行业、概念、期权可用等标签 | 否（`tag_list`）|
+
+### 常用字段速查 / Common Fields
+
+**StockField（价格/市场数据）**
+
+| 字段 | 说明 |
+|------|-----|
+| `MarketValue` | 总市值 Total market cap |
+| `FloatMarketVal` | 流通市值 Float market cap |
+| `current_ChangeRate` | 今日涨跌幅% Intraday change rate |
+| `Volume` | 成交量 Volume |
+| `Amount` | 成交额 Turnover amount |
+| `TurnoverRate` | 换手率 Turnover rate |
+| `PeTTM` | 市盈率 TTM P/E ratio |
+| `CurPrice` | 最新价 Latest price |
+| `Week52High` / `Week52Low` | 52周高/低 52-week high/low |
+
+**AccumulateField（需指定 `accumulate_period`）**
+
+| 字段 | 说明 | 值说明 |
+|------|-----|-------|
+| `ChangeRate` | 涨跌幅（含周期）| 百分比数值，如 5.0 |
+| `ROE` | 净资产收益率 | 小数，如 0.15 = 15% |
+| `ROA` | 总资产收益率 | 小数 |
+| `NetIncome_Ratio_Annual` | 净利润同比增长率 | 百分比 |
+| `GrossProfitRate` | 毛利率 | 小数 |
+| `Total_Revenue` | 营业收入 | 绝对值 |
+
+**AccumulatePeriod 常用值**: `ANNUAL`（年度）、`QUARTERLY`（季度）、`SEMIANNUAL`（半年）、`Five_Days`、`Beginning_Of_The_Year_To_Now`
+
+```bash
+# CLI
+# 今日涨幅 > 3%, 按涨幅降序
+tigeropen quote scanner --filter current_ChangeRate:3: --sort current_ChangeRate --sort-dir DESC --limit 20
+
+# 大市值且 PE < 30（美股）
+tigeropen quote scanner --filter MarketValue:1e10: --filter PeTTM::30 --sort MarketValue --limit 20
+
+# 高 ROE 筛选（年度，ROE > 15%）
+tigeropen quote scanner --filter acc.ROE:0.15::ANNUAL --sort acc.ROE:ANNUAL --sort-dir DESC --limit 20
+
+# 港股选股
+tigeropen quote scanner --market HK --filter MarketValue:1e9: --sort MarketValue --limit 20
+
+# 大市值 + 高 ROE + 低 PE（组合筛选）
+tigeropen quote scanner --filter MarketValue:1e10: --filter acc.ROE:0.15::ANNUAL --filter PeTTM::30 --sort MarketValue --limit 20
+```
+
+> **filter 格式 / Filter format**:
+> - `FIELD:min:max` — StockField 范围，如 `MarketValue:1e9:1e12`、`PeTTM::20`
+> - `acc.FIELD:min:max:PERIOD` — AccumulateField，如 `acc.ROE:0.15::ANNUAL`
+> - `fin.FIELD:min:max` — FinancialField (LTM)，如 `fin.ReturnOnEquityRate:0.15:`
+> - `tag.FIELD:tag1,tag2` — MultiTagField，如 `tag.OptionsAvailable:1`
+
+---
+
+## 行情权限管理 / Quote Permission Management
+
+```python
+# 查询权限 / Query permissions
+permissions = quote_client.get_quote_permission()
+for p in permissions:
+    print(f"{p['name']}: expires={p['expire_at']}")  # -1 = 永不过期 never expires
+
+# 抢占权限 / Grab permissions (多设备切换时 / multi-device)
+quote_client.grab_quote_permission()
+
+# K线配额 / K-line quota
+quota = quote_client.get_kline_quota(with_details=True)
+for q in quota:
+    print(f"{q['method']}: used={q['used']}, remain={q['remain']}")
+```
+
+**权限类型**: `usQuoteBasic`, `usStockQuoteLv2Totalview`, `hkStockQuoteLv2`, `usOptionQuote`, `hkFutureQuoteLv2`, `CBOEFuturesQuoteLv2`
+
+---
+
+## 注意事项 / Notes
+
+- 行情权限需单独购买，API 与 App 独立 / Quote permissions require separate purchase
+- 多设备同账号：最后抢占的设备获取权限 / Last device to grab gets permissions
+- K线有配额限制，大量数据用 `get_bars_by_page` / Use paginated fetch for large datasets
+- 港股代码5位数 `00700`(腾讯) / HK codes are 5-digit like `00700`
+- 深度行情需 L2 权限 / Depth quotes require Level 2 permission
+- 更多详情见 / More details: https://docs.itigerup.com/docs/quote-stock

--- a/.agents/skills/tigeropen/references/trade.md
+++ b/.agents/skills/tigeropen/references/trade.md
@@ -1,0 +1,786 @@
+
+# Tiger Open API 交易 / Trading
+
+> 中文 | English — 双语技能，代码通用。Bilingual skill with shared code examples.
+> 官方文档 Docs: https://docs.itigerup.com/docs/place-order
+
+## 安全规范 / Safety Rules
+
+> **默认使用模拟账户。Default to Paper Trading.**
+
+### 模拟交易 vs 实盘交易 / Paper vs Live Trading
+
+| 特性 Feature | 模拟 Paper | 实盘 Live |
+|------|------|------|
+| 资金 Funds | 虚拟，无风险 Virtual, no risk | 真实资金 Real money |
+| 账户类型 `account_type` | `PAPER` | `STANDARD` / `GLOBAL` |
+| 默认 Default | **是** Yes | 需用户明确要求 User must explicitly request |
+
+### 实盘下单工作流 / Live Order Workflow
+
+当用户要求实盘交易时，**必须执行以下流程** / When user requests live trading, follow these steps:
+
+1. **确认账户 Verify account**: 调用 `get_managed_accounts()` 获取账户列表，筛选 `account_type != 'PAPER'` 的实盘账户 / Call `get_managed_accounts()`, filter for non-PAPER accounts
+2. **二次确认 Confirm with user**: 下单前必须与用户确认：标的代码、买卖方向、数量、价格、账户类型 / Confirm symbol, action, quantity, price, account type
+3. **预览订单 Preview**: 建议先调用 `preview_order()` 查看预估佣金和保证金 / Call `preview_order()` for commission and margin estimates
+4. **执行下单 Execute**: 确认后执行 `place_order()` / Place the order after confirmation
+5. **检查状态 Check status**: `place_order()` 返回成功仅表示提交，需通过 `get_orders()` 确认成交 / Submission success ≠ execution; poll `get_orders()` to confirm fill
+
+---
+
+## 初始化 / Initialize
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.trade.trade_client import TradeClient
+
+client_config = TigerOpenClientConfig(props_path='/path/to/your/tiger_openapi_config.properties')
+trade_client = TradeClient(client_config=client_config)
+
+# 获取管理的账户 / Get managed accounts
+accounts = trade_client.get_managed_accounts()
+# 返回 AccountProfile 列表 / Returns list of AccountProfile objects
+for a in accounts:
+    print(f"{a.account}: type={a.account_type}, capability={a.capability}, status={a.status}")
+```
+
+**AccountProfile 属性 / AccountProfile Attributes**:
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `account` | 交易账户ID Trading account ID |
+| `account_type` | 账户类型: `PAPER`(模拟) / `STANDARD`(美股标准) / `GLOBAL`(全球) |
+| `capability` | 保证金类型: `CASH`(现金账户) / `MGRN`(Reg T 保证金) / `PMGRN`(投资组合保证金) |
+| `status` | 账户状态: `New`/`Funded`/`Open`/`Pending`/`Abandoned`/`Rejected`/`Closed`/`Unknown` |
+
+
+
+---
+
+## 合约 / Contracts
+
+交易前必须获取合约对象。Contracts must be obtained before trading.
+
+### 本地构造 / Local Construction
+
+```python
+from tigeropen.common.util.contract_utils import (
+    stock_contract, option_contract, option_contract_by_symbol,
+    future_contract, war_contract_by_symbol, iopt_contract_by_symbol,
+    fund_contract, cc_contract
+)
+
+# 股票 / Stock
+contract = stock_contract(symbol='AAPL', currency='USD')
+
+# 港股 / HK Stock
+contract = stock_contract(symbol='00700', currency='HKD')
+
+# 期权 / Option
+opt = option_contract_by_symbol(symbol='AAPL', expiry='20250829',
+                                 strike=150.0, put_call='CALL', currency='USD')
+
+# 期货 / Future
+fut = future_contract(symbol='CL2509', currency='USD')
+
+# 窝轮 / Warrant
+war = war_contract_by_symbol(symbol='12345', currency='HKD')
+
+# 牛熊证 / CBBC
+iopt = iopt_contract_by_symbol(symbol='56789', currency='HKD')
+
+# 基金 / Fund
+fund = fund_contract(symbol='ARKK', currency='USD')
+
+# 数字货币 / Crypto
+cc = cc_contract(symbol='BTC/USD', currency='USD')
+```
+
+### 远程获取 / Remote Fetch
+
+```python
+# 单个合约 / Single contract
+contract = trade_client.get_contract(symbol='AAPL', sec_type='STK')
+contract = trade_client.get_contract(symbol='AAPL', sec_type='OPT',
+                                      expiry='20250829', strike=150.0, put_call='CALL')
+
+# 批量合约 / Multiple contracts
+contracts = trade_client.get_contracts(symbols=['AAPL', 'TSLA'], sec_type='STK')
+
+# 衍生品合约列表 / Derivative contracts
+derivatives = trade_client.get_derivative_contracts(symbol='AAPL', sec_type='OPT')
+```
+
+### Contract 对象属性 / Contract Attributes
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `symbol` | 代码 Symbol |
+| `sec_type` | 证券类型 Security type (STK/OPT/FUT/WAR/IOPT) |
+| `currency` | 货币 Currency |
+| `exchange` | 交易所 Exchange |
+| `name` | 名称 Name |
+| `expiry` | 到期日 Expiry (options/futures) |
+| `strike` | 行权价 Strike (options) |
+| `put_call` | CALL/PUT (options) |
+| `multiplier` | 乘数 Multiplier |
+| `lot_size` | 每手股数 Lot size |
+| `shortable` | 可否卖空 Shortable |
+| `shortable_count` | 可卖空数量 Shortable count |
+| `min_tick` | 最小价格变动 Min tick size |
+
+---
+
+## 下单 / Place Orders
+<!-- 当用户提到 "买入"、"卖出"、"下单"、"buy"、"sell"、"order"、"place order" 时 -->
+
+### 限价单 LMT / Limit Order
+
+```python
+from tigeropen.common.util.order_utils import limit_order
+
+order = limit_order(account=client_config.account, contract=contract,
+                    action='BUY', quantity=100, limit_price=150.0)
+trade_client.place_order(order)
+print(f"Order ID: {order.id}")
+```
+
+### 市价单 MKT / Market Order
+
+```python
+from tigeropen.common.util.order_utils import market_order, market_order_by_amount
+
+order = market_order(account=client_config.account, contract=contract,
+                     action='BUY', quantity=100)
+trade_client.place_order(order)
+
+# 按金额下单(碎股) / By amount (fractional shares)
+order = market_order_by_amount(account=client_config.account, contract=contract,
+                               action='BUY', amount=5000)  # 买入 $5000 的股票
+trade_client.place_order(order)
+```
+
+> 也有 `limit_order_by_amount` 用于按金额的限价单。
+> There's also `limit_order_by_amount` for limit orders by amount.
+
+### 止损单 STP / Stop Order
+
+```python
+from tigeropen.common.util.order_utils import stop_order
+
+order = stop_order(account=client_config.account, contract=contract,
+                   action='SELL', quantity=100, aux_price=140.0)
+# aux_price = 触发价 / trigger price
+trade_client.place_order(order)
+```
+
+### 止损限价单 STP_LMT / Stop Limit Order
+
+```python
+from tigeropen.common.util.order_utils import stop_limit_order
+
+order = stop_limit_order(account=client_config.account, contract=contract,
+                         action='SELL', quantity=100,
+                         limit_price=139.0, aux_price=140.0)
+# 价格到 aux_price 时触发，以 limit_price 限价委托
+trade_client.place_order(order)
+```
+
+### 跟踪止损单 TRAIL / Trailing Stop
+
+```python
+from tigeropen.common.util.order_utils import trail_order
+
+# 百分比跟踪 / Percentage trailing
+order = trail_order(account=client_config.account, contract=contract,
+                    action='SELL', quantity=100, trailing_percent=5.0)
+
+# 金额跟踪 / Amount trailing
+order = trail_order(account=client_config.account, contract=contract,
+                    action='SELL', quantity=100, aux_price=3.0)
+trade_client.place_order(order)
+```
+
+### 算法单 TWAP/VWAP / Algo Orders
+
+```python
+from tigeropen.common.util.order_utils import algo_order, algo_order_params
+
+params = algo_order_params(start_time=1625097600000, end_time=1625184000000,
+                            participation_rate=0.1)
+order = algo_order(account=client_config.account, contract=contract,
+                   action='BUY', quantity=1000, strategy='TWAP',  # 或 'VWAP'
+                   algo_params=params)
+trade_client.place_order(order)
+```
+
+### 附加订单(止盈止损) / Bracket Orders (Take Profit / Stop Loss)
+
+```python
+from tigeropen.common.util.order_utils import limit_order_with_legs, order_leg
+
+# 推荐使用 limit_order_with_legs / Recommended: use limit_order_with_legs
+legs = [
+    order_leg(leg_type='PROFIT', price=170.0),              # 止盈 / Take profit
+    order_leg(leg_type='LOSS', price=140.0),                 # 止损 / Stop loss
+    # 也可用跟踪止损 / Or trailing stop loss:
+    # order_leg(leg_type='LOSS', trailing_percent=5.0),
+]
+order = limit_order_with_legs(account=client_config.account, contract=contract,
+                              action='BUY', quantity=100, limit_price=150.0,
+                              order_legs=legs)
+trade_client.place_order(order)
+```
+
+> 附加订单仅支持限价单作为主订单，最多2个 leg。子订单在主订单全部成交后自动生效。
+> Bracket orders only support limit as primary, max 2 legs. Legs activate after primary is fully filled.
+
+### order_leg 参数 / order_leg Parameters
+
+| 参数 Parameter | 说明 Description |
+|---------------|-----------------|
+| `leg_type` | `PROFIT`(止盈) 或 `LOSS`(止损) |
+| `price` | 触发价格 Trigger price |
+| `limit_price` | 限价(可选) Limit price (optional) |
+| `trailing_percent` | 跟踪止损百分比 Trailing percent |
+| `trailing_amount` | 跟踪止损金额 Trailing amount |
+| `quantity` | 数量(默认同主单) Quantity (default: same as primary) |
+
+---
+
+### 下单参数总览 / Order Parameters Overview
+
+| 参数 Parameter | 说明 Description | 必填 Required |
+|---------------|-----------------|--------------|
+| `account` | 交易账户 Trading account | ✅ |
+| `contract` | 合约对象 Contract | ✅ |
+| `action` | `BUY` / `SELL` | ✅ |
+| `quantity` | 数量 Quantity | ✅ |
+| `limit_price` | 限价 Limit price | LMT/STP_LMT |
+| `aux_price` | 触发价/跟踪金额 Trigger/trailing amount | STP/STP_LMT/TRAIL |
+| `trailing_percent` | 跟踪止损百分比 Trailing percent | TRAIL |
+| `time_in_force` | `DAY`/`GTC`(撤销前有效)/`GTD`(指定日期) | - |
+| `outside_rth` | 盘前盘后 Pre/after hours (仅美股 US only) | - |
+| `trading_session_type` | 交易时段 `TradingSessionType` 枚举值(PRE_RTH_POST/OVERNIGHT/RTH/FULL/HK_AUC/HK_CTS/HK_AUC_CTS) | - |
+| `order_id` | 自定义订单ID Custom order ID | - |
+| `user_mark` | 自定义标记 Custom mark | - |
+| `quantity_scale` | 数量精度(碎股) Quantity scale (fractional) | - |
+| `total_cash_amount` | 按金额下单 Order by amount | - |
+| `expire_time` | GTD到期时间 GTD expire time | GTD |
+
+### 各市场支持的订单类型 / Order Types by Market
+
+| 订单类型 | 美股 US | 港股 HK | 新加坡 SG | 期货 Futures | 期权 Options |
+|---------|---------|---------|----------|-------------|-------------|
+| MKT 市价 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| LMT 限价 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| STP 止损 | ✅ | - | - | ✅ | ✅ |
+| STP_LMT 止损限价 | ✅ | - | - | ✅ | ✅ |
+| TRAIL 跟踪止损 | ✅ | - | - | - | - |
+| TWAP/VWAP 算法 | ✅ | - | - | - | - |
+| AL 竞价限价 | - | ✅ | - | - | - |
+| AM 竞价市价 | - | ✅ | - | - | - |
+| OCA 一撤全撤 | ✅ | ✅ | - | - | - |
+
+```bash
+# CLI 下单 / Place orders via CLI
+tigeropen trade order place --symbol AAPL --action buy --order-type lmt --quantity 10 --limit-price 150
+tigeropen trade order place --symbol AAPL --action sell --order-type mkt --quantity 10
+tigeropen trade order place --symbol 00700 --action buy --order-type lmt --quantity 100 --limit-price 350 --sec-type stk
+tigeropen trade order place --symbol AAPL --action buy --order-type lmt --quantity 10 --limit-price 150 -y  # 跳过确认 skip confirm
+```
+
+### 特殊下单场景 / Special Order Scenarios
+
+```python
+# 盘前盘后 / Pre/after-hours (美股 US only)
+order = limit_order(account=client_config.account, contract=contract,
+                    action='BUY', quantity=100, limit_price=150.0)
+order.outside_rth = True
+trade_client.place_order(order)
+
+# 夜盘(通宵) / Overnight trading (使用 TradingSessionType 枚举)
+from tigeropen.common.consts import TradingSessionType
+order = limit_order(account=client_config.account, contract=contract,
+                    action='BUY', quantity=100, limit_price=150.0)
+order.trading_session_type = TradingSessionType.OVERNIGHT.value
+trade_client.place_order(order)
+# TradingSessionType 可选值: PRE_RTH_POST, OVERNIGHT, RTH, FULL, HK_AUC, HK_CTS, HK_AUC_CTS
+
+# GTC 订单 / Good Till Cancelled
+order = limit_order(account=client_config.account, contract=contract,
+                    action='BUY', quantity=100, limit_price=150.0)
+order.time_in_force = 'GTC'
+trade_client.place_order(order)
+
+# 港股下单 / HK stock order (注意: 数量须为 lot_size 的整数倍，可通过 get_trade_metas 查询)
+hk_contract = stock_contract(symbol='00700', currency='HKD')
+order = limit_order(account=client_config.account, contract=hk_contract,
+                    action='BUY', quantity=100, limit_price=350.0)
+trade_client.place_order(order)
+
+# 期货下单 / Futures order
+fut_contract = future_contract(symbol='CL2509', currency='USD')
+order = limit_order(account=client_config.account, contract=fut_contract,
+                    action='BUY', quantity=1, limit_price=70.0)
+trade_client.place_order(order)
+
+# 价格修正工具 / Price correction utility
+from tigeropen.common.util.price_util import PriceUtil
+price_util = PriceUtil(trade_client)
+corrected = price_util.correct_price(symbol='AAPL', price=150.123)
+```
+
+### 港股竞价单 / HK Auction Orders
+
+```python
+from tigeropen.common.util.order_utils import auction_limit_order, auction_market_order
+
+# 竞价限价单 AL / Auction Limit Order
+order = auction_limit_order(account=client_config.account, contract=hk_contract,
+                            action='BUY', quantity=100, limit_price=350.0)
+trade_client.place_order(order)
+
+# 竞价市价单 AM / Auction Market Order
+order = auction_market_order(account=client_config.account, contract=hk_contract,
+                             action='BUY', quantity=100)
+trade_client.place_order(order)
+```
+
+> 竞价单用于港股竞价时段(开盘竞价/收盘竞价)。`time_in_force` 支持 `DAY` 和 `OPG`。
+> Auction orders for HK pre-opening/closing auction sessions. `time_in_force` supports `DAY` and `OPG`.
+
+### OCA 订单(一撤全撤) / OCA Order (One-Cancels-All)
+
+```python
+from tigeropen.common.util.order_utils import oca_order, order_leg
+
+# OCA 订单: 多个子订单中任一成交，其余自动撤销
+# OCA order: when any leg fills, others are automatically cancelled
+legs = [
+    order_leg(leg_type='LMT', limit_price=160.0),   # 限价单
+    order_leg(leg_type='STP', price=140.0),           # 止损单
+]
+order = oca_order(account=client_config.account, contract=contract,
+                  action='SELL', order_legs=legs, quantity=100)
+trade_client.place_order(order)
+```
+
+---
+
+## 预览订单 / Preview Order
+<!-- 当用户提到 "预览"、"佣金"、"保证金"、"preview"、"commission" 时 -->
+
+```python
+preview = trade_client.preview_order(order)
+# 返回 dict / Returns dict
+```
+
+**preview_order 返回字段 / Return Fields** (dict):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `init_margin_before` | 下单前账户初始保证金 Initial margin before order |
+| `init_margin` | 下单后预计初始保证金 Estimated initial margin after order |
+| `maint_margin_before` | 下单前维持保证金 Maintenance margin before order |
+| `maint_margin` | 下单后预计维持保证金 Estimated maintenance margin after order |
+| `margin_currency` | 保证金货币 Margin currency (e.g. `USD`) |
+| `equity_with_loan_before` | 下单前含借贷值股权 Equity with loan value before |
+| `equity_with_loan` | 下单后含借贷值股权 Equity with loan value after |
+| `min_commission` | 预期最低佣金 Minimum estimated commission |
+| `max_commission` | 预期最高佣金 Maximum estimated commission |
+| `commission_currency` | 佣金货币 Commission currency |
+| `warning_text` | 无法下单原因（仅在拒绝时返回）Rejection reason (only when rejected) |
+
+> 若无法下单，仅返回 `warning_text` 字段。
+
+```bash
+# CLI
+tigeropen trade order preview --symbol AAPL --action buy --order-type lmt --quantity 10 --limit-price 150
+```
+
+## 修改订单 / Modify Order
+<!-- 当用户提到 "改单"、"修改订单"、"modify"、"change order" 时 -->
+
+```python
+order = trade_client.get_order(id=123456789)
+trade_client.modify_order(order,
+                           quantity=200,
+                           limit_price=155.0,
+                           time_in_force='GTC',
+                           outside_rth=True)
+```
+
+```bash
+# CLI (ORDER_ID 为全局订单 id / global order id)
+tigeropen trade order modify ORDER_ID --limit-price 155 --quantity 200
+```
+
+> 订单类型不可修改。仅 `Submitted` 或 `PartiallyFilled` 状态可改。
+> Order type cannot be changed. Only Submitted/PartiallyFilled orders can be modified.
+
+## 撤销订单 / Cancel Order
+<!-- 当用户提到 "撤单"、"取消订单"、"cancel order" 时 -->
+
+```python
+trade_client.cancel_order(id=123456789)
+
+# 批量撤销 / Batch cancel
+for order in trade_client.get_open_orders():
+    trade_client.cancel_order(id=order.id)
+```
+
+```bash
+# CLI
+tigeropen trade order cancel ORDER_ID
+tigeropen trade order cancel ORDER_ID -y   # 跳过确认 / skip confirmation
+```
+
+> 撤销为异步操作。使用 `id` (全局订单ID)。Cancellation is async. Use global order `id`.
+
+---
+
+## 查询订单 / Query Orders
+<!-- 当用户提到 "订单"、"委托"、"orders"、"order status"、"order list" 时 -->
+
+```python
+# 所有订单 / All orders
+orders = trade_client.get_orders(limit=100)
+
+# 待成交 / Open (pending) orders
+open_orders = trade_client.get_open_orders()
+
+# 已成交 / Filled orders (需指定时间，最多90天)
+filled = trade_client.get_filled_orders(start_time='2025-01-01', end_time='2025-03-31')
+
+# 已取消 / Cancelled orders
+cancelled = trade_client.get_cancelled_orders()
+
+# 指定订单 / Single order
+order = trade_client.get_order(id=123456789)
+
+# 条件筛选 / Filtered query
+orders = trade_client.get_orders(
+    symbol='AAPL', sec_type='STK', market='US',
+    states=['Filled', 'Cancelled'],
+    sort_by='latest_time',  # latest_time(默认) / limit_price
+    limit=100,
+    is_brief=False  # True: 精简模式 / brief mode
+)
+
+# 分页查询 / Pagination
+orders = trade_client.get_orders(limit=20)
+# 使用 page_token 翻页 / Use page_token for next page
+if hasattr(orders, 'page_token') and orders.page_token:
+    next_page = trade_client.get_orders(limit=20, page_token=orders.page_token)
+```
+
+### Order 对象属性 / Order Attributes
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `id` | 全局订单ID Global order ID |
+| `order_id` | 用户订单ID User order ID |
+| `account` | 交易账户ID Account ID |
+| `symbol` | 标的代码 Symbol |
+| `sec_type` | 证券类型 Security type |
+| `action` | BUY/SELL |
+| `order_type` | MKT/LMT/STP/STP_LMT/TRAIL |
+| `status` | 订单状态 Order status (见下方 Status 表) |
+| `quantity` | 下单数量 Order quantity |
+| `filled_quantity` | 成交数量 Filled quantity |
+| `remaining_quantity` | 剩余数量 Remaining quantity |
+| `limit_price` | 限价 Limit price |
+| `aux_price` | 触发价/跟踪金额 Aux/trigger price |
+| `avg_fill_price` | 平均成交价 Average fill price |
+| `trade_time` | 最新成交时间 Last trade time |
+| `time_in_force` | DAY/GTC/GTD |
+| `outside_rth` | 是否盘前盘后 Outside regular trading hours |
+| `trading_session_type` | 交易时段类型 Trading session type |
+| `order_legs` | 附加订单列表 Attached order legs |
+| `algo_params` | 算法参数 Algo parameters |
+| `user_mark` | 自定义标记 Custom mark |
+| `reason` | 拒绝/错误原因 Rejection reason |
+| `commission` | 实际佣金 Actual commission |
+| `combo_type` | 组合类型 Combo type |
+| `currency` | 货币 Currency |
+| `exchange` | 交易所 Exchange |
+| `contract` | 合约对象 Contract object |
+
+### 订单状态 / Order Status
+
+| 状态 Status | 说明 Description |
+|------------|-----------------|
+| `Initial` | 初始化 Created |
+| `PendingSubmit` | 待提交 Pending submit |
+| `Submitted` | 已提交 Submitted |
+| `PartiallyFilled` | 部分成交 Partially filled |
+| `Filled` | 全部成交 Fully filled |
+| `Cancelled` | 已取消 Cancelled |
+| `Inactive` | 已失效/拒绝 Rejected |
+| `PendingCancel` | 待取消 Pending cancel |
+
+```bash
+# CLI
+tigeropen trade order list                                   # 所有订单
+tigeropen trade order list --status Filled                   # 已成交
+tigeropen trade order list --status Submitted                # 持仓中
+tigeropen trade order list --symbol AAPL --limit 10         # 按标的筛选
+tigeropen trade order get ORDER_ID                           # 查单个订单
+```
+
+---
+
+## 成交记录 / Transaction Records
+
+```python
+# 按标的查询 / By symbol
+transactions = trade_client.get_transactions(
+    symbol='AAPL', sec_type='STK',
+    start_time=1625097600000, end_time=1625184000000)
+
+# 按订单查询 / By order ID
+transactions = trade_client.get_transactions(order_id='123456789',
+                                              start_time=1625097600000,
+                                              end_time=1625184000000)
+# 分页 / Pagination
+response = trade_client.get_transactions(symbol='AAPL', start_time=..., end_time=..., page_token='')
+next_page = response.page_token  # 下一页令牌
+```
+
+**Transaction 对象属性 / Transaction Attributes**:
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `id` | 成交记录ID Transaction ID |
+| `account` | 交易账户ID Account ID |
+| `order_id` | 关联订单ID Related order ID |
+| `contract` | 合约对象 Contract object |
+| `action` | BUY/SELL |
+| `filled_quantity` | 成交数量 Filled quantity |
+| `filled_quantity_scale` | 数量精度 Quantity scale (fractional shares) |
+| `filled_price` | 成交价格 Filled price |
+| `filled_amount` | 成交金额 Filled amount |
+| `transacted_at` | 成交时间（毫秒时间戳） Transaction time (ms) |
+
+```bash
+# CLI (--symbol 为必填 / --symbol is required)
+tigeropen trade transaction list --symbol AAPL
+tigeropen trade transaction list --symbol AAPL --start-time 2025-01-01 --end-time 2025-06-30
+tigeropen trade transaction list --symbol AAPL --limit 20
+```
+
+---
+
+## 账户资产 / Account Assets
+<!-- 当用户提到 "资产"、"资金"、"余额"、"购买力"、"assets"、"balance"、"buying power"、"cash" 时 -->
+
+### 综合资产(推荐) / Prime Assets (Recommended)
+
+```python
+assets = trade_client.get_prime_assets(base_currency='USD', consolidated=True)
+# ⚠️ 资产字段在 segments 字典中，不在 assets 对象上
+# Fields are on segment objects, NOT directly on assets
+# segments 键: 'S'=证券(Standard), 'G'=环球(Global), 'C'=商品/期货, 'F'=基金, 'D'=数字货币
+seg = assets.segments.get('S') or assets.segments.get('G')
+print(f"总资产 Net: {seg.net_liquidation}")
+print(f"可用资金 Available: {seg.cash_available_for_trade}")
+print(f"购买力 Buying Power: {seg.buying_power}")
+print(f"现金 Cash: {seg.cash_balance}")
+print(f"维持保证金 Margin: {seg.maintain_margin}")
+print(f"未实现盈亏 Unrealized PnL: {seg.unrealized_pl}")
+print(f"已实现盈亏 Realized PnL: {seg.realized_pl}")
+
+# 每个 Segment.currency_assets 包含各币种明细
+for currency, ca in seg.currency_assets.items():
+    print(f"  {currency}: net={ca.net_liquidation}, forex_rate={ca.forex_rate}")
+```
+
+### Segment 关键字段 / Segment Key Fields
+
+| 字段 Field | 说明 Description | APP 对应 |
+|------------|-----------------|----------|
+| `net_liquidation` | 总资产（净清算价值） Net liquidation | 总资产 |
+| `cash_balance` | 现金额 Cash balance | 现金 |
+| `cash_available_for_trade` | 可用资金（含保证金额度） Available funds | 可用资金 |
+| `cash_available_for_withdrawal` | 可提现金额 Withdrawable cash | 可提金额 |
+| `gross_position_value` | 证券总价值 Total position value | 市值 |
+| `buying_power` | 购买力 Buying power | 购买力 |
+| `unrealized_pl` | 浮动盈亏 Unrealized P&L | 未实现盈亏 |
+| `realized_pl` | 已实现盈亏 Realized P&L | 已实现盈亏 |
+| `init_margin` | 初始保证金 Initial margin | 初始保证金 |
+| `maintain_margin` | 维持保证金 Maintenance margin | 维持保证金 |
+| `overnight_margin` | 隔夜保证金 Overnight margin | - |
+| `excess_liquidation` | 剩余流动性 Excess liquidity (= equity - maintain_margin) | 剩余流动性 |
+| `leverage` | 杠杆倍数 Leverage | 杠杆 |
+| `locked_funds` | 锁定资金 Locked funds | - |
+
+> **多币种注意 / Multi-currency Note**: 持仓涉及多币种时（如同时持有 USD 和 HKD 标的），查询资产时指定 `base_currency` 统一币种口径，避免直接累加不同币种的数值。每个 Segment 的 `currency_assets` 包含各币种明细和 `forex_rate` 汇率。
+> When positions span multiple currencies, specify `base_currency` in the query. Do not sum values across currencies directly. Use `currency_assets` for per-currency breakdown with `forex_rate`.
+
+### 全球资产 / Global Assets
+
+```python
+assets_list = trade_client.get_assets()
+for a in assets_list:
+    print(f"Buying Power: {a.buying_power}")
+    print(f"Maintenance Margin: {a.maintenance_margin_requirement}")
+    print(f"Unrealized PnL: {a.unrealized_pnl}")
+```
+
+### 资产分析 / Asset Analytics
+
+```python
+analytics = trade_client.get_analytics_asset(
+    start_date='2025-01-01', end_date='2025-06-30',
+    seg_type='SEC',  # SEC(证券)/FUT(期货)/ALL
+    currency='USD')
+# 返回 summary(pnl, pnl_percentage, annualized_return) 和 history(每日资产/盈亏)
+```
+
+```bash
+# CLI
+tigeropen account assets                                      # 综合资产（推荐）
+tigeropen account assets --currency USD                      # 指定计价货币
+tigeropen account analytics --start-date 2025-01-01 --end-date 2025-12-31  # 资产分析
+```
+
+---
+
+## 持仓 / Positions
+<!-- 当用户提到 "持仓"、"仓位"、"我的股票"、"positions"、"holdings"、"portfolio" 时 -->
+
+```python
+from tigeropen.common.consts import SecurityType, Market
+
+# 所有持仓 / All positions
+positions = trade_client.get_positions()
+
+# 按类型 / By security type
+positions = trade_client.get_positions(sec_type=SecurityType.STK)
+for p in positions:
+    print(f"{p.contract.symbol}: qty={p.qty}, cost={p.average_cost}, "
+          f"price={p.market_price}, value={p.market_value}, "
+          f"pnl={p.unrealized_pnl}, salable={p.salable_qty}")
+
+# 按市场 / By market
+us_pos = trade_client.get_positions(sec_type=SecurityType.STK, market=Market.US)
+hk_pos = trade_client.get_positions(sec_type=SecurityType.STK, market=Market.HK)
+
+# 按代码 / By symbol
+aapl_pos = trade_client.get_positions(sec_type=SecurityType.STK, symbol='AAPL')
+
+# 期权持仓 / Option positions
+opt_pos = trade_client.get_positions(sec_type=SecurityType.OPT)
+
+# 期货持仓 / Futures positions
+fut_pos = trade_client.get_positions(sec_type=SecurityType.FUT)
+```
+
+### Position 对象属性 / Position Attributes
+
+| 属性 Attribute | 说明 Description | APP 对应 |
+|---------------|-----------------|----------|
+| `contract` | 合约对象 Contract | - |
+| `qty` / `position_qty` | 持仓数量 Quantity | 持有数量 |
+| `average_cost` | 含佣金持仓均价 Average cost (incl. commission) | 平均成本 |
+| `average_cost_by_average` | 均价成本（不含佣金） Average cost (excl. commission) | - |
+| `market_price` | 最新价格 Market price | 现价 |
+| `market_value` | 市值 Market value | 市值 |
+| `unrealized_pnl` | 浮动盈亏 Unrealized P&L (FIFO) | 未实现盈亏 |
+| `unrealized_pnl_by_average` | 均价成本浮动盈亏 Unrealized P&L (avg cost) | - |
+| `unrealized_pnl_percent` | 浮动盈亏率 Unrealized P&L % | 盈亏百分比 |
+| `realized_pnl` | 已实现盈亏 Realized P&L (FIFO) | 已实现盈亏 |
+| `salable_qty` | 可卖数量 Salable quantity | 可卖 |
+| `today_pnl` | 今日盈亏额 Today's P&L | 今日盈亏 |
+| `today_pnl_percent` | 今日盈亏率 Today's P&L % | - |
+| `ratio` | 持仓占比 Position ratio | - |
+| `latest_price` | 最新成交价 Latest trade price | - |
+| `currency` | 币种 Currency | - |
+
+```bash
+# CLI
+tigeropen trade position list                                 # 所有股票持仓
+tigeropen trade position list --sec-type opt                  # 期权持仓
+tigeropen trade position list --sec-type fut                  # 期货持仓
+tigeropen trade position list --market hk                     # 港股持仓
+tigeropen trade position list --symbol AAPL                  # 指定标的
+```
+
+---
+
+## 预估可交易数量 / Estimate Tradable Quantity
+
+```python
+result = trade_client.get_estimate_tradable_quantity(
+    symbol='AAPL', sec_type='STK', order_type='LMT',
+    action='BUY', limit_price=150.0)
+# 返回: tradable_quantity(可交易), financing_quantity(融资可交易), position_quantity(持仓数量)
+```
+
+## 资金划转 / Fund Transfer (Between Segments)
+
+```python
+# 查询可划转金额 / Query transferable amount
+available = trade_client.get_segment_fund_available(
+    from_segment='SEC', to_segment='FUT', currency='USD')
+
+# 划转 / Transfer
+trade_client.transfer_segment_fund(
+    from_segment='SEC', to_segment='FUT', amount=10000.0, currency='USD')
+
+# 取消划转 / Cancel transfer
+trade_client.cancel_segment_fund(id='transfer_id')
+
+# 划转历史 / Transfer history
+history = trade_client.get_segment_fund_history()
+```
+
+## 出入金记录 / Deposit/Withdrawal Records
+
+```python
+records = trade_client.get_funding_history(
+    start_time='2025-01-01', end_time='2025-06-30', currency='USD')
+```
+
+## 换汇下单 / Forex Order
+
+```python
+from tigeropen.common.consts import SegmentType
+
+trade_client.place_forex_order(
+    seg_type=SegmentType.SEC,  # SEC(证券板块) 或 FUT(期货板块)
+    source_currency='USD', target_currency='HKD', source_amount=10000.0)
+```
+
+---
+
+## 交易时间参考 / Trading Hours Reference
+
+| 市场 Market | 时段 Session | 时间 Time (当地/Local) |
+|-------------|-------------|----------------------|
+| 美股 US | 盘前 Pre-market | 04:00-09:30 ET |
+| | 常规 Regular | 09:30-16:00 ET |
+| | 盘后 After-hours | 16:00-20:00 ET |
+| | 夜盘 Overnight | 20:00-04:00 ET |
+| 港股 HK | 竞价 Pre-opening | 09:00-09:30 |
+| | 上午 Morning | 09:30-12:00 |
+| | 下午 Afternoon | 13:00-16:00 |
+| | 收盘竞价 Closing | 16:00-16:10 |
+| 新加坡 SG | 全天 Full | 09:00-17:16 |
+
+> 更多交易规则见 / More: https://docs.itigerup.com/docs/trade-rules
+
+---
+
+## 注意事项 / Notes
+
+- `place_order` 返回成功仅表示提交成功，需查询确认成交。可检查 `order.id` 和 `order.status` / Success only means submitted; check `order.id` and `order.status`
+- 市价单(MKT)和止损单(STP)不支持盘前盘后 / MKT and STP don't support pre/after-hours
+- 同一证券不能同时持有多头和空头 / Cannot hold long and short simultaneously
+- 下单前建议 `preview_order` / Use preview before placing real orders
+- 交易佣金与 App 一致，无额外费用 / Trading fees same as app
+- 已成交订单查询需指定时间范围，最多90天 / Filled orders require time range, max 90 days
+- 港股下单数量须为 `lot_size` 的整数倍，可通过 `get_trade_metas` 查询 / HK orders must be multiples of `lot_size`
+- `quantity_scale` 用于碎股精度控制 / `quantity_scale` controls fractional share precision
+- `adjust_limit` 参数可用于价格自动修正 / `adjust_limit` for automatic price adjustment

--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/tigeropen-typescript/SKILL.md
+++ b/.claude/skills/tigeropen-typescript/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: tigeropen-typescript
+description: |
+  Tiger Brokers OpenAPI TypeScript SDK — complete skills for AI coding tools. Covers SDK setup, market data queries, trading, and real-time push subscriptions. Use when building trading applications in TypeScript/Node.js, querying market data, placing orders, or integrating Tiger Brokers API.
+  老虎证券 OpenAPI TypeScript SDK 完整技能集。涵盖 SDK 配置、行情查询、交易、实时推送订阅。适用于用 TypeScript/Node.js 构建交易应用、查询行情数据、下单交易。
+  用户提到以下关键词时自动使用 / Auto-activate on these keywords: 行情、报价、K线、买入、卖出、下单、撤单、交易、持仓、资金、账户、订单、期权、期货、推送、订阅、TypeScript SDK、tigeropen typescript、quote、price、K-line、order、buy、sell、trade、position、asset、option、future、push
+license: MIT
+compatibility: Requires Node.js 16+, supports ESM and CommonJS
+metadata:
+  author: tigerbrokers
+  version: "0.1.0"
+  language: zh_CN, en_US
+---
+
+# Tiger Open API TypeScript SDK
+
+> 老虎量化开放平台 TypeScript SDK 完整技能集 / Complete AI skill set for Tiger Brokers OpenAPI (TypeScript)
+
+> **安全警告 / Safety Warning**: 交易涉及真实资金。生成交易代码时默认使用**模拟账户**，除非用户明确要求实盘。实盘下单前必须与用户确认订单详情。
+> Trading involves real money. Default to **Paper Trading** when generating trading code. Always confirm order details before live orders.
+
+- Docs: https://docs.itigerup.com/docs/prepare
+- npm: `npm install tigeropen` | Node.js 16+, ESM/CommonJS
+
+## Language Rules / 语言规则
+
+根据用户输入语言自动回复。技术术语（代码、API 名称、参数名）保持原文不翻译。
+Reply in the user's language. Keep technical terms (code, API names, parameters) as-is.
+
+## Reference Guides
+
+- **[Quickstart](references/quickstart.md)** — SDK install, config, client setup, error handling
+- **[Market Data](references/quote.md)** — Real-time quotes, K-lines, depth, options, futures
+- **[Trading](references/trade.md)** — Place/modify/cancel orders, positions, assets
+- **[Real-time Push](references/push.md)** — WebSocket push for quotes, orders, positions
+- **[Account Management](references/account.md)** — Account list, assets, positions, fund transfer, deposit/withdrawal
+- **[Options Trading](references/option.md)** — Option chain, expirations, Greeks, multi-leg strategies
+
+## Quick Start
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/client/http-client';
+import { QuoteClient } from 'tigeropen/quote/quote-client';
+import { TradeClient } from 'tigeropen/trade/trade-client';
+
+// 1. 创建配置 / Create config
+const config = createClientConfig({
+  tigerId: 'your_tiger_id',
+  privateKey: 'your_rsa_private_key',
+  account: 'your_account',
+});
+
+// 2. 查询行情 / Query quotes
+const httpClient = new HttpClient(config);
+const qc = new QuoteClient(httpClient);
+const quotes = await qc.getBrief(['AAPL', 'TSLA']);
+console.log(quotes);
+
+// 3. 交易操作 / Trading
+const tc = new TradeClient(httpClient, config.account);
+const orders = await tc.getOrders();
+console.log(orders);
+```
+
+## When to Use Each Reference
+
+| Task | Reference |
+|------|-----------|
+| First time setup, SDK install, auth config | [quickstart.md](references/quickstart.md) |
+| Get stock/option/future quotes, K-lines | [quote.md](references/quote.md) |
+| Place/modify/cancel orders, check positions/assets | [trade.md](references/trade.md) |
+| Real-time streaming data via WebSocket | [push.md](references/push.md) |
+| Account info, assets, fund transfer, deposit/withdrawal | [account.md](references/account.md) |
+| Option chain, Greeks, expirations, multi-leg orders | [option.md](references/option.md) |
+
+## Common Symbols / 常见标的速查
+
+### 港股 HK
+
+| 常见称呼 | 代码 Symbol |
+|---------|------------|
+| 腾讯 | 00700 |
+| 阿里巴巴 | 09988 |
+| 美团 | 03690 |
+| 小米 | 01810 |
+
+### 美股 US
+
+| 常见称呼 | 代码 Symbol |
+|---------|------------|
+| 苹果 / Apple | AAPL |
+| 特斯拉 / Tesla | TSLA |
+| 英伟达 / NVIDIA | NVDA |
+| 微软 / Microsoft | MSFT |
+| 谷歌 / Google | GOOGL |
+| 亚马逊 / Amazon | AMZN |
+| Meta | META |
+| 老虎证券 / TIGR | TIGR |
+| 标普500 ETF / SPY | SPY |
+| 纳指 ETF / QQQ | QQQ |

--- a/.claude/skills/tigeropen-typescript/references/account.md
+++ b/.claude/skills/tigeropen-typescript/references/account.md
@@ -1,0 +1,240 @@
+
+# Tiger OpenAPI TypeScript SDK — 账户管理 / Account Management
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/accounts
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/dist/esm/client/http-client.js';
+import { TradeClient } from 'tigeropen/dist/esm/trade/trade-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+
+const httpClient = new HttpClient(config);
+const tc = new TradeClient(httpClient, config.account);
+```
+
+---
+
+## 账户列表 / Account List
+
+```typescript
+// 不传 account 返回所有账号（综合、环球、模拟）
+// Omit account to return all accounts
+const result = await tc.accounts({});
+console.log(result);
+
+// 返回字段 / Response fields:
+// account     - 账户号（综合5~10位数字，模拟17位，环球以U开头）
+// capability  - CASH / RegTMargin / PMGRN
+// status      - Funded / Open / Pending / Rejected / Closed
+// accountType - STANDARD / GLOBAL / PAPER
+```
+
+---
+
+## 账户资产 / Account Assets
+
+### 环球账户 / Global Account
+
+```typescript
+const result = await tc.assets({
+  account: 'DU000001',
+  segment: true,       // 按证券/期货分类
+  market_value: true   // 按市场分市值（仅环球账户）
+});
+
+// 主要返回字段 / Key response fields:
+// netLiquidation  - 净清算值
+// availableFunds  - 可用资金
+// buyingPower     - 购买力
+// cashValue       - 现金
+// initMarginReq   - 初始保证金要求
+// maintMarginReq  - 维持保证金要求
+// unrealizedPnl   - 浮动盈亏
+// realizedPnl     - 已实现盈亏
+// segments        - 按交易品种（S=证券, C=期货）分类
+// marketValues    - 按市场（USD/HKD）分类
+```
+
+### 综合/模拟账号 / Standard/Paper Account
+
+```typescript
+const result = await tc.primeAssets({
+  account: '123456',
+  base_currency: 'USD',
+  consolidated: true   // SEC+FUND聚合显示
+});
+
+// segments 数组主要字段 / Segment key fields:
+// category              - S（证券）/ C（期货）/ F（基金）/ D（数字货币）
+// capability            - RegTMargin / Cash
+// buyingPower           - 最大购买力（保证金账户日内4倍，隔夜2倍）
+// cashAvailableForTrade - 可用资金
+// cashBalance           - 现金余额
+// netLiquidation        - 净清算值
+// initMargin            - 初始保证金
+// maintainMargin        - 维持保证金（低于此值会强平）
+// unrealizedPL          - 浮动盈亏
+// currencyAssets        - 按币种（USD/HKD/SGD/CNH）细分
+```
+
+---
+
+## 账户持仓 / Account Positions
+
+```typescript
+const result = await tc.positions({
+  account: '123456',
+  sec_type: 'STK',   // STK/OPT/FUT，默认STK
+  currency: 'ALL',   // ALL/USD/HKD/CNH
+  market: 'ALL'      // ALL/US/HK/CN
+});
+
+if (Array.isArray(result)) {
+  result.forEach(pos => {
+    console.log(`${pos.symbol}: qty=${pos.positionQty}, pnl=${pos.unrealizedPnl}`);
+  });
+}
+
+// 主要持仓字段 / Key position fields:
+// symbol        - 股票代码
+// positionQty   - 持仓数量
+// averageCost   - 平均成本（FIFO）
+// marketValue   - 市值
+// unrealizedPnl - 浮动盈亏
+// secType       - 证券类型
+// market        - 市场
+// currency      - 币种
+```
+
+### 期权持仓 / Option Positions
+
+```typescript
+const result = await tc.positions({
+  account: '123456',
+  sec_type: 'OPT'
+});
+// 期权持仓额外字段 / Option-specific fields:
+// strike - 行权价, expiry - 到期日, right - CALL/PUT
+```
+
+---
+
+## 历史资产分析 / Asset Analytics (PnL History)
+
+```typescript
+const result = await tc.primeAnalyticsAsset({
+  account: '123456',
+  start_date: '2024-01-01',
+  end_date: '2024-01-31',
+  seg_type: 'SEC',   // SEC / FUT
+  currency: 'USD'
+});
+
+// summary 字段 / Summary fields:
+// pnl                - 盈亏金额
+// pnlPercentage      - 收益率
+// annualizedReturn   - 年化收益率
+
+// history 数组每项字段 / History item fields:
+// date               - 日期时间戳（毫秒）
+// asset              - 总资产
+// pnl                - 当日盈亏
+// cashBalance        - 现金余额
+// grossPositionValue - 持仓市值
+// deposit            - 入金
+// withdrawal         - 出金
+```
+
+---
+
+## 最大可交易数量 / Estimate Tradable Quantity
+
+```typescript
+const result = await tc.estimateTradableQuantity({
+  account: '123456',
+  symbol: 'AAPL',
+  sec_type: 'STK',
+  action: 'BUY',
+  order_type: 'LMT',
+  limit_price: 150.0
+});
+
+console.log(`Can buy: ${result?.tradableQuantity} shares`);
+
+// 返回字段 / Response fields:
+// tradableQuantity          - 现金可买/卖数量
+// financingQuantity         - 融资融券可买/卖数量
+// positionQuantity          - 持仓数量
+// tradablePositionQuantity  - 持仓可交易数量
+```
+
+---
+
+## 资金转账（Segment 间）/ Segment Fund Transfer
+
+### 查询可转出金额 / Query Available Amount
+
+```typescript
+const result = await tc.segmentFundAvailable({
+  account: '123456',
+  from_segment: 'SEC',   // SEC / FUT
+  currency: 'USD'
+});
+// 返回 fromSegment, currency, amount
+```
+
+### 发起转账 / Transfer
+
+```typescript
+const result = await tc.segmentFundTransfer({
+  account: '123456',
+  from_segment: 'SEC',
+  to_segment: 'FUT',
+  currency: 'USD',
+  amount: 1000.0
+});
+// 转账状态 status: NEW / PROC / SUCC / FAIL / CANC
+```
+
+---
+
+## 出入金记录 / Deposit & Withdrawal Records
+
+```typescript
+const result = await tc.depositWithdraw({
+  account: '123456'
+});
+
+if (Array.isArray(result)) {
+  result.forEach(r => {
+    console.log(`${r.typeDesc}: ${r.currency} ${r.amount} on ${r.businessDate}`);
+  });
+}
+
+// 每条记录字段 / Record fields:
+// type         - 1(入金) / 3(出金) / 20(出金费用) 等
+// typeDesc     - 类型描述
+// currency     - 币种
+// amount       - 金额
+// businessDate - 业务日期
+// completedStatus - 是否完成
+```
+
+---
+
+## 注意事项 / Notes
+
+- 环球账户(Global)用 `assets()`，综合/模拟账户(Standard/Paper)用 `primeAssets()`
+- Segment 分类：S=证券, C=期货, F=基金, D=数字货币
+- 持仓使用 `positionQty` 字段，旧字段 `position`+`positionScale` 已废弃
+- `maintainMargin` 低于 0 时会触发强制平仓
+- 机构用户额外传 `secret_key` 字段
+- 所有方法均为 async，需要 `await`
+- 子路径导入需使用 `tigeropen/dist/esm/...` 路径（参见 quickstart.md）

--- a/.claude/skills/tigeropen-typescript/references/option.md
+++ b/.claude/skills/tigeropen-typescript/references/option.md
@@ -1,0 +1,429 @@
+
+# Tiger OpenAPI TypeScript SDK — 期权 / Options Trading
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/quote-option
+
+## 期权操作工作流 / Option Workflow
+
+当用户提到期权时，按以下流程操作 / When user mentions options, follow this workflow:
+
+### 查询期权 / Query Options
+
+1. **查到期日 Get expirations**: `qc.optionExpirations()` → 获取可选到期日列表
+2. **查期权链 Get chain**: `qc.optionChain()` → 获取指定到期日的所有合约
+3. **查行情 Get quotes**: `qc.optionBriefs()` → 获取期权实时行情和 Greeks
+
+### 港股期权特殊处理 / HK Option Special Handling
+
+- 港股期权标的代码不同于正股 / HK option underlyings differ from stock codes: `00700` → `TCH`（腾讯）
+- 使用 `qc.optionSymbols()` 查询港股期权代码映射
+
+---
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/dist/esm/client/http-client.js';
+import { QuoteClient } from 'tigeropen/dist/esm/quote/quote-client.js';
+import { TradeClient } from 'tigeropen/dist/esm/trade/trade-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+
+const httpClient = new HttpClient(config);
+const qc = new QuoteClient(httpClient);
+const tc = new TradeClient(httpClient, config.account);
+```
+
+---
+
+## 期权到期日 / Option Expirations
+
+```typescript
+const result = await qc.optionExpirations({
+  symbols: ['AAPL'],
+  market: 'US',   // 'US' | 'HK'
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// symbol     - 股票代码
+// count      - 到期日数量
+// dates      - 到期日数组 (e.g. "2024-06-28")
+// timestamps - 到期日时间戳数组（毫秒，纽约时间）
+// periodTags - 周期标签: "m"=月期权, "w"=周期权, "q"=季度
+```
+
+---
+
+## 期权链 / Option Chain
+
+```typescript
+const result = await qc.optionChain({
+  symbol: 'AAPL',
+  expiry: '2025-08-29',
+  market: 'US',
+  returnGreekValue: true,   // 返回希腊字母 / Return Greeks
+  // 可选筛选 / Optional filters:
+  // inTheMoney: true,
+  // impliedVolatilityMin: 0.15,
+  // impliedVolatilityMax: 0.80,
+  // deltaMin: 0.2,
+  // deltaMax: 0.8,
+  // openInterestMin: 100,
+});
+console.log(result);
+
+// 返回字段 / Response fields (items[].call / items[].put):
+// identifier   - 期权完整代码 (e.g. "AAPL  250829C00150000")
+// strike       - 行权价
+// right        - "CALL" / "PUT"
+// askPrice     - 卖价
+// bidPrice     - 买价
+// latestPrice  - 最新价
+// volume       - 成交量
+// openInterest - 持仓量
+// impliedVol   - 隐含波动率
+// delta/gamma/theta/vega/rho - 希腊字母（需 returnGreekValue=true）
+```
+
+---
+
+## 港股期权代码映射 / HK Option Symbol Mapping
+
+```typescript
+const result = await qc.optionSymbols({
+  market: 'HK',
+  lang: 'en_US',   // 'en_US' | 'zh_CN' | 'zh_TW'
+});
+
+if (Array.isArray(result)) {
+  // 查找腾讯 / Find Tencent (00700 -> TCH.HK)
+  const tencent = result.find(s => s.underlyingSymbol === '00700');
+  console.log(`Option symbol: ${tencent?.symbol}`);
+}
+
+// 返回字段 / Response fields:
+// symbol           - 期权 symbol (e.g. "TCH.HK")
+// name             - 标的名称
+// underlyingSymbol - 正股代码 (e.g. "00700")
+```
+
+---
+
+## 期权实时行情 / Option Brief (Real-time Quotes)
+
+```typescript
+const result = await qc.optionBriefs({
+  market: 'US',
+  optionBasic: [
+    {
+      symbol: 'AAPL',
+      right: 'CALL',
+      expiry: '2025-08-29',   // yyyy-MM-dd
+      strike: '150.0',         // 小数位须和期权链一致
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// identifier    - 期权完整代码
+// symbol        - 标的代码
+// bidPrice/askPrice/latestPrice
+// volume/openInterest
+// high/low/open/preClose
+// change        - 涨跌额
+// midPrice      - 中间价
+// markPrice     - 标记价格
+// sellingReturn - 卖出年化收益率
+```
+
+---
+
+## 期权深度行情 / Option Depth Quotes
+
+```typescript
+const result = await qc.optionDepth({
+  market: 'US',
+  optionBasic: [
+    {
+      symbol: 'AAPL',
+      right: 'PUT',
+      expiry: '2024-06-28',
+      strike: '210.0',
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// ask[]/bid[] - 卖/买盘挂单列表
+//   price    - 委托价
+//   volume   - 委托量
+//   code     - 交易所代码 (CBOE, PHLX 等)
+//   timestamp - 交易所时间
+```
+
+---
+
+## 期权逐笔成交 / Option Trade Ticks
+
+```typescript
+// 仅支持美股期权 / US market only
+
+const result = await qc.optionTradeTicks({
+  optionBasic: [
+    {
+      symbol: 'AAPL',
+      right: 'PUT',
+      expiry: '2024-03-08',
+      strike: '185.0',
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// items[] - 逐笔成交列表
+//   price  - 成交价
+//   volume - 成交量
+//   time   - 成交时间（毫秒）
+```
+
+---
+
+## 期权K线 / Option K-line
+
+```typescript
+const result = await qc.optionKline({
+  market: 'US',
+  optionQuery: [
+    {
+      symbol: 'AAPL',
+      right: 'CALL',
+      expiry: '2024-06-28',
+      strike: '170.0',
+      beginTime: '2024-06-26',
+      endTime: '2024-06-26 23:59:59',
+      period: '1min',   // 'day' | '1min' | '5min' | '30min' | '60min'
+      limit: 10,
+      sortDir: 'DESC',
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// items[] - K线数据点列表
+//   open/high/low/close - 开高低收
+//   volume              - 成交量
+//   time                - 时间戳（毫秒）
+//   openInterest        - 持仓量（仅日K线）
+```
+
+---
+
+## 期权分时数据 / Option Timeline
+
+```typescript
+// 目前仅支持港股期权 / HK market only currently
+
+const result = await qc.optionTimeline({
+  market: 'HK',
+  optionList: [
+    {
+      symbol: 'ALB.HK',
+      right: 'CALL',
+      expiry: 1753878054000,   // 毫秒时间戳
+      strike: '117.50',
+    },
+  ],
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// preClose   - 昨日收盘价
+// minutes[]  - 分时数据点
+//   price    - 最新价
+//   avgPrice - 均价
+//   volume   - 成交量
+//   time     - 时间戳（毫秒）
+```
+
+---
+
+## 期权分析 / Option Analysis
+
+```typescript
+const result = await qc.optionAnalysis({
+  symbols: [
+    {
+      symbol: 'AAPL',
+      period: '52week',   // '3year' | '52week' | '26week' | '13week'
+      requireVolatilityList: true,   // 返回IV/HV历史时序
+    },
+  ],
+  market: 'US',
+});
+console.log(result);
+
+// 返回字段 / Response fields:
+// symbol           - 标的代码
+// impliedVol30Days - 30日隐含波动率
+// hisVolatility    - 历史波动率（30天）
+// ivHisVRatio      - IV/HV 比率
+// callPutRatio     - Call/Put 比率
+// impliedVolMetric:
+//   percentile  - IV百分位（0%-100%）
+//   rank        - IV排名（0-1）
+//   period      - 分析周期
+```
+
+---
+
+## 期权指标计算 / Option Indicator Calculation
+
+```typescript
+// 查询单个期权的盘中实时指标（Greeks、IV、杠杆等）
+const result = await qc.optionIndicator({
+  symbol: 'BABA',
+  right: 'CALL',
+  strike: '205.0',
+  expiry: '2019-11-01',   // yyyy-MM-dd
+});
+console.log(`delta: ${result?.delta}, iv: ${result?.volatility}%`);
+
+// 返回字段 / Response fields:
+// delta/gamma/theta/vega/rho - 希腊字母
+// insideValue      - 内在价值
+// timeValue        - 时间价值
+// leverage         - 杠杆率
+// openInterest     - 未平仓量
+// historyVolatility - 历史波动率（百分比，如24.38表示24.38%）
+// volatility       - 隐含波动率（百分比）
+// premiumRate      - 溢价率（百分比）
+// profitRate       - 买入盈利率（百分比）
+```
+
+---
+
+## 单腿期权下单 / Single-leg Option Order
+
+```typescript
+// 买入看涨期权 / Buy call option
+const result = await tc.placeOrder({
+  account: config.account,
+  contract: {
+    symbol: 'AAPL',
+    secType: 'OPT',
+    expiry: '20250829',   // YYYYMMDD
+    strike: 150.0,
+    right: 'CALL',
+    currency: 'USD',
+  },
+  action: 'BUY',
+  orderType: 'LMT',
+  limitPrice: 5.0,
+  quantity: 1,             // 1张 = 100股
+});
+console.log(`order id: ${result?.id}, status: ${result?.status}`);
+```
+
+---
+
+## 多腿组合策略 / Multi-leg Combo Strategies
+
+```typescript
+// 牛市看涨价差 / Bull Call Spread (VERTICAL)
+const result = await tc.placeComboOrder({
+  account: config.account,
+  comboType: 'VERTICAL',
+  action: 'BUY',
+  orderType: 'LMT',
+  limitPrice: 3.0,
+  quantity: 1,
+  legs: [
+    {
+      symbol: 'AAPL',
+      secType: 'OPT',
+      expiry: '20250829',
+      strike: 145.0,
+      right: 'CALL',
+      action: 'BUY',
+      ratio: 1,
+    },
+    {
+      symbol: 'AAPL',
+      secType: 'OPT',
+      expiry: '20250829',
+      strike: 155.0,
+      right: 'CALL',
+      action: 'SELL',
+      ratio: 1,
+    },
+  ],
+});
+```
+
+### 其他策略示例 / Other Strategy Examples
+
+```typescript
+// 跨式策略 / Straddle — comboType: 'STRADDLE'，同行权价 Call+Put
+// Iron Condor — comboType: 'CUSTOM'，4腿：Put spread + Call spread
+// 备兑策略 / Covered Call — comboType: 'COVERED'
+//   Leg1: secType='STK', action='BUY', ratio=100
+//   Leg2: secType='OPT', action='SELL', ratio=1
+```
+
+### 组合策略类型总览 / Combo Strategy Types
+
+| comboType | 策略 Strategy | 说明 Description |
+|-----------|--------------|-----------------|
+| `VERTICAL` | 垂直价差 | 同到期日不同行权价 Same expiry, different strikes |
+| `STRADDLE` | 跨式 | 同行权价同到期日 Call+Put, same strike & expiry |
+| `STRANGLE` | 宽跨式 | 不同行权价同到期日 Different strikes, same expiry |
+| `CALENDAR` | 日历价差 | 同行权价不同到期日 Same strike, different expiries |
+| `DIAGONAL` | 对角线价差 | 不同行权价不同到期日 Different strikes & expiries |
+| `COVERED` | 备兑 | 持有股票+卖Call Long stock + short call |
+| `PROTECTIVE` | 保护性 | 持有股票+买Put Long stock + long put |
+| `SYNTHETIC` | 合成 | 合成多/空头 Synthetic long/short |
+| `CUSTOM` | 自定义 | 4条腿组合（Iron Condor等） |
+
+---
+
+## 查询期权持仓 / Query Option Positions
+
+```typescript
+const result = await tc.positions({
+  account: config.account,
+  sec_type: 'OPT',
+});
+
+if (Array.isArray(result)) {
+  result.forEach(pos => {
+    console.log(`${pos.symbol} ${pos.expiry} ${pos.strike} ${pos.right}: `
+      + `qty=${pos.positionQty}, pnl=${pos.unrealizedPnl}`);
+  });
+}
+
+// 期权持仓额外字段 / Option-specific position fields:
+// strike - 行权价
+// expiry - 到期日
+// right  - CALL/PUT
+```
+
+---
+
+## 注意事项 / Notes
+
+- 港股期权需先用 `optionSymbols()` 获取代码映射 / HK options require symbol mapping
+- 期权每张合约通常代表100股标的 / Each contract = 100 shares
+- 期权链返回的 Greeks 为上一交易日收盘值，盘中请用 `optionIndicator()` / Chain Greeks are from previous close
+- 行权价小数位须和期权链一致 / Strike decimals must match the option chain
+- 期权行情需要期权行情权限 / Option quotes require option quote permission
+- 所有方法均为 async，需要 `await`
+- 子路径导入需使用 `tigeropen/dist/esm/...` 路径（参见 quickstart.md）

--- a/.claude/skills/tigeropen-typescript/references/push.md
+++ b/.claude/skills/tigeropen-typescript/references/push.md
@@ -1,0 +1,155 @@
+# Tiger OpenAPI TypeScript SDK — Real-time Push / 实时推送
+
+> TypeScript SDK 实时推送 API 参考 / Push API Reference
+<!-- 当用户提到"推送"、"实时"、"订阅"、"WebSocket"、"push"、"subscribe"时 -->
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { PushClient } from 'tigeropen/dist/esm/push/push-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+const pc = new PushClient(config);
+```
+
+---
+
+## 完整示例 / Full Example
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { PushClient } from 'tigeropen/dist/esm/push/push-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+
+const pc = new PushClient(config);
+
+// 设置回调 / Set callbacks
+// ⚠️ 订阅必须在 onConnect 回调中执行 / Subscriptions MUST be placed inside onConnect callback
+pc.setCallbacks({
+  onQuote: (data) => {
+    console.log(`[行情] ${data.symbol} 最新价: ${data.latestPrice} 量: ${data.volume}`);
+  },
+  onOrder: (data) => {
+    console.log(`[订单] ${data.symbol} 状态: ${data.status}`);
+  },
+  onAsset: (data) => {
+    console.log(`[资产] 账户: ${data.account} 净资产: ${data.netLiquidation}`);
+  },
+  onPosition: (data) => {
+    console.log(`[持仓] ${data.symbol} 数量: ${data.quantity}`);
+  },
+  onConnect: () => {
+    console.log('推送连接成功');
+    // ⚠️ 在此处执行订阅 / Subscribe here after connection established
+    // 重连后订阅不会自动恢复，需在此重新订阅 / Subscriptions NOT auto-restored on reconnect
+    pc.subscribeQuote(['AAPL', 'TSLA']);
+    pc.subscribeAsset();
+    pc.subscribeOrder();
+    pc.subscribePosition();
+  },
+  onDisconnect: () => console.log('推送连接断开'),
+  onError: (err) => console.error('推送错误:', err),
+});
+
+// 连接 / Connect
+await pc.connect();
+
+// 等待退出 / Keep running
+process.on('SIGINT', () => {
+  pc.unsubscribeQuote(['AAPL', 'TSLA']);
+  pc.disconnect();
+  process.exit(0);
+});
+```
+
+---
+
+## 回调函数 / Callbacks
+
+| 回调 Callback | 触发时机 | 数据类型 |
+|--------------|---------|---------|
+| `onQuote` | 行情更新时 | `QuoteData` |
+| `onOrder` | 订单状态变化时 | `OrderData` |
+| `onAsset` | 账户资产变动时 | `AssetData` |
+| `onPosition` | 持仓变动时 | `PositionData` |
+| `onConnect` | WebSocket 连接成功时 | - |
+| `onDisconnect` | 连接断开时 | - |
+| `onError` | 发生错误时 | `Error` |
+
+---
+
+## 订阅方法 / Subscribe Methods
+
+```typescript
+// 行情订阅 / Quote subscription
+pc.subscribeQuote(['AAPL', 'TSLA', '00700']);
+pc.unsubscribeQuote(['TSLA']);
+
+// 账户推送 / Account push
+pc.subscribeAsset();       // 资产变动
+pc.subscribeOrder();       // 订单状态
+pc.subscribePosition();    // 持仓变动
+pc.unsubscribeAsset();
+pc.unsubscribeOrder();
+pc.unsubscribePosition();
+
+// 断开连接 / Disconnect
+pc.disconnect();
+```
+
+---
+
+## QuoteData 字段 / QuoteData Fields
+
+| 字段 Field | 说明 |
+|-----------|------|
+| `symbol` | 标的代码 |
+| `latestPrice` | 最新价 |
+| `volume` | 成交量 |
+| `askPrice` | 卖一价 |
+| `bidPrice` | 买一价 |
+| `change` | 涨跌额 |
+| `changeRatio` | 涨跌幅 |
+| `timestamp` | 时间戳（毫秒） |
+
+---
+
+## AssetData 字段 / AssetData Fields
+
+| 字段 Field | 说明 |
+|-----------|------|
+| `account` | 账户号 |
+| `netLiquidation` | 净资产 |
+| `cashBalance` | 现金余额 |
+| `buyingPower` | 购买力 |
+| `currency` | 计价货币 |
+
+---
+
+## PositionData 字段 / PositionData Fields
+
+| 字段 Field | 说明 |
+|-----------|------|
+| `account` | 账户号 |
+| `symbol` | 标的代码 |
+| `quantity` | 持仓数量 |
+| `averageCost` | 平均成本 |
+| `marketPrice` | 最新价格 |
+| `marketValue` | 市值 |
+| `unrealizedPnl` | 浮动盈亏 |
+
+---
+
+## 注意事项 / Notes
+
+- **在 `onConnect` 回调中执行订阅**，连接成功后才能订阅
+- SDK 自动处理断线重连，无需手动重连
+- ⚠️ **断线重连后订阅不会自动恢复**，必须在 `onConnect` 回调中重新订阅 / Subscriptions NOT auto-restored after reconnect; re-subscribe in `onConnect`
+- 心跳保活由 SDK 自动维护
+- 同一个 `PushClient` 实例只能有一个活跃连接

--- a/.claude/skills/tigeropen-typescript/references/quickstart.md
+++ b/.claude/skills/tigeropen-typescript/references/quickstart.md
@@ -1,0 +1,156 @@
+# Tiger OpenAPI TypeScript SDK — Quickstart
+
+> TypeScript SDK 快速入门 / Quick Start for TypeScript SDK
+> npm: https://www.npmjs.com/package/tigeropen
+
+## 安装 / Installation
+
+```bash
+npm install tigeropen
+# 或 / or
+yarn add tigeropen
+# 或 / or
+pnpm add tigeropen
+```
+
+要求 / Requirements: Node.js 16+，支持 ESM 和 CommonJS
+
+---
+
+## 配置 / Configuration
+
+### 方式一：代码直接设置 / Method 1: Direct config
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+
+const config = createClientConfig({
+  tigerId: 'your_tiger_id',
+  privateKey: 'your_rsa_private_key',   // PEM 格式私钥字符串
+  account: 'your_account',
+});
+```
+
+### 方式二：从 properties 文件加载 / Method 2: Properties file
+
+```typescript
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+```
+
+配置文件格式 / Config file format:
+```properties
+tiger_id=your_tiger_id
+private_key=your_rsa_private_key
+account=your_account
+```
+
+### 方式三：环境变量 / Method 3: Environment variables
+
+```bash
+export TIGEROPEN_TIGER_ID=your_tiger_id
+export TIGEROPEN_PRIVATE_KEY=your_rsa_private_key
+export TIGEROPEN_ACCOUNT=your_account
+```
+
+> 优先级：环境变量 > 代码设置 > properties 文件
+
+### 配置项说明 / Config Options
+
+| 配置项 | 说明 | 必填 | 默认值 |
+|--------|------|------|--------|
+| `tigerId` | 开发者 ID | ✅ | - |
+| `privateKey` | RSA 私钥 PEM 字符串 | ✅ | - |
+| `account` | 交易账户号 | - | - |
+| `propertiesFilePath` | .properties 文件路径 | - | - |
+| `language` | `zh_CN` / `en_US` | - | `zh_CN` |
+| `timeout` | 请求超时（秒） | - | 15 |
+| `sandboxDebug` | 使用沙箱环境 | - | `false` |
+
+---
+
+## 客户端创建 / Create Clients
+
+```typescript
+// ⚠️ 包只导出根路径，子路径导入需指定 dist 路径 / Package only exports root, sub-path imports need dist paths
+import { createClientConfig } from 'tigeropen';
+// ESM sub-path imports (tigeropen@0.1.0 doesn't expose sub-path exports):
+import { HttpClient } from 'tigeropen/dist/esm/client/http-client.js';
+import { QuoteClient } from 'tigeropen/dist/esm/quote/quote-client.js';
+import { TradeClient } from 'tigeropen/dist/esm/trade/trade-client.js';
+import { PushClient } from 'tigeropen/dist/esm/push/push-client.js';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+
+const httpClient = new HttpClient(config);
+
+const qc = new QuoteClient(httpClient);                 // 行情客户端
+const tc = new TradeClient(httpClient, config.account); // 交易客户端
+const pc = new PushClient(config);                      // 推送客户端
+```
+
+> ⚠️ **注意 / Note**: `tigeropen@0.1.0` 包 `exports` 字段仅暴露根路径 `.`，`tigeropen/client/http-client` 等子路径会报 `ERR_PACKAGE_PATH_NOT_EXPORTED` 错误。需直接使用 `tigeropen/dist/esm/...` 路径。CJS 环境同理使用 `tigeropen/dist/cjs/...`。
+
+---
+
+## ESM 和 CommonJS / ESM and CommonJS
+
+```typescript
+// ESM (see note above about sub-path exports)
+import { createClientConfig } from 'tigeropen';
+import { QuoteClient } from 'tigeropen/dist/esm/quote/quote-client.js';
+
+// CommonJS
+const { createClientConfig } = require('tigeropen');
+const { QuoteClient } = require('tigeropen/dist/cjs/quote/quote-client.js');
+```
+
+---
+
+## 通用 API 调用 / Generic API Call
+
+当 SDK 未封装某个 API 时：
+
+```typescript
+const resp = await httpClient.execute(
+  'market_state',
+  JSON.stringify({ market: 'US' })
+);
+console.log(resp);
+```
+
+---
+
+## 错误处理 / Error Handling
+
+```typescript
+try {
+  const data = await qc.getBrief(['AAPL']);
+  console.log(data);
+} catch (error) {
+  if (error instanceof Error) {
+    console.error('API 错误:', error.message);
+  }
+}
+```
+
+---
+
+## 前置条件 / Prerequisites
+
+1. 老虎证券账户 + 开发者 API 权限：https://developer.itigerup.com/
+2. 准备好 `tigerId`、RSA 私钥、`account`
+3. 行情数据需要对应的行情权限；期权行情需要期权行情权限
+
+---
+
+## FAQ
+
+**Q: 私钥如何生成?**
+参考官方文档 https://docs.itigerup.com/docs/prepare，使用 RSA-2048 生成密钥对，上传公钥到开发者后台。
+
+**Q: 模拟账户和实盘账户区别?**
+模拟账户在开发者后台申请，`sandboxDebug: true` 连接沙箱环境；实盘账户直接使用生产域名。

--- a/.claude/skills/tigeropen-typescript/references/quote.md
+++ b/.claude/skills/tigeropen-typescript/references/quote.md
@@ -1,0 +1,144 @@
+# Tiger OpenAPI TypeScript SDK — Market Data / 行情查询
+
+> TypeScript SDK 行情 API 参考 / Quote API Reference
+<!-- 当用户提到"行情"、"报价"、"K线"、"价格"、"深度"、"quote"、"kline"、"price"时 -->
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/client/http-client';
+import { QuoteClient } from 'tigeropen/quote/quote-client';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+const httpClient = new HttpClient(config);
+const qc = new QuoteClient(httpClient);
+```
+
+---
+
+## 市场状态 / Market State
+
+```typescript
+// market: 'US' / 'HK' / 'CN' / 'SG'
+const data = await qc.getMarketState('US');
+// 返回 [{market, status, openTime, closeTime, ...}]
+```
+
+---
+
+## 实时报价 / Real-time Quotes
+<!-- 当用户提到"实时报价"、"最新价"、"real-time"时 -->
+
+```typescript
+const data = await qc.getBrief(['AAPL', 'TSLA']);
+// 每个元素包含: symbol, latestPrice, askPrice, bidPrice, volume, change, changeRatio 等
+```
+
+---
+
+## K 线 / Kline
+<!-- 当用户提到"K线"、"kline"、"bar"、"日线"时 -->
+
+```typescript
+// period: 'day'/'week'/'month'/'year'/'1min'/'3min'/'5min'/'10min'/'15min'/'30min'/'60min'
+const data = await qc.getKline('AAPL', 'day');
+// 返回数组，每个元素: time, open, high, low, close, volume
+```
+
+---
+
+## 分时 / Timeline
+
+```typescript
+const data = await qc.getTimeline(['AAPL', 'TSLA']);
+// 返回分时数据: time, price, volume, avgPrice
+```
+
+---
+
+## 深度行情 / Quote Depth
+<!-- 当用户提到"买卖盘"、"深度"、"depth"时 -->
+
+```typescript
+const data = await qc.getQuoteDepth('AAPL');
+// 返回 {asks: [{price, volume},...], bids: [{price, volume},...]}
+```
+
+---
+
+## 逐笔成交 / Trade Ticks
+
+```typescript
+const data = await qc.getTradeTick(['AAPL']);
+// 返回逐笔: time, price, volume, direction
+```
+
+---
+
+## 期权到期日 / Option Expirations
+
+```typescript
+const data = await qc.getOptionExpiration('AAPL');
+// 返回到期日列表: dates, timestamps, periodTag ("m"=月度/"w"=周度)
+```
+
+---
+
+## 期权链 / Option Chain
+
+```typescript
+const data = await qc.getOptionChain('AAPL', '2025-08-29');
+// 返回 call/put 合约: identifier, strike, bid/ask, volume, openInterest, impliedVol, delta, gamma 等
+```
+
+---
+
+## 期权报价 / Option Brief
+
+```typescript
+const data = await qc.getOptionBrief(['AAPL  250829C00150000']);
+// 期权代码格式: 标的(6位右空格填充) + YYMMDD + C/P + 行权价*1000(8位)
+// 返回: identifier, strike, putCall, latestPrice, bid/ask, impliedVol, delta, gamma, theta, vega 等
+```
+
+---
+
+## 期货 / Futures
+
+```typescript
+// 获取交易所列表
+const exchanges = await qc.getFutureExchange();
+
+// 获取期货合约
+const contracts = await qc.getFutureContracts('CME');
+
+// 期货实时报价
+const data = await qc.getFutureRealTimeQuote(['CL2509']);
+```
+
+---
+
+## 直接调用 API / Raw API Call
+
+当以上方法不满足需求时：
+
+```typescript
+import { HttpClient } from 'tigeropen/client/http-client';
+
+const resp = await httpClient.execute(
+  'quote_real_time',
+  JSON.stringify({ symbols: ['AAPL', 'TSLA'] })
+);
+```
+
+---
+
+## 注意事项 / Notes
+
+- 所有方法返回 `Promise`，需 `await`
+- 行情数据需要对应市场的行情权限
+- 期权行情需要单独开通期权行情权限
+- 港股期权代码格式：`TCH.HK 230616C00550000`（与美股不同）

--- a/.claude/skills/tigeropen-typescript/references/trade.md
+++ b/.claude/skills/tigeropen-typescript/references/trade.md
@@ -1,0 +1,197 @@
+# Tiger OpenAPI TypeScript SDK — Trading / 交易
+
+> TypeScript SDK 交易 API 参考 / Trade API Reference
+<!-- 当用户提到"下单"、"买入"、"卖出"、"撤单"、"改单"、"持仓"、"资产"、"order"、"trade"时 -->
+
+## 安全规范 / Safety Rules
+
+> ⚠️ **默认使用模拟账户。Default to Paper Trading.**
+
+实盘下单前，**必须执行**以下流程：
+1. 与用户确认：标的代码、方向（买/卖）、数量、价格、账户
+2. 先调用 `previewOrder()` 查看预估佣金和保证金
+3. 用户确认后再调用 `placeOrder()`
+4. 下单后通过 `getOrders()` 确认订单状态
+
+---
+
+## 初始化 / Initialize
+
+```typescript
+import { createClientConfig } from 'tigeropen';
+import { HttpClient } from 'tigeropen/client/http-client';
+import { TradeClient } from 'tigeropen/trade/trade-client';
+
+const config = createClientConfig({
+  propertiesFilePath: 'tiger_openapi_config.properties',
+});
+const httpClient = new HttpClient(config);
+const tc = new TradeClient(httpClient, config.account);
+```
+
+---
+
+## 下单 / Place Orders
+<!-- 当用户提到"下单"、"买入"、"卖出"、"buy"、"sell"、"order"时 -->
+
+### 构造订单 / Build Order
+
+```typescript
+// 限价单 / Limit order
+const order = {
+  symbol: 'AAPL',
+  secType: 'STK',
+  action: 'BUY',
+  orderType: 'LMT',
+  totalQuantity: 100,
+  limitPrice: 150.0,
+  timeInForce: 'DAY',
+};
+
+// 市价单 / Market order
+const order = {
+  symbol: 'AAPL',
+  secType: 'STK',
+  action: 'BUY',
+  orderType: 'MKT',
+  totalQuantity: 100,
+};
+
+// 止损限价单 / Stop-limit order
+const order = {
+  symbol: 'AAPL',
+  secType: 'STK',
+  action: 'SELL',
+  orderType: 'STP_LMT',
+  totalQuantity: 100,
+  limitPrice: 145.0,   // 限价
+  auxPrice: 148.0,     // 触发价
+};
+
+// 盘后交易 / After-hours trading
+const order = {
+  symbol: 'AAPL',
+  secType: 'STK',
+  action: 'BUY',
+  orderType: 'LMT',
+  totalQuantity: 100,
+  limitPrice: 150.0,
+  outsideRth: true,   // 允许盘前盘后
+  timeInForce: 'GTC',
+};
+```
+
+### 预览订单 / Preview Order
+
+```typescript
+const preview = await tc.previewOrder(order);
+// 返回预估保证金和佣金信息
+```
+
+### 提交下单 / Submit Order
+
+```typescript
+const result = await tc.placeOrder(order);
+// 返回 {id, orderId, status: 'PendingSubmit', ...}
+```
+
+### 修改订单 / Modify Order
+
+```typescript
+const modified = { ...order, limitPrice: 155.0 };
+await tc.modifyOrder(orderId, modified);  // orderId: number
+```
+
+### 取消订单 / Cancel Order
+
+```typescript
+await tc.cancelOrder(orderId);  // orderId: number
+```
+
+---
+
+## 查询订单 / Query Orders
+<!-- 当用户提到"订单"、"委托"、"orders"时 -->
+
+```typescript
+// 所有订单 / All orders
+const orders = await tc.getOrders();
+
+// 待成交订单 / Active (pending) orders
+const active = await tc.getActiveOrders();
+
+// 已成交订单 / Filled orders
+const filled = await tc.getFilledOrders();
+
+// 已撤销订单 / Inactive (cancelled) orders
+const inactive = await tc.getInactiveOrders();
+
+// 订单成交明细 / Order transactions
+const transactions = await tc.getOrderTransactions(orderId);
+```
+
+---
+
+## 持仓查询 / Query Positions
+<!-- 当用户提到"持仓"、"仓位"、"positions"时 -->
+
+```typescript
+const positions = await tc.positions();
+// ⚠️ 返回 JSON 字符串，需手动解析 / Returns JSON string, parse manually:
+// const items = JSON.parse(positions).items;
+// 每个元素包含 / each item has:
+// symbol, secType, positionQty, averageCost, marketPrice/latestPrice, marketValue, unrealizedPnl
+```
+
+---
+
+## 资产查询 / Query Assets
+<!-- 当用户提到"资产"、"资金"、"余额"、"assets"时 -->
+
+```typescript
+// 普通账户资产 / Standard account assets
+const assets = await tc.assets();
+// ⚠️ 返回 JSON 字符串，需手动解析 / Returns JSON string, parse manually
+
+// 综合账户（Prime）资产 / Prime account assets
+const prime = await tc.primeAssets();
+// 返回: netLiquidation, cashBalance, buyingPower, unrealizedPl, initMargin, maintMargin 等
+```
+
+---
+
+## 合约查询 / Contract Query
+
+```typescript
+// 单个合约
+const contract = await tc.contract('AAPL', 'STK');
+
+// 批量合约
+const contracts = await tc.contracts(['AAPL', 'TSLA'], 'STK');
+
+// secType: 'STK'(股票)/'OPT'(期权)/'FUT'(期货)/'CASH'(外汇)
+```
+
+---
+
+## 订单字段说明 / Order Fields
+
+| 字段 | 类型 | 说明 |
+|-----|------|------|
+| `symbol` | string | 标的代码，如 `'AAPL'` |
+| `secType` | string | `'STK'` / `'OPT'` / `'FUT'` |
+| `action` | string | `'BUY'` / `'SELL'` |
+| `orderType` | string | `'LMT'` / `'MKT'` / `'STP'` / `'STP_LMT'` |
+| `totalQuantity` | number | 数量 |
+| `limitPrice` | number | 限价（LMT/STP_LMT 必填） |
+| `auxPrice` | number | 止损价（STP/STP_LMT 必填） |
+| `timeInForce` | string | `'DAY'` / `'GTC'` / `'GTD'` |
+| `outsideRth` | boolean | 是否允许盘前盘后交易 |
+
+---
+
+## 注意事项 / Notes
+
+- `placeOrder()` 返回成功仅表示订单**已提交**，不代表已成交
+- 需通过 `getOrders()` 或推送回调确认最终成交状态
+- 期权下单需先通过 `qc.getOptionChain()` 获取 identifier，并设置 `expiry`/`strike`/`right` 字段

--- a/.claude/skills/tigeropen/SKILL.md
+++ b/.claude/skills/tigeropen/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: tigeropen
+description: |
+  Tiger Brokers OpenAPI Python SDK — complete skills for AI coding tools. Covers SDK setup, market data queries, stock/futures/options trading, real-time push subscriptions, CLI command-line tool, and MCP server integration. Use when building trading applications, querying market data, placing orders, using the tigeropen CLI, or integrating Tiger Brokers API with AI editors.
+  老虎证券 OpenAPI Python SDK 完整技能集。涵盖 SDK 配置、行情查询、股票/期货/期权交易、实时推送订阅、CLI 命令行工具、MCP Server 集成。适用于构建交易应用、查询行情数据、下单交易、使用 tigeropen CLI、或将老虎 API 集成到 AI 编辑器。
+  用户提到以下关键词时自动使用 / Auto-activate on these keywords: 行情、报价、价格、K线、快照、买卖盘、深度、买入、卖出、下单、撤单、改单、交易、持仓、资金、账户、订单、委托、期权、期权链、到期日、期货、推送、订阅、选股、筛选、tigeropen、tiger API、quote、price、K-line、order、buy、sell、trade、position、asset、account、option、future、push、scanner
+license: Apache-2.0
+compatibility: Requires Python 3.8+, pip, and a Tiger Brokers developer account
+metadata:
+  author: tigerbrokers
+  version: "3.5.6"
+  language: zh_CN, en_US
+  openclaw:
+    requires:
+      env:
+        - TIGEROPEN_TIGER_ID
+        - TIGEROPEN_PRIVATE_KEY
+        - TIGEROPEN_ACCOUNT
+      bins:
+        - pip
+        - python
+    primaryEnv: TIGEROPEN_TIGER_ID
+---
+
+# Tiger Open API Python SDK
+
+> 老虎量化开放平台 Python SDK 完整技能集 / Complete AI skill set for Tiger Brokers OpenAPI
+
+> **安全警告 / Safety Warning**: 交易涉及真实资金。生成交易代码时默认使用**模拟账户**（Paper Trading），除非用户明确要求实盘。实盘下单前必须与用户确认订单详情。
+> Trading involves real money. Default to **Paper Trading** account when generating trading code unless the user explicitly requests live trading. Always confirm order details with the user before live orders.
+
+- Docs: https://docs.itigerup.com/docs/prepare
+- GitHub: https://github.com/tigerfintech/openapi-python-sdk
+- SDK: `pip install tigeropen` | Python 3.8 - 3.14
+
+## Language Rules / 语言规则
+
+根据用户输入语言自动回复。用户使用英文提问则用英文回复，使用中文提问则用中文回复。技术术语（代码、API 名称、参数名）保持原文不翻译。
+Reply in the user's language. Keep technical terms (code, API names, parameters) as-is.
+
+## Reference Guides
+
+This skill is organized into focused reference files. Load the relevant guide based on your task:
+
+- **[Quickstart](references/quickstart.md)** — SDK install, authentication, client setup, enums/objects, error codes, FAQ
+- **[Market Data](references/quote.md)** — Real-time quotes, K-lines, depth, ticks, capital flow, fundamentals, scanner
+- **[Trading](references/trade.md)** — Place orders (market/limit/stop/algo), order management, assets, positions, fund transfers
+- **[Options](references/option.md)** — Option chains, Greeks, single-leg/multi-leg combos, option calculator
+- **[Real-time Push](references/push.md)** — Subscribe to quote/depth/tick/K-line/order/position/asset changes via PushClient
+- **[CLI Tool](references/cli.md)** — Command-line interface: config, quote, trade, account, push commands with table/json/csv output
+- **[MCP Server](references/mcp.md)** — Expose Tiger API as MCP tools for Cursor, Claude Code, Kiro, Trae
+
+## Quick Start
+
+```python
+from tigeropen.common.consts import Language, Market
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.common.util.signature_utils import read_private_key
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.trade.trade_client import TradeClient
+
+# 1. Configure / 配置
+# 方式一：配置文件(推荐) / Method 1: Config file (recommended)
+config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+
+# 方式二：代码赋值 / Method 2: Code assignment
+# config = TigerOpenClientConfig()
+# config.tiger_id = 'your_tiger_id'
+# config.private_key = read_private_key('/path/to/your_private_key.pem')
+# config.account = 'your_account'
+# config.language = Language.en_US
+
+# 2. Query quotes / 查询行情
+quote_client = QuoteClient(config)
+quote = quote_client.get_market_status(Market.US)
+
+# 3. Place order / 下单
+trade_client = TradeClient(config)
+# See references/trade.md for order examples
+```
+
+## When to Use Each Reference
+
+| Task | Reference |
+|------|-----------|
+| First time setup, SDK install, auth config | [quickstart.md](references/quickstart.md) |
+| Get stock/option/future quotes, K-lines, screener | [quote.md](references/quote.md) |
+| Place/modify/cancel orders, check positions/assets | [trade.md](references/trade.md) |
+| Option chains, Greeks, combo strategies | [option.md](references/option.md) |
+| Real-time streaming data via WebSocket | [push.md](references/push.md) |
+| CLI commands: query data, manage orders from terminal | [cli.md](references/cli.md) |
+| Set up MCP Server for AI editor integration | [mcp.md](references/mcp.md) |
+
+## Common Symbols / 常见标的速查
+
+当用户使用中文名称或英文简称时，按下表映射。不在表中的标的根据上下文判断。
+Map user's natural language to symbols. For unlisted symbols, infer from context.
+
+### 港股 HK
+
+| 常见称呼 | 代码 Symbol |
+|---------|------------|
+| 腾讯 | 00700 |
+| 阿里巴巴、阿里 | 09988 |
+| 美团 | 03690 |
+| 小米 | 01810 |
+| 京东 | 09618 |
+| 比亚迪 | 01211 |
+| 快手 | 01024 |
+| 百度 | 09888 |
+| 网易 | 09999 |
+| 中芯国际 | 00981 |
+| MINIMAX | 00100 |
+| 智谱 | 02513 |
+
+### 美股 US
+
+| 常见称呼 | 代码 Symbol |
+|---------|------------|
+| 苹果 / Apple | AAPL |
+| 特斯拉 / Tesla | TSLA |
+| 英伟达 / NVIDIA | NVDA |
+| 微软 / Microsoft | MSFT |
+| 谷歌 / Google | GOOGL |
+| 亚马逊 / Amazon | AMZN |
+| Meta | META |
+| 台积电 / TSM | TSM |
+| AMD | AMD |
+| 老虎证券 / Tiger / TIGR | TIGR |
+| 阿里巴巴（美股）/ BABA | BABA |
+| 京东（美股）/ JD | JD |
+| 拼多多 / PDD | PDD |
+| 标普500 ETF / SPY | SPY |
+| 纳指 ETF / QQQ | QQQ |

--- a/.claude/skills/tigeropen/references/cli.md
+++ b/.claude/skills/tigeropen/references/cli.md
@@ -1,0 +1,586 @@
+
+# Tiger Open API CLI 命令行工具 / CLI Tool
+
+> 中文 | English — 双语技能，代码通用。Bilingual skill with shared code examples.
+> 官方 CLI 入口: `tigeropen` (安装 SDK 后自动可用 / Available after SDK install)
+
+## 概述 / Overview
+
+TigerOpen CLI 是基于 click 框架的命令行工具，安装 `tigeropen` SDK 后自动获得 `tigeropen` 命令。
+无需编写 Python 代码即可查询行情、管理订单、查看账户信息。
+The TigerOpen CLI is a click-based command-line tool, available automatically after installing the `tigeropen` SDK.
+Query market data, manage orders, and view account info without writing Python code.
+
+- 入口命令 Entry point: `tigeropen`
+- 安装 Install: `pip install tigeropen`
+- Python: 3.8 - 3.14
+
+---
+
+## 配置 / Configuration
+
+### 初始化配置 / Initialize Config
+
+```bash
+# 交互式配置（会引导输入 tiger_id, account, private_key）
+# Interactive setup (prompts for tiger_id, account, private_key)
+tigeropen config init
+```
+
+配置文件默认保存到 `~/.tigeropen/tiger_openapi_config.properties`。
+Config file is saved to `~/.tigeropen/tiger_openapi_config.properties` by default.
+
+### 查看配置 / Show Config
+
+```bash
+# 查看当前配置（私钥已脱敏）/ Show config (private key masked)
+tigeropen config show
+```
+
+### 修改配置 / Set Config Value
+
+```bash
+# 设置单个配置项 / Set a single config value
+tigeropen config set tiger_id your_tiger_id
+tigeropen config set account your_account
+```
+
+### 查看配置路径 / Show Config Path
+
+```bash
+tigeropen config path
+```
+
+### 指定配置目录 / Specify Config Directory
+
+```bash
+# 使用 --config-path 或 -c 指定配置文件路径（全局选项）
+# Use --config-path or -c to specify config path (global option)
+tigeropen -c /path/to/config/ quote briefs AAPL
+```
+
+---
+
+## 全局选项 / Global Options
+
+所有命令均支持以下全局选项。These global options apply to all commands.
+
+| 选项 Option | 短写 Short | 说明 Description | 默认 Default |
+|-------------|-----------|-----------------|-------------|
+| `--config-path` | `-c` | 配置文件路径 Config file path | `~/.tigeropen/` |
+| `--format` | `-f` | 输出格式 Output format: `table` / `json` / `csv` | `table` |
+| `--language` | `-l` | 语言 Language: `en_US` / `zh_CN` / `zh_TW` | `en_US` |
+| `--verbose` | `-v` | 调试日志 Enable debug logging | `false` |
+
+### 输出格式示例 / Output Format Examples
+
+```bash
+# 表格输出（默认）/ Table output (default)
+tigeropen quote briefs AAPL
+
+# JSON 输出 / JSON output
+tigeropen -f json quote briefs AAPL
+
+# CSV 输出 / CSV output
+tigeropen --format csv quote bars AAPL --limit 5
+```
+
+---
+
+## 版本 / Version
+
+```bash
+tigeropen version
+```
+
+---
+
+## 行情命令 / Quote Commands
+
+### 实时报价 / Real-time Quotes
+
+```bash
+# 获取一个或多个股票的实时行情 / Get real-time quotes for one or more symbols
+tigeropen quote briefs AAPL TSLA GOOG
+
+# 包含盘前盘后数据 / Include pre/after market data
+tigeropen quote briefs AAPL --hour-trading
+```
+
+### K 线数据 / Candlestick (Bars) Data
+
+```bash
+# 日 K 线 / Daily bars
+tigeropen quote bars AAPL
+
+# 指定周期和数量 / Specify period and limit
+tigeropen quote bars AAPL --period 5min --limit 20
+
+# 指定时间范围 / Specify time range
+tigeropen quote bars AAPL --begin-time 2026-01-01 --end-time 2026-03-01
+
+# 可选周期 / Available periods:
+# day, week, month, year, 1min, 3min, 5min, 10min, 15min, 30min, 60min
+```
+
+### 分时数据 / Intraday Timeline
+
+```bash
+# 今日分时 / Today's timeline
+tigeropen quote timeline AAPL
+
+# 指定日期 / Specific date
+tigeropen quote timeline AAPL --date 2026-03-20
+```
+
+### 逐笔成交 / Tick Data
+
+```bash
+tigeropen quote ticks AAPL
+
+# 限制条数 / Limit results
+tigeropen quote ticks AAPL --limit 50
+
+# 指定范围 / Specify range
+tigeropen quote ticks AAPL --begin-index 0 --end-index 100
+```
+
+### 盘口深度 / Order Book Depth
+
+```bash
+# --market 为必选参数 / --market is required
+tigeropen quote depth AAPL --market US
+tigeropen quote depth 00700 --market HK
+```
+
+### 市场状态 / Market Status
+
+```bash
+# 所有市场 / All markets
+tigeropen quote market-status
+
+# 指定市场 / Specific market
+tigeropen quote market-status --market US
+tigeropen quote market-status --market HK
+
+# 可选: US, HK, CN, ALL
+```
+
+### 股票列表 / Symbol List
+
+```bash
+# 美股列表 / US stock list
+tigeropen quote symbols
+
+# 港股列表 / HK stock list
+tigeropen quote symbols --market HK
+```
+
+---
+
+## 期权命令 / Option Commands
+
+```bash
+# 期权到期日列表 / Option expiration dates
+tigeropen quote option expirations AAPL
+
+# 期权链（需指定标的和到期日）/ Option chain (symbol + expiry)
+tigeropen quote option chain AAPL 2026-06-19
+
+# 期权报价（需期权标识符）/ Option quotes (by identifier)
+tigeropen quote option briefs "AAPL  260619C00150000"
+
+# 期权 K 线 / Option bars
+tigeropen quote option bars "AAPL  260619C00150000" --period day --limit 10
+```
+
+> 期权标识符格式 / Option identifier format: `SYMBOL  YYMMDDCSSSSSSSS` (C=Call, P=Put, S=Strike*1000)
+
+---
+
+## 期货命令 / Futures Commands
+
+```bash
+# 期货交易所列表 / Futures exchanges
+tigeropen quote future exchanges
+
+# 交易所合约列表 / Contracts for an exchange
+tigeropen quote future contracts CME
+
+# 期货报价 / Futures quotes
+tigeropen quote future briefs ES2606 CL2509
+
+# 期货 K 线 / Futures bars
+tigeropen quote future bars CL2509 --period day --limit 20
+```
+
+---
+
+## 资金流向 / Capital Flow
+
+```bash
+# 资金流向数据 / Capital flow
+tigeropen quote capital flow AAPL --market US --period day
+
+# 可选 period: intraday, day, week, month
+```
+
+### 资金分布 / Capital Distribution
+
+```bash
+tigeropen quote capital distribution AAPL --market US
+```
+
+---
+
+## 基本面数据 / Fundamental Data
+
+### 财务报告 / Financial Reports
+
+```bash
+# 年度营收和净利润 / Annual revenue and net income
+tigeropen quote fundamental financial AAPL --fields total_revenue,net_income
+
+# 季度数据 / Quarterly data
+tigeropen quote fundamental financial AAPL --period-type QUARTERLY
+
+# 指定时间范围 / Specify date range
+tigeropen quote fundamental financial AAPL --begin-date 2024-01-01 --end-date 2026-01-01
+
+# 可选 period-type: ANNUAL, QUARTERLY, LTM
+```
+
+### 分红数据 / Dividend Data
+
+```bash
+tigeropen quote fundamental dividend AAPL --begin-date 2024-01-01 --end-date 2026-01-01
+```
+
+### 财报日历 / Earnings Calendar
+
+```bash
+tigeropen quote fundamental earnings --begin-date 2026-03-01 --end-date 2026-03-31
+tigeropen quote fundamental earnings --market HK --begin-date 2026-03-01 --end-date 2026-03-31
+```
+
+---
+
+## 交易命令 / Trade Commands
+
+### 订单管理 / Order Management
+
+```bash
+# 订单列表 / List orders
+tigeropen trade order list
+
+# 按状态筛选 / Filter by status
+tigeropen trade order list --status Filled
+tigeropen trade order list --status Submitted
+
+# 按标的筛选 / Filter by symbol
+tigeropen trade order list --symbol AAPL
+
+# 按市场筛选 / Filter by market
+tigeropen trade order list --market US
+
+# 限制数量 / Limit results
+tigeropen trade order list --limit 20
+
+# 查看订单详情 / Order details
+tigeropen trade order get 12345678
+```
+
+### 预览订单 / Preview Order
+
+```bash
+# 预览限价买单 / Preview a limit buy order
+tigeropen trade order preview --symbol AAPL --action BUY --quantity 100 --limit-price 150
+
+# 预览市价卖单 / Preview a market sell order
+tigeropen trade order preview --symbol AAPL --action SELL --quantity 50 --order-type MKT
+
+# 可选参数 / Options:
+#   --symbol       标的代码 Symbol (required)
+#   --action       BUY/SELL (required)
+#   --quantity     数量 Quantity (required)
+#   --order-type   LMT/MKT/STP/STP_LMT (default: LMT)
+#   --limit-price  限价 Limit price (LMT/STP_LMT)
+#   --sec-type     STK/OPT/FUT (default: STK)
+```
+
+### 下单 / Place Order
+
+```bash
+# 下单（默认需要确认）/ Place order (confirmation required by default)
+tigeropen trade order place --symbol AAPL --action BUY --quantity 100 --limit-price 150
+
+# 跳过确认 / Skip confirmation
+tigeropen trade order place --symbol AAPL --action BUY --quantity 100 --limit-price 150 -y
+```
+
+> 下单前建议先 preview 预览订单。Preview order before placing.
+
+### 修改订单 / Modify Order
+
+```bash
+# 修改限价 / Modify limit price
+tigeropen trade order modify 12345678 --limit-price 155
+
+# 修改数量 / Modify quantity
+tigeropen trade order modify 12345678 --quantity 200
+
+# 修改辅助价 / Modify aux price
+tigeropen trade order modify 12345678 --aux-price 140
+
+# 跳过确认 / Skip confirmation
+tigeropen trade order modify 12345678 --limit-price 155 -y
+```
+
+### 撤销订单 / Cancel Order
+
+```bash
+# 撤销订单（需确认）/ Cancel order (confirmation required)
+tigeropen trade order cancel 12345678
+
+# 跳过确认 / Skip confirmation
+tigeropen trade order cancel 12345678 -y
+```
+
+---
+
+## 持仓命令 / Position Commands
+
+```bash
+# 所有股票持仓 / All stock positions
+tigeropen trade position list
+
+# 按证券类型 / By security type
+tigeropen trade position list --sec-type OPT
+tigeropen trade position list --sec-type FUT
+
+# 按市场 / By market
+tigeropen trade position list --market US
+tigeropen trade position list --market HK
+
+# 按标的 / By symbol
+tigeropen trade position list --symbol AAPL
+
+# 可选 sec-type: STK, OPT, FUT, WAR
+# 可选 market: US, HK, ALL
+```
+
+---
+
+## 成交记录 / Transaction Records
+
+```bash
+# 所有成交记录 / All transactions
+tigeropen trade transaction list
+
+# 按标的筛选 / Filter by symbol
+tigeropen trade transaction list --symbol AAPL
+
+# 按时间范围 / Filter by time range
+tigeropen trade transaction list --start-time 2026-01-01 --end-time 2026-03-31
+
+# 限制条数 / Limit results
+tigeropen trade transaction list --limit 50
+```
+
+---
+
+## 账户命令 / Account Commands
+
+```bash
+# 账户信息 / Account info
+tigeropen account info
+
+# 资产概览 / Asset summary
+tigeropen account assets
+
+# 按币种 / By currency
+tigeropen account assets --currency USD
+
+# 资产分析 / Asset analytics
+tigeropen account analytics
+tigeropen account analytics --start-date 2026-01-01 --end-date 2026-03-31
+```
+
+---
+
+## 推送命令 / Push Commands (Real-time Streaming)
+
+推送命令使用 WebSocket 连接，持续输出直到 Ctrl+C。
+Push commands use WebSocket connections, streaming until Ctrl+C.
+
+```bash
+# 实时行情推送 / Real-time quote streaming
+tigeropen push quote AAPL TSLA
+
+# 订单状态推送 / Order status updates
+tigeropen push order
+
+# 持仓变动推送 / Position updates
+tigeropen push position
+
+# 资产变动推送 / Asset updates
+tigeropen push asset
+```
+
+> 同一 `tiger_id` 只能有一个推送连接，新连接会踢掉旧连接。
+> Only one push connection per `tiger_id`; new connection kicks the old one.
+
+---
+
+## 命令总览 / Command Reference
+
+```
+tigeropen [全局选项 Global Options]
+├── version                             # SDK 版本 Version
+├── config                              # 配置管理 Configuration
+│   ├── init                            # 交互式配置 Interactive setup
+│   ├── show                            # 查看配置（脱敏）Show config (masked)
+│   ├── set <KEY> <VALUE>               # 设置配置项 Set config value
+│   └── path                            # 配置路径 Config path
+├── quote                               # 行情数据 Market Data
+│   ├── briefs <SYMBOLS...>             # 实时报价 Real-time quotes
+│   ├── bars <SYMBOLS...>               # K 线 Candlestick
+│   ├── timeline <SYMBOLS...>           # 分时 Intraday timeline
+│   ├── ticks <SYMBOLS...>              # 逐笔 Tick data
+│   ├── depth <SYMBOLS...>              # 盘口 Order book depth
+│   ├── market-status                   # 市场状态 Market status
+│   ├── symbols                         # 股票列表 Symbol list
+│   ├── option                          # 期权 Options
+│   │   ├── expirations <SYMBOL>        # 到期日 Expiration dates
+│   │   ├── chain <SYMBOL> <EXPIRY>     # 期权链 Option chain
+│   │   ├── briefs <IDENTIFIERS...>     # 期权报价 Option quotes
+│   │   └── bars <IDENTIFIERS...>       # 期权 K 线 Option bars
+│   ├── future                          # 期货 Futures
+│   │   ├── exchanges                   # 交易所 Exchanges
+│   │   ├── contracts <EXCHANGE>        # 合约列表 Contract list
+│   │   ├── briefs <IDENTIFIERS...>     # 期货报价 Futures quotes
+│   │   └── bars <IDENTIFIER>           # 期货 K 线 Futures bars
+│   ├── capital                         # 资金 Capital
+│   │   ├── flow <SYMBOL>               # 资金流向 Capital flow
+│   │   └── distribution <SYMBOL>       # 资金分布 Capital distribution
+│   └── fundamental                     # 基本面 Fundamental
+│       ├── financial <SYMBOLS...>      # 财务报告 Financial reports
+│       ├── dividend <SYMBOLS...>       # 分红 Dividends
+│       └── earnings                    # 财报日历 Earnings calendar
+├── trade                               # 交易 Trading
+│   ├── order                           # 订单 Orders
+│   │   ├── list                        # 订单列表 Order list
+│   │   ├── get <ORDER_ID>              # 订单详情 Order details
+│   │   ├── preview                     # 预览 Preview
+│   │   ├── place                       # 下单 Place order
+│   │   ├── modify <ORDER_ID>           # 改单 Modify order
+│   │   └── cancel <ORDER_ID>           # 撤单 Cancel order
+│   ├── position                        # 持仓 Positions
+│   │   └── list                        # 持仓列表 Position list
+│   └── transaction                     # 成交 Transactions
+│       └── list                        # 成交记录 Transaction list
+├── account                             # 账户 Account
+│   ├── info                            # 账户信息 Account info
+│   ├── assets                          # 资产 Assets
+│   └── analytics                       # 分析 Analytics
+└── push                                # 推送 Push (Streaming)
+    ├── quote <SYMBOLS...>              # 行情推送 Quote streaming
+    ├── order                           # 订单推送 Order streaming
+    ├── position                        # 持仓推送 Position streaming
+    └── asset                           # 资产推送 Asset streaming
+```
+
+---
+
+## 常用场景 / Common Workflows
+
+### 快速查看行情 / Quick Quote Check
+
+```bash
+tigeropen quote briefs AAPL TSLA GOOG --format json
+```
+
+### 查看持仓盈亏 / Check Position P&L
+
+```bash
+tigeropen trade position list --format table
+tigeropen account assets
+```
+
+### 下单完整流程 / Full Order Workflow
+
+```bash
+# 1. 查看实时行情 / Check current price
+tigeropen quote briefs AAPL
+
+# 2. 预览订单 / Preview order
+tigeropen trade order preview --symbol AAPL --action BUY --quantity 100 --limit-price 150
+
+# 3. 下单 / Place order
+tigeropen trade order place --symbol AAPL --action BUY --quantity 100 --limit-price 150
+
+# 4. 查看订单状态 / Check order status
+tigeropen trade order list --symbol AAPL --status Submitted
+
+# 5. 如需撤单 / Cancel if needed
+tigeropen trade order cancel <ORDER_ID>
+```
+
+### 导出数据 / Export Data
+
+```bash
+# 导出 K 线到 CSV 文件 / Export bars to CSV file
+tigeropen -f csv quote bars AAPL --period day --limit 100 > aapl_bars.csv
+
+# 导出持仓为 JSON / Export positions as JSON
+tigeropen -f json trade position list > positions.json
+
+# 导出成交记录 / Export transactions
+tigeropen -f csv trade transaction list --symbol AAPL > aapl_transactions.csv
+```
+
+### 实时监控 / Real-time Monitoring
+
+```bash
+# 监控行情（Ctrl+C 停止）/ Monitor quotes (Ctrl+C to stop)
+tigeropen push quote AAPL TSLA
+
+# 监控订单状态 / Monitor order updates
+tigeropen push order
+```
+
+---
+
+## 错误处理 / Error Handling
+
+CLI 自动捕获 API 异常并显示错误代码和消息。
+The CLI automatically catches API exceptions and displays error codes and messages.
+
+```bash
+# 启用详细日志查看完整调用栈 / Enable verbose for full stack trace
+tigeropen -v quote briefs INVALID_SYMBOL
+```
+
+常见错误 / Common errors:
+
+| 错误 Error | 说明 Description |
+|-----------|-----------------|
+| `API Error [4]` | 访问被拒绝（检查凭证/权限）Access forbidden (check credentials) |
+| `API Error [5]` | 频率限制（稍后重试）Rate limited (retry later) |
+| `Config file not found` | 运行 `tigeropen config init` 初始化配置 / Run config init |
+| `No quote data found` | 无数据（检查标的代码/市场状态）No data (check symbol/market status) |
+
+---
+
+## 注意事项 / Notes
+
+- CLI 复用 SDK 的 `TigerOpenClientConfig` 配置体系，支持配置文件、环境变量、`--config-path` 参数
+  CLI reuses SDK's `TigerOpenClientConfig`, supports config file, env vars, and `--config-path`
+- 下单/改单/撤单操作默认需要交互确认，`-y` 跳过
+  Place/modify/cancel require confirmation by default; use `-y` to skip
+- 推送命令使用 WebSocket 长连接，Ctrl+C 断开
+  Push commands use WebSocket; Ctrl+C to disconnect
+- 行情权限需单独购买，API 与 App 独立
+  Quote permissions require separate purchase; API and App are independent
+- 全部输出支持 `--format json` 用于管道和脚本处理
+  All output supports `--format json` for piping and scripting

--- a/.claude/skills/tigeropen/references/mcp.md
+++ b/.claude/skills/tigeropen/references/mcp.md
@@ -1,0 +1,192 @@
+
+# Tiger MCP Server
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/mcp
+
+Tiger MCP Server 将老虎 OpenAPI 暴露为 MCP (Model Context Protocol) 工具，集成到 Cursor、Claude Code、Kiro、Trae 等 AI 编辑器。
+Tiger MCP Server exposes Tiger OpenAPI as MCP tools for AI editors like Cursor, Claude Code, Kiro, and Trae.
+
+## 安装 / Installation
+
+```bash
+pip install tigermcp
+# 或推荐使用 uvx / Or recommended:
+uvx tigermcp
+```
+
+### 前置：安装 uv / Prerequisites: Install uv
+
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+## 配置 / Configuration
+
+### 方式一：配置文件 / Config File
+
+```bash
+export TIGEROPEN_PROPS_PATH="/path/to/config/"  # 配置文件所在目录 / Directory containing config file
+```
+
+### 方式二：环境变量 / Environment Variables
+
+```bash
+export TIGEROPEN_TIGER_ID="your_tiger_id"
+export TIGEROPEN_PRIVATE_KEY="your_private_key"  # 私钥内容或文件路径 / Key content or file path
+export TIGEROPEN_ACCOUNT="your_account"
+```
+
+### 可选配置 / Optional
+
+```bash
+export TIGERMCP_READONLY=true   # 只读模式，禁止交易 / Read-only mode, disable trading
+export TIGERMCP_DEBUG=true      # 调试模式 / Debug mode
+```
+
+## 运行 / Run
+
+```bash
+uvx tigermcp
+```
+
+## AI 编辑器集成 / AI Editor Integration
+
+### 个人用户 / Individual Users
+
+在编辑器的 MCP 配置中添加 / Add to editor's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "tigermcp": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "tigermcp"],
+      "env": {
+        "TIGEROPEN_TIGER_ID": "your_tiger_id",
+        "TIGEROPEN_PRIVATE_KEY": "your_private_key",
+        "TIGEROPEN_ACCOUNT": "your_account",
+        "TIGERMCP_READONLY": true
+      }
+    }
+  }
+}
+```
+
+> 也可使用 `TIGEROPEN_PROPS_PATH` 指定配置文件路径，代替 `TIGEROPEN_TIGER_ID` 等配置。
+> You can also use `TIGEROPEN_PROPS_PATH` to specify config file path instead of individual env vars.
+
+### 机构用户 / Institutional Users
+
+```json
+{
+  "mcpServers": {
+    "tigermcp": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "tigermcp"],
+      "env": {
+        "TIGEROPEN_TIGER_ID": "your_tiger_id",
+        "TIGEROPEN_PRIVATE_KEY": "your_private_key",
+        "TIGEROPEN_ACCOUNT": "your_account",
+        "TIGEROPEN_SECRET_KEY": "your_secret_key",
+        "TIGEROPEN_SIGN_TYPE": "TBHK",
+        "TIGERMCP_TOKEN": "your_2fa_token"
+      }
+    }
+  }
+}
+```
+
+### 只读模式(推荐初次使用) / Read-only Mode (Recommended for First-time Use)
+
+```json
+{
+  "mcpServers": {
+    "tigermcp": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "tigermcp"],
+      "env": {
+        "TIGEROPEN_PROPS_PATH": "/path/to/config/",
+        "TIGERMCP_READONLY": true
+      }
+    }
+  }
+}
+```
+
+### 编辑器配置文件位置 / Editor Config File Locations
+
+| 编辑器 Editor | 配置路径 Config Path |
+|--------------|---------------------|
+| Cursor | `.cursor/mcp.json` (项目级) 或 `~/.cursor/mcp.json` (全局) |
+| Claude Code | `.claude/settings.local.json` 或 `~/.claude/settings.json` |
+| Trae | `.trae/mcp.json` |
+| Kiro | `.kiro/settings/mcp.json` (项目级) 或 `~/.kiro/settings/mcp.json` (全局) |
+
+## 可用 MCP 工具 / Available MCP Tools
+
+### 行情工具 / Quote Tools
+
+| 工具 Tool | 功能 Function |
+|----------|--------------|
+| `get_realtime_quote` | 股票/期权/期货实时行情 Real-time stock/option/future quotes |
+| `get_depth_quote` | 深度盘口 Level 2 order book |
+| `get_ticks` | 逐笔成交 Trade ticks |
+| `get_bars` | K线数据 K-line candlestick data |
+| `get_timeline` | 分时数据 Intraday timeline |
+| `get_capital_flow` | 资金流向 Capital flow |
+| `get_capital_distribution` | 资金分布 Capital distribution |
+| `get_stock_broker` | 港股经纪商数据 HK broker seat data |
+| `get_option_expirations` | 期权到期日 Option expiration dates |
+| `get_option_chain` | 期权链 Option chain with Greeks |
+| `get_hk_option_symbols` | 港股期权代码映射 HK option symbol mapping |
+| `get_market_status` | 市场状态 Market status |
+
+### 交易工具 / Trade Tools
+
+| 工具 Tool | 功能 Function |
+|----------|--------------|
+| `place_order` | 下单 Place order (只读模式禁用 disabled in read-only) |
+| `cancel_order` | 撤单 Cancel order (只读模式禁用 disabled in read-only) |
+| `preview_order` | 预览订单 Preview order |
+| `get_orders` | 查询订单列表 Query orders |
+| `get_order` | 订单详情 Order details |
+| `get_transactions` | 成交记录 Transaction records |
+| `get_positions` | 持仓查询 Position query |
+| `get_assets` | 资产查询 Asset query |
+| `get_analytics_asset` | 资产分析 Asset analytics |
+| `get_contract` | 合约信息 Contract info |
+
+## 常见问题 / Troubleshooting
+
+### macOS 12 及以下 `realpath: command not found`
+
+```bash
+brew install coreutils
+```
+
+### Homebrew 未安装 / Homebrew Not Installed
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### 连接问题 / Connection Issues
+
+- 确保网络可访问 Tiger API 服务器 / Ensure network can reach Tiger API servers
+- 检查 tiger_id/private_key/account 是否正确 / Verify credentials
+- 检查私钥格式为 PKCS#1 / Ensure private key is PKCS#1 format
+
+## 注意事项 / Notes
+
+- `TIGERMCP_READONLY=true` 启用只读模式，禁止 `place_order` 和 `cancel_order`，初次使用建议开启
+- MCP Server 通过 stdio 模式运行 / Runs in stdio mode
+- 需要 `tigeropen>=3.4.8` 和 `mcp[cli]>=1.13.0`
+- 也可使用 `TIGEROPEN_PROPS_PATH` 指定配置文件路径，代替单独配置各环境变量
+- Tiger MCP 是 AI 连接 Tiger API 的工具，输出取决于 AI/LLM 能力
+- 用户承担所有投资决策风险 / Users bear all investment decision risks
+- 免责声明 / Disclaimer: https://docs.itigerup.com/docs/mcp

--- a/.claude/skills/tigeropen/references/option.md
+++ b/.claude/skills/tigeropen/references/option.md
@@ -1,0 +1,978 @@
+
+# Tiger Open API 期权 / Options Trading
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/quote-option
+
+## 期权操作工作流 / Option Workflow
+<!-- 当用户提到 "期权"、"期权链"、"到期日"、"行权价"、"Greeks"、"Call"、"Put"、"看涨"、"看跌"、"option"、"option chain"、"expiration"、"strike" 时 -->
+
+当用户提到期权时，按以下流程操作 / When user mentions options, follow this workflow:
+
+### 查询期权 / Query Options
+
+1. **查到期日 Get expirations**: `get_option_expirations()` → 获取可选到期日列表 / Get available expiration dates
+2. **查期权链 Get chain**: `get_option_chain()` → 获取指定到期日的所有合约，可用 `OptionFilter` 筛选 / Get all contracts for a given expiry, filter with `OptionFilter`
+3. **查行情 Get quotes**: `get_option_briefs()` → 获取期权实时行情和希腊字母 / Get real-time quotes and Greeks
+
+### 期权交易 / Option Trading
+
+1. **构造合约 Build contract**: `option_contract_by_symbol(symbol, expiry, strike, put_call, currency)`
+2. **预览订单 Preview**: `preview_order()` → 确认保证金和佣金 / Confirm margin and commission
+3. **下单 Place order**: `place_order()` → 期权数量单位为"张" / Option quantity is in "contracts"
+
+### 港股期权特殊处理 / HK Option Special Handling
+
+- 港股期权标的代码不同于正股 / HK option underlyings differ from stock codes: `00700` → `TCH`（腾讯）
+- 使用 `get_option_symbols()` 查询港股期权代码映射 / Use `get_option_symbols()` for HK option symbol mapping
+
+---
+
+## 初始化 / Initialize
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.trade.trade_client import TradeClient
+
+client_config = TigerOpenClientConfig(props_path='/path/to/your/tiger_openapi_config.properties')
+quote_client = QuoteClient(client_config=client_config)
+trade_client = TradeClient(client_config=client_config)
+```
+
+---
+
+## 期权到期日 / Option Expirations
+
+```python
+expirations = quote_client.get_option_expirations(symbols=['AAPL'], market='US')
+# 返回 DataFrame / Returns DataFrame
+# 列: symbol, option_symbol, date, timestamp, period_tag
+# period_tag: "m"=月度期权(monthly), "w"=周期权(weekly)
+# 也支持 symbols=['AAPL', 'TSLA'] 批量查询
+```
+
+## 期权链 / Option Chain
+
+```python
+from tigeropen.quote.domain.filter import OptionFilter
+
+# 基础期权链 / Basic chain
+chain = quote_client.get_option_chain(symbol='AAPL', expiry='2025-08-29', market='US')
+# 返回 DataFrame，包含 call/put 的行权价、价格、成交量、持仓量等
+
+# 带筛选和希腊字母 / With filters and Greeks
+option_filter = OptionFilter(
+    implied_volatility_min=0.3,
+    implied_volatility_max=0.8,
+    delta_min=0.2,
+    delta_max=0.8,
+    gamma_min=0.005,
+    theta_max=-0.05,
+    open_interest_min=100,
+    volume_min=50,
+    in_the_money=True
+)
+chain = quote_client.get_option_chain(
+    symbol='AAPL', expiry='2025-08-29',
+    option_filter=option_filter,
+    return_greek_value=True,  # 返回 delta/gamma/theta/vega/rho
+    market='US')
+```
+
+### OptionFilter 筛选字段 / Filter Fields
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `implied_volatility_min/max` | 隐含波动率范围 IV range |
+| `delta_min/max` | Delta 范围 |
+| `gamma_min/max` | Gamma 范围 |
+| `theta_min/max` | Theta 范围 |
+| `vega_min/max` | Vega 范围 |
+| `open_interest_min/max` | 持仓量范围 Open interest |
+| `volume_min/max` | 成交量范围 Volume |
+| `in_the_money` | 是否实值 In the money (True/False) |
+
+**get_option_chain 返回字段 / Return Fields** (pandas.DataFrame, 21列):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期权完整代码 (e.g. `AAPL  250829C00150000`) |
+| `symbol` | 标的代码 Underlying symbol |
+| `expiry` | 到期日毫秒时间戳 Expiration timestamp (ms) |
+| `strike` | 行权价 Strike price |
+| `put_call` | `CALL`(看涨) / `PUT`(看跌) |
+| `multiplier` | 乘数（美股通常100） Option multiplier |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 |
+| `pre_close` | 前收盘价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `volume` | 成交量 Volume |
+| `open_interest` | 未平仓合约数 Open interest |
+| `last_timestamp` | 最后交易时间戳（毫秒） Last trade time (ms) |
+| `implied_vol` | 隐含波动率 Implied volatility |
+| `delta` | Delta（需 `return_greek_value=True`）|
+| `gamma` | Gamma |
+| `theta` | Theta（每日时间价值损耗，通常为负值） |
+| `vega` | Vega（波动率敏感度） |
+| `rho` | Rho（利率敏感度） |
+
+---
+
+## 港股期权 / HK Options
+
+港股期权标的代码与股票代码不同，需先映射。
+HK option underlying symbols differ from stock codes; map first.
+
+```python
+# 获取映射 / Get mapping (e.g. 00700 -> TCH.HK)
+# 返回 DataFrame: columns=['symbol'(期权代码), 'name', 'underlying_symbol'(正股代码)]
+hk_symbols_df = quote_client.get_option_symbols(market='HK')
+# 查找腾讯 / Find Tencent:
+tencent = hk_symbols_df[hk_symbols_df['underlying_symbol'] == '00700'].iloc[0]
+option_symbol = tencent['symbol']  # e.g. 'TCH.HK'
+
+# 使用映射后的代码 / Use mapped symbol
+expirations = quote_client.get_option_expirations(symbols=['TCH.HK'], market='HK')
+chain = quote_client.get_option_chain(symbol='TCH.HK', expiry='2025-06-18', market='HK')
+```
+
+---
+
+## 期权行情 / Option Quotes
+
+```python
+# 实时行情 / Real-time quotes
+briefs = quote_client.get_option_briefs(identifiers=['AAPL  250829C00150000'])
+
+# K线 / K-lines (支持周期: day, 1min, 5min, 30min, 60min)
+bars = quote_client.get_option_bars(identifiers=['AAPL  250829C00150000'], period='day')
+# 可选参数: sort_dir (SortDirection.ASC/DESC), limit, begin_time, end_time
+
+# 深度行情 / Depth quotes
+depth = quote_client.get_option_depth(identifiers=['AAPL  250829C00150000'], market='US')
+
+# 逐笔成交 / Trade ticks
+ticks = quote_client.get_option_trade_ticks(identifiers=['AAPL  250829C00150000'])
+
+# 分时 / Timeline (支持 US 和 HK 市场 / Supports US and HK markets)
+timeline = quote_client.get_option_timeline(identifiers=['AAPL  250829C00150000'])
+# HK 期权: quote_client.get_option_timeline(identifiers=['TCH.HK250828C00610000'], market='HK')
+```
+
+**get_option_briefs 返回字段 / Return Fields** (pandas.DataFrame, 27列):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期权完整代码 Full option identifier |
+| `symbol` | 标的代码 Underlying symbol |
+| `expiry` | 到期日毫秒时间戳 |
+| `strike` | 行权价 Strike price |
+| `put_call` | `CALL` / `PUT` |
+| `multiplier` | 乘数 Option multiplier |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 Ask size |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 Bid size |
+| `pre_close` | 前收价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `latest_time` | 最新交易时间 Latest trade time |
+| `volume` | 成交量 Volume |
+| `open_interest` | 未平仓数量 Open interest |
+| `open` | 开盘价 Open price |
+| `high` | 最高价 High price |
+| `low` | 最低价 Low price |
+| `change` | 价格变动 Price change |
+| `volatility` | 历史波动率 Historical volatility |
+| `rates_bonds` | 无风险利率 Risk-free interest rate |
+| `mid_price` | 买卖中间价 Mid price (ask+bid)/2 |
+| `mid_timestamp` | 中间价时间戳 Mid price timestamp (ms) |
+| `mark_price` | 标记价格 Mark price |
+| `mark_timestamp` | 标记价格时间戳 Mark price timestamp (ms) |
+| `pre_mark_price` | 前标记价格 Previous mark price |
+| `selling_return` | 卖出收益率 Selling return (for covered call/cash-secured put) |
+
+### 期权代码格式 / Option Symbol Format
+
+- 美股 US: `'AAPL  250829C00150000'`
+  - 格式: `标的` + 空格填充至6位 + `YYMMDD` + `C/P` + 行权价*1000(8位)
+  - Format: symbol padded to 6 chars + YYMMDD + C/P + strike*1000 (8 digits)
+- 港股 HK: `'TCH.HK 230616C00550000'`
+  - 注意使用映射后的代码 / Use mapped symbol
+
+---
+
+## 期权分析 / Option Analysis
+
+```python
+from tigeropen.common.consts import OptionAnalysisPeriod
+
+# 基础用法(默认52周) / Basic usage (default 52-week)
+analysis = quote_client.get_option_analysis(symbols=['AAPL'])
+
+# 指定分析周期 / Specify analysis period
+analysis = quote_client.get_option_analysis(
+    symbols=['AAPL'],
+    period=OptionAnalysisPeriod.TWENTY_SIX_WEEK)
+
+# 每个标的不同周期 / Per-symbol periods
+analysis = quote_client.get_option_analysis(
+    symbols=[
+        'AAPL',  # 使用默认周期
+        {'symbol': 'TSLA', 'period': '26week'},  # 指定26周
+    ])
+
+# 返回 List[OptionAnalysis]，属性:
+# - symbol: 标的代码
+# - implied_vol_30_days: 30日隐含波动率
+# - his_volatility: 历史波动率
+# - iv_his_v_ratio: IV/HV 比率
+# - call_put_ratio: 看涨/看跌比率
+# - iv_metric: IVMetric 对象，包含:
+#     - period: 分析周期
+#     - percentile: IV 百分位
+#     - rank: IV 排名
+```
+
+### OptionAnalysisPeriod 分析周期
+
+| 周期 Period | 值 Value | 说明 Description |
+|------------|---------|-----------------|
+| `THREE_YEAR` | `3year` | 3年 / 3 years |
+| `FIFTY_TWO_WEEK` | `52week` | 52周(1年，默认) / 52 weeks (default) |
+| `TWENTY_SIX_WEEK` | `26week` | 26周(6个月) / 26 weeks |
+| `THIRTEEN_WEEK` | `13week` | 13周(3个月) / 13 weeks |
+
+---
+
+## 期权合约 / Option Contracts
+
+```python
+from tigeropen.common.util.contract_utils import option_contract_by_symbol
+
+# 本地构造 / Local construction
+opt = option_contract_by_symbol(
+    symbol='AAPL', expiry='20250829',
+    strike=150.0, put_call='CALL', currency='USD')
+
+# 远程获取 / Remote fetch
+opt = trade_client.get_contract(
+    symbol='AAPL', sec_type='OPT',
+    expiry='20250829', strike=150.0, put_call='CALL')
+```
+
+---
+
+## 单腿期权下单 / Single-leg Option Order
+
+```python
+from tigeropen.common.util.order_utils import limit_order
+
+# 买入看涨期权 / Buy call
+order = limit_order(account=client_config.account, contract=opt,
+                    action='BUY', quantity=1, limit_price=5.0)
+trade_client.place_order(order)
+
+# 卖出看跌期权 / Sell put
+put_contract = option_contract_by_symbol(
+    symbol='AAPL', expiry='20250829', strike=140.0, put_call='PUT', currency='USD')
+order = limit_order(account=client_config.account, contract=put_contract,
+                    action='SELL', quantity=1, limit_price=3.0)
+trade_client.place_order(order)
+```
+
+> 期权1张合约 = 100股标的。1 option contract = 100 shares of underlying.
+
+---
+
+## 多腿组合策略 / Multi-leg Combo Strategies
+
+```python
+from tigeropen.common.util.order_utils import combo_order, contract_leg
+```
+
+### 牛市看涨价差 / Bull Call Spread (VERTICAL)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=145.0, put_call='CALL', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=155.0, put_call='CALL', action='SELL', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='VERTICAL', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=3.0)
+trade_client.place_order(order)
+```
+
+### 跨式策略 / Straddle (STRADDLE)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='CALL', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='PUT', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='STRADDLE', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=8.0)
+trade_client.place_order(order)
+```
+
+### 宽跨式策略 / Strangle (STRANGLE)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=160.0, put_call='CALL', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=140.0, put_call='PUT', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='STRANGLE', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=5.0)
+trade_client.place_order(order)
+```
+
+### 日历价差 / Calendar Spread (CALENDAR)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='CALL', action='SELL', ratio=1),  # 近月卖
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20251219',
+                 strike=150.0, put_call='CALL', action='BUY', ratio=1),   # 远月买
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='CALENDAR', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=2.0)
+trade_client.place_order(order)
+```
+
+### 对角线价差 / Diagonal Spread (DIAGONAL)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=155.0, put_call='CALL', action='SELL', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20251219',
+                 strike=145.0, put_call='CALL', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='DIAGONAL', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=5.0)
+trade_client.place_order(order)
+```
+
+### 备兑策略 / Covered Call (COVERED)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='STK', action='BUY', ratio=100),  # 买100股
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=160.0, put_call='CALL', action='SELL', ratio=1),     # 卖1张call
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='COVERED', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=145.0)
+trade_client.place_order(order)
+```
+
+### 保护性看跌 / Protective Put (PROTECTIVE)
+
+```python
+legs = [
+    contract_leg(symbol='AAPL', sec_type='STK', action='BUY', ratio=100),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=140.0, put_call='PUT', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='PROTECTIVE', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=152.0)
+trade_client.place_order(order)
+```
+
+### 熊市看跌价差 / Bear Put Spread (VERTICAL)
+
+方向性策略，预期股价下跌，有限盈利有限亏损。
+
+```python
+# 买高行权价Put，卖低行权价Put（净支出）
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=155.0, put_call='PUT', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=145.0, put_call='PUT', action='SELL', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='VERTICAL', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=4.0)
+trade_client.place_order(order)
+```
+
+---
+
+### 牛市看跌价差（信用价差）/ Bull Put Spread (Credit Spread)
+
+卖出实值Put，买入更低行权价Put保护，收取权利金净信用，预期股价维持或上涨。
+
+```python
+# 卖高行权价Put，买低行权价Put（净收入信用）
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=145.0, put_call='PUT', action='SELL', ratio=1),  # 卖Put收信用
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=135.0, put_call='PUT', action='BUY', ratio=1),   # 买Put限风险
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='VERTICAL', action='SELL',
+                    quantity=1, order_type='LMT', limit_price=2.50)
+# limit_price 为净收入信用（正值），max_loss = (145-135)*100 - 250 = 750
+trade_client.place_order(order)
+```
+
+---
+
+### 熊市看涨价差（信用价差）/ Bear Call Spread (Credit Spread)
+
+卖出虚值Call，买入更高行权价Call保护，预期股价维持或下跌。
+
+```python
+# 卖低行权价Call，买高行权价Call
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=165.0, put_call='CALL', action='SELL', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=175.0, put_call='CALL', action='BUY', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='VERTICAL', action='SELL',
+                    quantity=1, order_type='LMT', limit_price=2.00)
+trade_client.place_order(order)
+```
+
+---
+
+### 铁鹰策略 / Iron Condor
+
+同时卖出 Bull Put Spread + Bear Call Spread，适合区间震荡行情，收取双边权利金。
+
+```python
+# Iron Condor = Bull Put Spread + Bear Call Spread（4条腿，用 CUSTOM）
+legs = [
+    # Put spread（下方保护）
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=140.0, put_call='PUT', action='BUY', ratio=1),   # 买低Put
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='PUT', action='SELL', ratio=1),  # 卖高Put
+    # Call spread（上方保护）
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=165.0, put_call='CALL', action='SELL', ratio=1), # 卖低Call
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=175.0, put_call='CALL', action='BUY', ratio=1),  # 买高Call
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='CUSTOM', action='SELL',
+                    quantity=1, order_type='LMT', limit_price=3.50)
+# limit_price = 净收入信用（正值）
+# max_profit = 350（股价到期在 150-165 区间内）
+# max_loss = (165-150)*100 - 350 = 1150（突破任一侧边界）
+trade_client.place_order(order)
+```
+
+---
+
+### 铁蝴蝶策略 / Iron Butterfly
+
+卖出同行权价的 Straddle，再分别买入两侧保护，适合极低波动率预期，比 Iron Condor 收入更高但区间更窄。
+
+```python
+atm_strike = 155.0  # ATM 行权价（接近当前股价）
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=145.0, put_call='PUT', action='BUY', ratio=1),   # 买下方Put
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=atm_strike, put_call='PUT', action='SELL', ratio=1),  # 卖ATM Put
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=atm_strike, put_call='CALL', action='SELL', ratio=1), # 卖ATM Call
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=165.0, put_call='CALL', action='BUY', ratio=1),  # 买上方Call
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='CUSTOM', action='SELL',
+                    quantity=1, order_type='LMT', limit_price=6.00)
+trade_client.place_order(order)
+```
+
+---
+
+### 穷人备兑开仓 / Poor Man's Covered Call (PMCC)
+
+用深度实值的长期 LEAPS Call 替代持有正股，成本更低，结构类似 Covered Call。
+
+```python
+# 买入远期深度实值Call（LEAPS，delta ~0.7-0.9），替代持股
+# 卖出近期虚值Call收取权利金
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20270117',  # 远期 ~1.5年
+                 strike=120.0, put_call='CALL', action='BUY', ratio=1),  # 深度实值
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',  # 近期 ~1个月
+                 strike=165.0, put_call='CALL', action='SELL', ratio=1), # 虚值
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='DIAGONAL', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=28.0)
+# 注意: 近月Call行权价必须 > 远月Call行权价，否则存在最大亏损为负的风险
+trade_client.place_order(order)
+```
+
+---
+
+### 合成股票 / Synthetic Stock (SYNTHETIC)
+
+买Call卖同行权价Put，经济效果等同于持有100股，资金占用更少。
+
+```python
+# 合成多头（等同于持股）: 买Call + 卖Put，同行权价同到期日
+legs = [
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='CALL', action='BUY', ratio=1),
+    contract_leg(symbol='AAPL', sec_type='OPT', expiry='20250829',
+                 strike=150.0, put_call='PUT', action='SELL', ratio=1),
+]
+order = combo_order(account=client_config.account, legs=legs,
+                    combo_type='SYNTHETIC', action='BUY',
+                    quantity=1, order_type='LMT', limit_price=0.50)
+# 合成空头: 两腿 action 均改为相反（卖Call+买Put）
+trade_client.place_order(order)
+```
+
+---
+
+### 常用策略对比速查 / Strategy Quick Reference
+
+| 策略 Strategy | 方向 Bias | 盈亏结构 | 风险 Risk | 典型用途 Use Case |
+|--------------|-----------|---------|-----------|-----------------|
+| Bull Call Spread | 温和看涨 | 有限盈亏 | 有限（净支出） | 方向性，控制成本 |
+| Bear Put Spread | 温和看跌 | 有限盈亏 | 有限（净支出） | 方向性下行保护 |
+| Bull Put Spread | 温和看涨/中性 | 有限盈亏 | 有限（净收入） | 收取权利金，高胜率 |
+| Bear Call Spread | 温和看跌/中性 | 有限盈亏 | 有限（净收入） | 收取权利金，高胜率 |
+| Iron Condor | 中性区间震荡 | 有限盈亏 | 有限 | 低波动率环境，双边收费 |
+| Iron Butterfly | 极度中性 | 有限盈亏 | 有限 | 极低波动预期，权利金最高 |
+| Straddle（买） | 高波动预期 | 无限盈利 | 有限（净支出） | 财报/事件驱动 |
+| Strangle（买） | 高波动预期 | 无限盈利 | 有限（更低成本） | 财报/事件驱动 |
+| Covered Call | 温和看涨/持股 | 有限盈利 | 持股风险 | 持股增收 |
+| Sell Put / CSP | 温和看涨 | 有限盈利 | 较大（行权买股） | 目标价买入+收费 |
+| PMCC | 温和看涨 | 有限盈利 | 有限 | 低成本备兑替代 |
+| Wheel Strategy | 温和看涨 | 稳定收租 | 行权买股 | 长期稳定增收 |
+| Calendar Spread | 中性/轻方向 | 有限盈亏 | 有限 | 时间价值套利 |
+| Diagonal Spread | 轻方向 | 有限盈亏 | 有限 | 方向性时间套利 |
+| Synthetic Stock | 强方向 | 无限盈亏 | 较大 | 杠杆替代持股 |
+
+---
+
+### 组合策略类型总览 / Combo Strategy Types
+
+| ComboType | 策略 Strategy | 说明 Description |
+|-----------|--------------|-----------------|
+| `VERTICAL` | 垂直价差 | 同到期日不同行权价 Same expiry, different strikes |
+| `STRADDLE` | 跨式 | 同行权价同到期日 Call+Put Same strike & expiry |
+| `STRANGLE` | 宽跨式 | 不同行权价同到期日 Call+Put Different strikes, same expiry |
+| `CALENDAR` | 日历价差 | 同行权价不同到期日 Same strike, different expiries |
+| `DIAGONAL` | 对角线价差 | 不同行权价不同到期日 Different strikes & expiries |
+| `COVERED` | 备兑 | 持有股票+卖Call Long stock + short call |
+| `PROTECTIVE` | 保护性 | 持有股票+买Put Long stock + long put |
+| `SYNTHETIC` | 合成 | 合成多/空头 Synthetic long/short |
+| `CUSTOM` | 自定义 | 自定义组合 Custom combination |
+
+### contract_leg 参数 / contract_leg Parameters
+
+| 参数 Parameter | 说明 Description | 必填 |
+|---------------|-----------------|------|
+| `symbol` | 标的代码 Symbol | ✅ |
+| `sec_type` | `OPT` / `STK` | ✅ |
+| `expiry` | 到期日 YYYYMMDD (期权) | OPT |
+| `strike` | 行权价 Strike (期权) | OPT |
+| `put_call` | `CALL` / `PUT` (期权) | OPT |
+| `action` | `BUY` / `SELL` | ✅ |
+| `ratio` | 比率 Ratio (STK用100, OPT用1) | ✅ |
+
+---
+
+## 查询期权持仓 / Query Option Positions
+
+```python
+from tigeropen.common.consts import SecurityType
+
+opt_positions = trade_client.get_positions(sec_type=SecurityType.OPT)
+for p in opt_positions:
+    c = p.contract
+    print(f"{c.symbol} {c.expiry} {c.strike} {c.put_call}: "
+          f"qty={p.qty}, cost={p.average_cost}, value={p.market_value}, pnl={p.unrealized_pnl}")
+```
+
+---
+
+## 期权计算工具 / Option Calculator Tools
+
+> 需安装 `pip install quantlib==1.40`
+
+### 期权定价与希腊字母 / Option Pricing & Greeks
+
+```python
+from tigeropen.examples.option_helpers.helpers import (
+    FDAmericanDividendOptionHelper,   # 美式期权(美股/港股/ETF) American options
+    FDEuropeanDividendOptionHelper,   # 欧式期权(指数期权) European options
+)
+
+# 计算期权价格 / Calculate option price
+helper = FDAmericanDividendOptionHelper(
+    option_type='CALL',    # CALL/PUT
+    expiry='2025-08-29',   # 到期日
+    settlement='2025-03-18',  # 结算日
+    strike=150.0,          # 行权价
+    underlying=155.0,      # 标的价格
+    rate=0.05,             # 无风险利率
+    volatility=0.25,       # 波动率
+)
+result = helper.calculate()
+# result: npv(期权价格), delta, gamma, theta, vega, rho
+
+# 从期权价格反算隐含波动率 / Calculate implied volatility from price
+helper = FDAmericanDividendOptionHelper(
+    option_type='CALL', expiry='2025-08-29', settlement='2025-03-18',
+    strike=150.0, underlying=155.0, rate=0.05,
+    option_price=8.5,  # 期权市场价格
+)
+iv = helper.implied_volatility()
+```
+
+### 期权指标计算器 / Option Metrics Calculator
+
+```python
+from tigeropen.examples.option_helpers.util import OptionUtil
+
+option_util = OptionUtil(client_config=client_config)
+
+# 计算期权指标 / Calculate option metrics
+# 输入期权代码，自动查询市场数据计算
+metrics = option_util.calculate('TSLA 260220C00385000')
+# 返回: Greeks, profit_probability(盈利概率), annualized_return_for_selling(卖出年化收益率), leverage_ratio(杠杆比率)
+```
+
+---
+
+## 复杂业务场景 / Advanced Strategy Scenarios
+
+### Wheel Strategy（车轮策略）概述
+
+Wheel Strategy = **Sell Put → 被行权后持有股票 → Sell Covered Call → 反复循环**
+
+```
+阶段1: Sell Cash-Secured Put
+  └── 若未被行权 → 收保证金，重复卖Put
+  └── 若被行权   → 以行权价买入股票
+         |
+阶段2: Sell Covered Call
+  └── 若未被行权 → 收权利金，重复卖Call
+  └── 若被行权   → 以行权价卖出股票，回到阶段1
+```
+
+**策略目标**: 持续通过卖出期权收取权利金，降低实际持股成本。
+
+---
+
+### 场景一：扫描股票池的 Sell Put 机会
+
+扫描一组股票，找出近期到期、Delta 合适、权利金收益率高的 Put 合约。
+
+```python
+import pandas as pd
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.quote.domain.filter import OptionFilter
+
+client_config = TigerOpenClientConfig(props_path='/path/to/config/')
+quote_client = QuoteClient(client_config=client_config)
+
+# 1. 定义股票池
+watchlist = ['AAPL', 'MSFT', 'TSLA', 'NVDA', 'AMD']
+
+# 2. 筛选参数（根据策略调整）
+DELTA_MIN = -0.35     # Put delta 为负，-0.35 表示约 35% 被行权概率
+DELTA_MAX = -0.15     # 偏保守，目标 delta 在 -0.15 ~ -0.35
+IV_MIN = 0.20         # 过滤低波动率标的（权利金太少）
+OI_MIN = 100          # 最小持仓量，保证流动性
+VOLUME_MIN = 10
+DAYS_TO_EXPIRY = 30   # 目标到期天数（21-45天最佳）
+
+# 3. 查询各标的的近期到期日
+def get_target_expiry(symbol, target_days=DAYS_TO_EXPIRY):
+    """找距当前最接近目标天数的到期日"""
+    import datetime
+    expirations = quote_client.get_option_expirations(symbols=[symbol], market='US')
+    today = datetime.date.today()
+    target_date = today + datetime.timedelta(days=target_days)
+
+    # 筛选月度期权（period_tag='m'），找最近的
+    monthly = expirations[expirations['period_tag'] == 'm'].copy()
+    monthly['date'] = pd.to_datetime(monthly['date']).dt.date
+    monthly['diff'] = (monthly['date'] - target_date).abs()
+
+    if monthly.empty:
+        return None
+    best = monthly.loc[monthly['diff'].idxmin()]
+    return str(best['date'])
+
+# 4. 扫描每个标的
+opportunities = []
+
+for symbol in watchlist:
+    try:
+        expiry = get_target_expiry(symbol)
+        if not expiry:
+            continue
+
+        # 查询 Put 期权链，按 delta 筛选
+        option_filter = OptionFilter(
+            delta_min=DELTA_MIN,
+            delta_max=DELTA_MAX,
+            implied_volatility_min=IV_MIN,
+            open_interest_min=OI_MIN,
+            volume_min=VOLUME_MIN,
+        )
+        chain = quote_client.get_option_chain(
+            symbol=symbol,
+            expiry=expiry,
+            option_filter=option_filter,
+            return_greek_value=True,
+            market='US'
+        )
+
+        if chain is None or chain.empty:
+            continue
+
+        # 只取 PUT
+        puts = chain[chain['put_call'] == 'PUT'].copy()
+        if puts.empty:
+            continue
+
+        # 计算关键指标
+        puts['mid_price'] = (puts['bid_price'] + puts['ask_price']) / 2
+        puts['bid_ask_spread'] = puts['ask_price'] - puts['bid_price']
+        puts['bid_ask_ratio'] = puts['bid_ask_spread'] / puts['mid_price']
+        # 年化权利金收益率 = 权利金/行权价 * (365/天数)
+        import datetime
+        today = datetime.date.today()
+        expiry_date = datetime.date.fromisoformat(expiry)
+        days_left = (expiry_date - today).days
+        puts['premium_yield'] = (puts['bid_price'] / puts['strike']) * (365 / max(days_left, 1))
+
+        # 流动性过滤: bid/ask 价差不超过 mid 的 30%
+        liquid = puts[puts['bid_ask_ratio'] < 0.30]
+
+        if liquid.empty:
+            continue
+
+        # 按年化收益率排序，取最优
+        best = liquid.sort_values('premium_yield', ascending=False).head(3)
+        best['underlying'] = symbol
+        best['expiry_date'] = expiry
+        best['days_left'] = days_left
+        opportunities.append(best)
+
+    except Exception as e:
+        print(f"Skip {symbol}: {e}")
+        continue
+
+# 5. 汇总结果
+if opportunities:
+    result = pd.concat(opportunities, ignore_index=True)
+    display_cols = [
+        'underlying', 'expiry_date', 'days_left', 'strike', 'delta',
+        'bid_price', 'ask_price', 'mid_price', 'implied_vol',
+        'open_interest', 'volume', 'premium_yield'
+    ]
+    result = result[display_cols].sort_values('premium_yield', ascending=False)
+    print(result.to_string(index=False))
+else:
+    print("No opportunities found.")
+```
+
+**输出示例 / Sample Output**:
+
+```
+underlying expiry_date  days_left  strike  delta  bid_price  ask_price  mid_price  implied_vol  open_interest  volume  premium_yield
+      NVDA  2025-05-16         38   800.0  -0.28       8.50      9.00       8.75       0.420          1523     312          0.418
+      TSLA  2025-05-16         38   220.0  -0.25       4.20      4.50       4.35       0.510           892     245          0.389
+      AAPL  2025-05-16         38   170.0  -0.22       1.80      2.00       1.90       0.280          2104     567          0.215
+```
+
+---
+
+### 场景二：执行 Sell Put 下单
+
+从扫描结果中选择目标合约并下单：
+
+```python
+from tigeropen.common.util.contract_utils import option_contract_by_symbol
+from tigeropen.common.util.order_utils import limit_order
+from tigeropen.trade.trade_client import TradeClient
+
+trade_client = TradeClient(client_config=client_config)
+
+# ⚠️ 默认使用模拟账户，实盘需用户确认
+account = client_config.account
+
+# 选择目标 Put 合约
+symbol = 'NVDA'
+expiry = '20250516'   # YYYYMMDD 格式
+strike = 800.0
+limit_price = 8.50    # 以 bid 价卖出（保守），或 mid 价（激进）
+quantity = 1          # 1张 = 100股
+
+# 构造合约
+put_contract = option_contract_by_symbol(
+    symbol=symbol,
+    expiry=expiry,
+    strike=strike,
+    put_call='PUT',
+    currency='USD'
+)
+
+# 卖出 Put
+order = limit_order(
+    account=account,
+    contract=put_contract,
+    action='SELL',
+    quantity=quantity,
+    limit_price=limit_price
+)
+
+# 预览（建议先预览确认保证金）
+preview = trade_client.preview_order(order)
+print(f"预估保证金: {preview.init_margin}")
+print(f"预估佣金: {preview.commission}")
+
+# 确认后下单
+result = trade_client.place_order(order)
+print(f"订单ID: {result.id}, 状态: {result.status}")
+```
+
+---
+
+### 场景三：监控持仓并执行 Covered Call（Wheel 第二阶段）
+
+当 Sell Put 被行权，持有正股后，自动寻找 Covered Call 机会：
+
+```python
+from tigeropen.common.consts import SecurityType
+
+# 1. 查询当前期权持仓（监控被行权的 Put）
+opt_positions = trade_client.get_positions(sec_type=SecurityType.OPT)
+assigned_symbols = []
+
+for pos in opt_positions:
+    c = pos.contract
+    # Put 被行权后会消失，但持有对应的正股
+    print(f"期权持仓: {c.symbol} {c.expiry} {c.strike} {c.put_call} qty={pos.qty}")
+
+# 2. 查询正股持仓（被行权后的股票）
+stk_positions = trade_client.get_positions(sec_type=SecurityType.STK)
+
+for pos in stk_positions:
+    symbol = pos.contract.symbol
+    qty = pos.qty
+    avg_cost = pos.average_cost
+
+    if qty < 100:  # 至少持有100股才能卖1张Covered Call
+        continue
+
+    max_contracts = qty // 100  # 可卖的最大张数
+
+    print(f"\n{symbol}: 持有 {qty}股, 均价 ${avg_cost:.2f}, 可卖 {max_contracts} 张 Covered Call")
+
+    # 3. 查询 OTM Call 期权（行权价 > 当前价格，略高于持仓成本）
+    expiry = get_target_expiry(symbol)  # 使用前面定义的函数
+    if not expiry:
+        continue
+
+    call_filter = OptionFilter(
+        delta_min=0.20,   # Call delta 0.20-0.35 （约20-35%被行权概率）
+        delta_max=0.35,
+        open_interest_min=50,
+        volume_min=5,
+    )
+    chain = quote_client.get_option_chain(
+        symbol=symbol, expiry=expiry,
+        option_filter=call_filter,
+        return_greek_value=True, market='US'
+    )
+
+    if chain is None or chain.empty:
+        continue
+
+    calls = chain[chain['put_call'] == 'CALL'].copy()
+    if calls.empty:
+        continue
+
+    # 筛选行权价高于均价（避免亏损卖出股票）
+    calls = calls[calls['strike'] > avg_cost]
+
+    if calls.empty:
+        print(f"  {symbol}: 无合适的 Covered Call 合约（所有行权价低于持仓均价）")
+        continue
+
+    # 按权利金收益率排序
+    calls['mid_price'] = (calls['bid_price'] + calls['ask_price']) / 2
+    calls = calls.sort_values('mid_price', ascending=False)
+
+    best_call = calls.iloc[0]
+    print(f"  推荐 Covered Call: 行权价 ${best_call['strike']:.1f}, "
+          f"Delta={best_call['delta']:.2f}, "
+          f"权利金 bid=${best_call['bid_price']:.2f}")
+```
+
+---
+
+### Wheel Strategy 关键参数选择指南
+
+| 参数 | 保守型 | 平衡型 | 激进型 |
+|------|--------|--------|--------|
+| Put Delta | -0.15 ~ -0.20 | -0.25 ~ -0.30 | -0.35 ~ -0.40 |
+| Call Delta | 0.20 ~ 0.25 | 0.25 ~ 0.35 | 0.35 ~ 0.45 |
+| 到期天数 DTE | 45-60 天 | 30-45 天 | 14-30 天 |
+| IV 要求 | IV Rank > 30% | IV Rank > 20% | 无特殊要求 |
+| 流动性 | OI > 500 | OI > 100 | OI > 50 |
+
+**止损原则**: 当期权市值达到权利金的 2-3 倍时考虑平仓止损。
+
+```python
+# 检查是否需要止损
+for pos in opt_positions:
+    if pos.qty < 0:  # 持有空头期权（卖出方）
+        entry_credit = abs(pos.average_cost)  # 收到的权利金（每股）
+        current_price = pos.market_price       # 当前期权价格
+        loss_ratio = current_price / entry_credit
+
+        if loss_ratio > 2.0:  # 亏损超过2倍权利金
+            c = pos.contract
+            print(f"⚠️ 止损警告: {c.symbol} {c.strike}{c.put_call} "
+                  f"当前亏损 {loss_ratio:.1f}x 权利金，考虑平仓")
+```
+
+---
+
+## 注意事项 / Notes
+
+- 港股期权需 `get_option_symbols` 获取代码映射 / HK options need symbol mapping
+- 期权每张合约通常代表100股标的 / Each contract = 100 shares
+- 希腊字母通过 `return_greek_value=True` 获取 / Greeks via `return_greek_value=True`
+- 组合策略下单时所有 leg 标的必须一致 / All legs must share same underlying
+- 期权行情需要期权行情权限 / Option quotes require option quote permission
+- 期权计算工具需安装 quantlib / Calculator tools require `pip install quantlib==1.40`
+- 更多期权知识见 / More: https://docs.itigerup.com/docs/quote-option

--- a/.claude/skills/tigeropen/references/push.md
+++ b/.claude/skills/tigeropen/references/push.md
@@ -1,0 +1,488 @@
+
+# Tiger Open API 实时推送 / Real-time Push
+
+> 中文 | English — 双语技能。Bilingual skill.
+> 官方文档 Docs: https://docs.itigerup.com/docs/push-quote
+
+## 创建推送客户端 / Create Push Client
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.push.push_client import PushClient
+
+client_config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+protocol, host, port = client_config.socket_host_port
+push_client = PushClient(host, port, use_ssl=(protocol == 'ssl'), use_protobuf=True, client_config=client_config)
+```
+
+> `client_config` 参数推荐传入，使用 `use_full_tick` 等功能时必须传入。
+> Passing `client_config` is recommended; required for features like `use_full_tick`.
+
+---
+
+## 回调函数 / Callback Functions
+
+### 行情变动 / Quote Change
+
+```python
+def on_quote_changed(frame):
+    """股票/期货行情变动 Stock/future quote change"""
+    # ⚠️ 使用 protobuf 时字段名为 camelCase / protobuf mode fields are camelCase
+    print(f"{frame.symbol}: price={frame.latestPrice}, volume={frame.volume}")
+    # protobuf 字段 / protobuf fields: symbol, latestPrice, volume, amount,
+    #   open, high, low, preClose, latestTime, marketStatus, identifier
+    # 盘前盘后 / Extended hours: hourTradingTag
+```
+
+### 买卖盘口(BBO)变动 / Quote BBO Change
+
+```python
+def on_quote_bbo_changed(frame):
+    """买一卖一盘口变动 Best Bid/Offer change"""
+    print(f"{frame.symbol}: bid={frame.bid_price}x{frame.bid_size}, "
+          f"ask={frame.ask_price}x{frame.ask_size}")
+    # 属性: symbol, bid_price, bid_size, ask_price, ask_size
+```
+
+> `quote_bbo_changed` 与 `quote_changed` 是独立的回调，分别推送盘口和行情数据。
+> `quote_bbo_changed` and `quote_changed` are separate callbacks for BBO and quote data.
+
+### 深度行情 / Depth Quote Change
+
+```python
+def on_depth_quote(frame):
+    """深度盘口变动 Depth quote change"""
+    print(f"{frame.symbol}: asks={frame.asks}, bids={frame.bids}")
+    # asks/bids 各为列表: [price, volume, order_count]
+```
+
+### 逐笔成交 / Tick Change
+
+```python
+def on_tick(frame):
+    """逐笔成交推送 Trade tick push"""
+    print(f"{frame.symbol}: price={frame.price}, volume={frame.volume}, time={frame.time}")
+    # 属性: symbol, price, volume, time, type, sn
+```
+
+### 完整逐笔成交 / Full Tick Change
+
+```python
+def on_full_tick(frame):
+    """完整逐笔成交推送(含历史) Full trade tick push (includes history)"""
+    print(f"{frame.symbol}: price={frame.price}, volume={frame.volume}")
+    # 需要 use_full_tick=True 且传入 client_config
+    # Requires use_full_tick=True and client_config passed to PushClient
+```
+
+### K线推送 / K-line Change
+
+```python
+def on_kline(frame):
+    """分钟K线推送 Minute K-line push"""
+    print(f"{frame.symbol}: open={frame.open}, high={frame.high}, "
+          f"low={frame.low}, close={frame.close}, volume={frame.volume}")
+    # 属性: symbol, time, open, high, low, close, volume
+```
+
+### 订单变动 / Order Change
+
+```python
+def on_order_changed(frame):
+    """订单状态变动 Order status change"""
+    print(f"Order {frame.id}: symbol={frame.symbol}, status={frame.status}, "
+          f"action={frame.action}, filled={frame.filled_quantity}/{frame.quantity}")
+    # 属性: id, order_id, symbol, sec_type, action, order_type, status,
+    #       quantity, filled_quantity, avg_fill_price, limit_price, aux_price,
+    #       trade_time, time_in_force, outside_rth, cancel_status, replace_status
+```
+
+### 持仓变动 / Position Change
+
+```python
+def on_position_changed(frame):
+    """持仓变动 Position change"""
+    print(f"{frame.symbol}: qty={frame.quantity}, cost={frame.average_cost}, "
+          f"price={frame.latest_price}, pnl={frame.unrealized_pnl}")
+    # 属性: symbol, sec_type, market, currency, quantity, average_cost,
+    #       latest_price, market_value, unrealized_pnl, realized_pnl
+```
+
+### 资产变动 / Asset Change
+
+```python
+def on_asset_changed(frame):
+    """资产变动 Asset change"""
+    print(f"Net: {frame.net_liquidation}, Available: {frame.available_funds}")
+    # 属性: net_liquidation, available_funds, excess_liquidity, buying_power,
+    #       cash_balance, init_margin, maintain_margin, realized_pnl, unrealized_pnl
+```
+
+### 成交推送 / Transaction Change
+
+```python
+def on_transaction_changed(frame):
+    """成交推送 Transaction push"""
+    print(f"Order {frame.order_id}: filled {frame.filled_quantity} @ {frame.filled_price}")
+    # 属性: order_id, filled_price, filled_quantity, transact_time
+```
+
+### 数字货币行情 / Crypto Quote Change
+
+```python
+def on_cc_changed(frame):
+    """数字货币行情变动 Crypto quote change"""
+    print(f"{frame.symbol}: price={frame.latest_price}")
+
+def on_cc_bbo_changed(frame):
+    """数字货币盘口变动 Crypto BBO change"""
+    print(f"{frame.symbol}: bid={frame.bid_price}, ask={frame.ask_price}")
+```
+
+### 热门排行 / Top Ranking Change
+
+```python
+def on_stock_top_changed(frame):
+    """股票热门排行变动 Stock top ranking change"""
+    print(frame)
+
+def on_option_top_changed(frame):
+    """期权热门排行变动 Option top ranking change"""
+    print(frame)
+```
+
+### 连接/断开/错误回调 / Connection Callbacks
+
+```python
+def on_connected(frame):
+    """连接成功 Connected — frame 参数必须接收 / frame arg required"""
+    print("Push connected")
+    # ⚠️ 在此处执行订阅 / Subscribe here after connection established
+    push_client.subscribe_quote(['AAPL', 'TSLA'])
+
+def on_disconnected(frame=None):
+    """断开连接 Disconnected (自动重连 auto-reconnects)"""
+    print("Push disconnected, will auto-reconnect")
+    # ⚠️ 重连后订阅不会自动恢复，需在 on_connected 中重新订阅
+    # Subscriptions NOT auto-restored on reconnect; re-subscribe in on_connected
+
+def on_error(frame):
+    """错误 Error"""
+    print(f"Push error: {frame}")
+
+def on_kickout(frame):
+    """被踢出(新连接登录) Kicked out by new connection"""
+    print(f"Kicked out: {frame}")
+```
+
+---
+
+## 注册回调并连接 / Register Callbacks & Connect
+
+```python
+# 注册回调 / Register callbacks
+push_client.quote_changed = on_quote_changed
+push_client.quote_bbo_changed = on_quote_bbo_changed
+push_client.quote_depth_changed = on_depth_quote
+push_client.tick_changed = on_tick
+push_client.full_tick_changed = on_full_tick
+push_client.kline_changed = on_kline
+push_client.order_changed = on_order_changed
+push_client.position_changed = on_position_changed
+push_client.asset_changed = on_asset_changed
+push_client.transaction_changed = on_transaction_changed
+push_client.cc_changed = on_cc_changed
+push_client.cc_bbo_changed = on_cc_bbo_changed
+push_client.stock_top_changed = on_stock_top_changed
+push_client.option_top_changed = on_option_top_changed
+
+# 连接/断开回调 / Connection callbacks
+push_client.connect_callback = on_connected
+push_client.disconnect_callback = on_disconnected
+push_client.error_callback = on_error
+push_client.kickout_callback = on_kickout
+
+# 连接 / Connect
+push_client.connect(client_config.tiger_id, client_config.private_key)
+```
+
+---
+
+## 订阅数据 / Subscribe
+
+### 股票行情 / Stock Quotes
+
+```python
+# 订阅行情变动 / Subscribe quote changes
+push_client.subscribe_quote(['AAPL', 'TSLA', '00700'])
+
+# 取消订阅 / Unsubscribe
+push_client.unsubscribe_quote(['AAPL'])
+```
+
+### 期权行情 / Option Quotes
+
+```python
+# 订阅期权行情(使用 subscribe_option，空格分隔格式)
+# Subscribe option quotes (use subscribe_option, space-separated format)
+push_client.subscribe_option(['AAPL 20250829 150.0 CALL'])
+
+# 也可通过 subscribe_quote 使用 OCC 格式
+# Or via subscribe_quote with OCC format
+push_client.subscribe_quote(['AAPL  250829C00150000'])
+
+push_client.unsubscribe_quote(['AAPL  250829C00150000'])
+```
+
+> 注意: `subscribe_option` 使用空格分隔格式 `'AAPL 20250829 150.0 CALL'`，
+> 而 `subscribe_quote` 使用 OCC 格式 `'AAPL  250829C00150000'`。
+> Note: `subscribe_option` uses space-separated format, while `subscribe_quote` uses OCC format.
+
+### 期货行情 / Future Quotes
+
+```python
+# 订阅期货行情 / Subscribe future quotes
+push_client.subscribe_future(['CL2509'])
+```
+
+### 数字货币行情 / Crypto Quotes
+
+```python
+# 数字货币使用 subscribe_cc / Use subscribe_cc for crypto
+push_client.subscribe_cc(['BTC/USD', 'ETH/USD'])
+push_client.unsubscribe_cc(['BTC/USD'])
+# 回调: cc_changed, cc_bbo_changed / Callbacks: cc_changed, cc_bbo_changed
+```
+
+### 深度盘口 / Depth Quotes
+
+```python
+push_client.subscribe_depth_quote(['AAPL'])  # 需要 L2 权限 / Requires L2
+push_client.unsubscribe_depth_quote(['AAPL'])
+```
+
+### 逐笔成交 / Trade Ticks
+
+```python
+push_client.subscribe_tick(['AAPL'])
+push_client.unsubscribe_tick(['AAPL'])
+
+# 完整逐笔(含历史) / Full tick (includes history)
+# 需在连接前设置，且 PushClient 必须传入 client_config
+# Must set before connect, and PushClient must have client_config
+push_client.use_full_tick = True
+push_client.subscribe_tick(['AAPL'])
+# 回调: full_tick_changed / Callback: full_tick_changed
+```
+
+### K线推送 / K-line Push
+
+```python
+# 订阅分钟K线 / Subscribe minute K-lines
+push_client.subscribe_kline(['AAPL'])
+push_client.unsubscribe_kline(['AAPL'])
+```
+
+### 交易相关 / Trading Events
+
+```python
+# 订单变动 / Order changes (连接后自动推送 / auto-pushed after connect)
+push_client.subscribe_order()
+push_client.unsubscribe_order()
+
+# 持仓变动 / Position changes
+push_client.subscribe_position()
+push_client.unsubscribe_position()
+
+# 资产变动 / Asset changes
+push_client.subscribe_asset()
+push_client.unsubscribe_asset()
+
+# 成交推送 / Transaction changes
+push_client.subscribe_transaction()
+push_client.unsubscribe_transaction()
+```
+
+### 热门排行 / Hot Trading Rank
+
+```python
+from tigeropen.common.consts import StockRankingIndicator, OptionRankingIndicator
+
+# 股票热门排行(需传 market 和可选 indicators) / Stock hot ranking (requires market, optional indicators)
+push_client.subscribe_stock_top('US', indicators=[StockRankingIndicator.Amount, StockRankingIndicator.ChangeRate])
+push_client.unsubscribe_stock_top('US')
+
+# 期权热门排行 / Option hot ranking
+push_client.subscribe_option_top('US', indicators=[OptionRankingIndicator.Volume])
+push_client.unsubscribe_option_top('US')
+```
+
+> `StockRankingIndicator`: ChangeRate, ChangeRate5Min, TurnoverRate, Amount, Volume, Amplitude
+> `OptionRankingIndicator`: BigOrder, Volume, Amount, OpenInt
+
+### 全市场订阅 / Market-wide Subscription
+
+```python
+# 订阅整个市场行情 / Subscribe entire market
+push_client.subscribe_market('US')
+push_client.unsubscribe_market('US')
+```
+
+### 查询已订阅 / Query Subscriptions
+
+```python
+subscribed = push_client.query_subscribed_quote()
+print(f"已订阅: {subscribed}")
+```
+
+---
+
+## 断开连接 / Disconnect
+
+```python
+push_client.disconnect()
+```
+
+---
+
+## 完整示例 / Complete Example
+
+```python
+import time
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.push.push_client import PushClient
+
+config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+protocol, host, port = config.socket_host_port
+push_client = PushClient(host, port, use_ssl=(protocol == 'ssl'), use_protobuf=True, client_config=config)
+
+def on_quote(frame):
+    print(f"{frame.symbol}: {frame.latest_price} ({frame.latest_change_percent}%)")
+
+def on_quote_bbo(frame):
+    print(f"{frame.symbol}: bid={frame.bid_price}, ask={frame.ask_price}")
+
+def on_order(frame):
+    print(f"Order {frame.id}: {frame.status}, filled={frame.filled_quantity}")
+
+def on_position(frame):
+    print(f"{frame.symbol}: qty={frame.quantity}, pnl={frame.unrealized_pnl}")
+
+def on_asset(frame):
+    print(f"Net: {frame.net_liquidation}, Available: {frame.available_funds}")
+
+def on_connected():
+    print("Connected! Subscribing...")
+    push_client.subscribe_quote(['AAPL', 'TSLA', '00700'])
+    push_client.subscribe_order()
+    push_client.subscribe_position()
+    push_client.subscribe_asset()
+
+def on_disconnected():
+    print("Disconnected, will auto-reconnect...")
+
+push_client.quote_changed = on_quote
+push_client.quote_bbo_changed = on_quote_bbo
+push_client.order_changed = on_order
+push_client.position_changed = on_position
+push_client.asset_changed = on_asset
+push_client.connect_callback = on_connected
+push_client.disconnect_callback = on_disconnected
+
+push_client.connect(config.tiger_id, config.private_key)
+
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    push_client.disconnect()
+    print("Disconnected")
+```
+
+---
+
+## 带自动重连的断线处理 / Reconnection with Resubscription
+
+```python
+def on_disconnected():
+    """断线回调，PushClient 会自动重连，重连后需要重新订阅"""
+    print("Disconnected, auto-reconnecting...")
+
+def on_connected():
+    """重连成功后重新订阅"""
+    print("Reconnected, resubscribing...")
+    push_client.subscribe_quote(['AAPL', 'TSLA'])
+    push_client.subscribe_order()
+
+push_client.connect_callback = on_connected
+push_client.disconnect_callback = on_disconnected
+```
+
+---
+
+## STOMP 协议(备选) / STOMP Protocol (Alternative)
+
+```python
+from tigeropen.push.push_client import PushClient
+
+protocol, host, port = client_config.socket_host_port
+stomp_client = PushClient(host, port, use_ssl=(protocol == 'ssl'), use_protobuf=False)
+# 使用方式与 Protobuf PushClient 类似 / Usage similar to Protobuf PushClient
+```
+
+---
+
+## 订阅限制 / Subscription Limits
+
+订阅数量取决于行情权限等级(基于资产/交易量)：
+Subscription limits depend on permission tier (based on assets/volume):
+
+| 等级 Tier | 标准订阅 Standard | 深度订阅 Depth |
+|----------|------------------|---------------|
+| 基础 Base | 20 | 10 |
+| 高级 Advanced ($50K+) | 100 | 50 |
+| 顶级 Top ($1M+) | 2000 | 500 |
+
+---
+
+## 所有回调属性一览 / All Callback Properties
+
+| 回调 Callback | 说明 Description |
+|--------------|-----------------|
+| `quote_changed` | 行情变动(价格/成交量等) Quote changes |
+| `quote_bbo_changed` | 买一卖一盘口变动 Best bid/offer changes |
+| `quote_depth_changed` | 深度盘口变动 Depth quote changes |
+| `tick_changed` | 逐笔成交 Trade ticks |
+| `full_tick_changed` | 完整逐笔(含历史，需 `use_full_tick=True`) Full ticks |
+| `kline_changed` | K线推送 K-line changes |
+| `cc_changed` | 数字货币行情 Crypto quote changes |
+| `cc_bbo_changed` | 数字货币盘口 Crypto BBO changes |
+| `stock_top_changed` | 股票热门排行 Stock top ranking |
+| `option_top_changed` | 期权热门排行 Option top ranking |
+| `order_changed` | 订单变动 Order changes |
+| `position_changed` | 持仓变动 Position changes |
+| `asset_changed` | 资产变动 Asset changes |
+| `transaction_changed` | 成交推送 Transaction changes |
+| `connect_callback` | 连接成功 Connected |
+| `disconnect_callback` | 断开连接 Disconnected |
+| `error_callback` | 错误 Error |
+| `kickout_callback` | 被踢出 Kicked out |
+| `subscribe_callback` | 订阅结果 Subscribe result |
+| `unsubscribe_callback` | 退订结果 Unsubscribe result |
+| `heartbeat_callback` | 心跳 Heartbeat |
+
+---
+
+## 注意事项 / Notes
+
+- 推荐 Protobuf 协议(默认)，性能优于 STOMP / Protobuf (default) recommended over STOMP
+- PushClient 有自动重连机制 / Auto-reconnects after disconnection
+- 同一 tiger_id 只能有一个推送连接 / Only one push connection per tiger_id
+- 新连接会踢掉旧连接(触发 kickout_callback) / New connection kicks old one
+- 订单/持仓/资产变动连接后自动推送 / Trade events auto-pushed after connect
+- 行情推送需对应行情权限 / Quote push requires corresponding permissions
+- 深度推送需 L2 权限 / Depth push requires L2 permission
+- 断线重连后需重新订阅 / Resubscribe after reconnection
+- `use_full_tick = True` 需在连接前设置，且 PushClient 需传入 `client_config` / Set before connect, requires `client_config`
+- `subscribe_option` 使用空格分隔格式，`subscribe_quote` 使用 OCC 格式 / Different symbol formats for option subscription
+- `subscribe_stock_top`/`subscribe_option_top` 需传入 `market` 参数 / Requires `market` parameter

--- a/.claude/skills/tigeropen/references/quickstart.md
+++ b/.claude/skills/tigeropen/references/quickstart.md
@@ -1,0 +1,489 @@
+
+# Tiger Open API Python SDK
+
+> 中文 | English — 本技能双语编写，代码示例通用。This skill is bilingual with shared code examples.
+
+## 概述 / Overview
+
+老虎量化开放平台 Python SDK (tigeropen) 为个人和机构用户提供交易与行情 API，支持美股、港股、A股、新加坡、澳洲市场的股票、期权、期货等品种。
+The Tiger Open Platform Python SDK (tigeropen) provides trading and market data APIs for stocks, options, futures across US, HK, China A-shares, Singapore, and Australia markets.
+
+- 官方文档 / Docs: https://docs.itigerup.com/docs/prepare
+- GitHub: https://github.com/tigerfintech/openapi-python-sdk
+- SDK Version: 3.5.6 | Python: 3.8 - 3.14
+
+### 支持的市场和品种 / Supported Markets
+
+| 市场 Market | 股票/ETF | 期权 Options | 期货 Futures | 窝轮/牛熊证 Warrants/CBBC |
+|-------------|---------|-------------|-------------|--------------------------|
+| 美国 US     | ✅      | ✅          | ✅          | -                        |
+| 香港 HK     | ✅      | ✅          | ✅          | ✅                       |
+| 新加坡 SG   | ✅      | -           | ✅          | -                        |
+| 澳洲 AU    | ✅      | -           | -           | -                        |
+| A股 CN      | ✅      | -           | -           | -                        |
+
+### 支持的订单类型 / Supported Order Types
+
+市价单 MKT, 限价单 LMT, 止损单 STP, 止损限价单 STP_LMT, 跟踪止损单 TRAIL, 附加订单(止盈止损), 算法单 TWAP/VWAP
+
+## 安装 / Installation
+
+```bash
+pip install tigeropen
+
+# 升级 / Upgrade
+pip install tigeropen --upgrade
+
+# 或使用 conda / Or use conda
+conda install tigeropen
+
+# 验证 / Verify
+python -c "import tigeropen; print(tigeropen.__VERSION__)"
+```
+
+## 前置条件 / Prerequisites
+
+1. 开通老虎证券账户并入金 / Open a Tiger Brokers account and fund it
+2. 个人用户访问 https://developer.itigerup.com/profile 激活 API 权限 / Individual users activate API permissions
+   机构用户访问机构账户中心 / Institutional users visit institutional account center
+3. 获取 `tiger_id`、RSA 私钥(PKCS#1格式)和资金账号 / Obtain `tiger_id`, RSA private key (PKCS#1 format), and account
+4. 导出配置文件 `tiger_openapi_config.properties` / Export config file
+
+> 私钥不会保存在服务端，刷新页面后消失，请务必保存。Private key is not stored on server; save it before refreshing the page.
+> Java 使用 PKCS#8 格式，Python 使用 PKCS#1 格式。Java uses PKCS#8, Python uses PKCS#1.
+
+## 账户类型 / Account Types
+
+| 类型 Type | 说明 Description | 推荐 |
+|-----------|-----------------|------|
+| 综合账户 Comprehensive (Live) | 支持所有市场、保证金交易、全品种。**推荐** | ✅ |
+| 环球账户 Global (Live) | 环球账户类型，不支持窝轮/牛熊证 | - |
+| 模拟账户 Paper | 测试用，支持美股/港股/A股/期权，无需真实资金 | 测试推荐 |
+
+## 配置 / Configuration
+
+### 方式一：配置文件(推荐) / Config File (Recommended)
+
+从开发者网站导出配置文件 `tiger_openapi_config.properties`，放入合适的系统路径(请不要修改文件名)。
+Export config file from developer website and place it in a suitable path.
+
+配置文件格式 / Config file format:
+
+```properties
+tiger_id=YOUR_TIGER_ID
+account=12345678
+license=TBHK
+private_key_pk1=MIICXgIBAAKBgQC.....your_pkcs1_private_key
+private_key_pk8=MIICeAIBADANBgk.....your_pkcs8_private_key
+env=PROD
+# 机构用户需额外配置 / Institutional users also need:
+# secret_key=your_secret_key
+```
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+
+# 指定配置文件所在目录 / Specify directory containing config file
+client_config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+# 也可将配置文件放入程序当前目录，SDK 默认取当前路径
+# Or place config file in current directory; SDK defaults to current path
+```
+
+> 港股牌照(TBHK)还需将 `tiger_openapi_token.properties` 放入同一目录。
+> HK license (TBHK) also requires `tiger_openapi_token.properties` in the same directory.
+
+### 方式二：环境变量 / Environment Variables
+
+```bash
+export TIGEROPEN_TIGER_ID="your_tiger_id"
+export TIGEROPEN_PRIVATE_KEY="your_private_key_content"  # 私钥内容或私钥文件路径 / Key content or file path
+export TIGEROPEN_ACCOUNT="your_account"
+# 可选 / Optional:
+# export TIGEROPEN_PROPS_PATH="/path/to/config/"  # 配置文件目录 / Config file directory
+# export TIGEROPEN_LICENSE="TBSG"
+# export TIGEROPEN_SECRET_KEY="your_secret_key"  # 机构用户 / Institutional users
+# export TIGEROPEN_TOKEN="your_2fa_token"  # TBHK 牌照 / TBHK license
+```
+
+```python
+client_config = TigerOpenClientConfig()  # 自动读取环境变量 / Auto-reads env vars
+```
+
+### 方式三：代码赋值 / Code Assignment
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.common.util.signature_utils import read_private_key
+
+client_config = TigerOpenClientConfig()
+client_config.tiger_id = 'your_tiger_id'
+client_config.private_key = read_private_key('/path/to/private_key.pem')  # 读取 PKCS#1 格式 PEM 文件
+# 私钥也可直接填字符串内容 / Or set private key content directly:
+# client_config.private_key = 'MIICWwIBAAKBgQCSW+.....私钥内容'
+client_config.account = 'your_account'
+client_config.license = 'TBSG'  # 牌照信息 / License info
+client_config.language = Language.zh_CN  # 可选，默认英语 / Optional, defaults to English
+# client_config.timezone = 'US/Eastern'  # 可选时区 / Optional timezone
+```
+
+> 优先级 Priority: 代码参数 code > 环境变量 env > 配置文件 config > 默认值 defaults
+
+### 机构用户 / Institutional Users
+
+```python
+client_config.secret_key = 'your_secret_key'  # 在机构中心获取 / Obtain from institutional center
+# 香港机构(TBHK牌照)需额外设置 token / HK institutional (TBHK license) needs token:
+# client_config.token = 'your_2fa_token'
+# token 有效期30天，可配置自动刷新 / Token valid for 30 days, can auto-refresh:
+# client_config.token_refresh_duration = 24 * 60 * 60  # 单位秒 / seconds
+```
+
+## 创建客户端 / Create Clients
+
+```python
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.trade.trade_client import TradeClient
+
+# 行情客户端 / Quote client (建议模块级创建一次并复用 / create once and reuse)
+quote_client = QuoteClient(client_config=client_config)
+# is_grab_permission 默认 True，自动抢占行情权限
+# 多设备同账号时仅最后抢占的设备收到行情
+
+# 交易客户端 / Trade client
+trade_client = TradeClient(client_config=client_config)
+```
+
+## 模拟交易 / Paper Trading
+
+```python
+client_config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+client_config.account = 'your_paper_account'  # 17位数字模拟账号 / 17-digit paper account
+# 模拟账户支持美股/港股/A股/期权
+```
+
+> `sandbox_debug` 参数已废弃，请勿使用。SDK 通过账号自动识别模拟账户。
+> `sandbox_debug` is deprecated. SDK auto-detects paper accounts by account number.
+
+## 完整入门示例 / Complete Quickstart
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.common.consts import Market, BarPeriod
+from tigeropen.quote.quote_client import QuoteClient
+from tigeropen.trade.trade_client import TradeClient
+
+# 1. 加载配置(推荐使用配置文件) / Load config (config file recommended)
+client_config = TigerOpenClientConfig(props_path='/path/to/your/config/')
+
+# 或代码赋值 / Or code assignment:
+# from tigeropen.common.util.signature_utils import read_private_key
+# client_config = TigerOpenClientConfig()
+# client_config.tiger_id = 'your_tiger_id'
+# client_config.private_key = read_private_key('/path/to/private_key.pem')
+# client_config.account = 'your_account'
+
+# 2. 创建客户端 / Create clients
+quote_client = QuoteClient(client_config=client_config)
+trade_client = TradeClient(client_config=client_config)
+
+# 3. 查看市场状态 / Check market status
+status = quote_client.get_market_status(Market.US)
+for s in status:
+    print(f"Market: {s.market}, Status: {s.trading_status}, Open: {s.open_time}")
+
+# 4. 获取实时行情 / Get real-time quotes
+briefs = quote_client.get_stock_briefs(['AAPL', 'TSLA'])
+# get_stock_briefs returns a pandas DataFrame
+for _, b in briefs.iterrows():
+    print(f"{b['symbol']}: price={b['latest_price']}, change={b['change_percentage']}%")
+
+# 5. 获取K线 / Get K-line data
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, limit=30)
+print(bars.tail())
+
+# 6. 查看账户 / Check account
+assets = trade_client.get_prime_assets(base_currency='USD')
+# Access via segments dict: 'S' = 综合(Standard), 'G' = 环球(Global)
+segment = assets.segments.get('S') or assets.segments.get('G')
+if segment:
+    print(f"Net Liquidation: {segment.net_liquidation}, Available: {segment.cash_available_for_trade}")
+
+# 7. 查看持仓 / Check positions
+positions = trade_client.get_positions()
+for p in positions:
+    print(f"{p.contract.symbol}: qty={p.quantity}, pnl={p.unrealized_pnl}")
+```
+
+## 核心模块 / Core Modules
+
+| 模块 Module | 用途 Purpose | 导入路径 Import |
+|-------------|-------------|----------------|
+| `TigerOpenClientConfig` | 配置管理 / Config | `tigeropen.tiger_open_config` |
+| `QuoteClient` | 行情数据 / Market data | `tigeropen.quote.quote_client` |
+| `TradeClient` | 交易操作 / Trading | `tigeropen.trade.trade_client` |
+| `PushClient` | 实时推送 / Real-time push | `tigeropen.push.push_client` |
+
+## 枚举参考 / Enum Reference
+
+```python
+from tigeropen.common.consts import (
+    Market,        # ALL, US, HK, CN, SG, AU
+    SecurityType,  # STK, OPT, FUT, WAR, IOPT, CASH, FUND, MLEG, CC
+    Currency,      # USD, HKD, CNH, SGD, AUD
+    Language,      # zh_CN, zh_TW, en_US
+    OrderType,     # MKT, LMT, STP, STP_LMT, TRAIL, TWAP, VWAP
+    OrderStatus,   # Initial, PendingSubmit, Submitted, PartiallyFilled, Filled, Cancelled, Inactive, PendingCancel
+    BarPeriod,     # DAY, WEEK, MONTH, YEAR, ONE_MINUTE, THREE_MINUTES, FIVE_MINUTES, TEN_MINUTES,
+                   # FIFTEEN_MINUTES, HALF_HOUR, FORTY_FIVE_MINUTES, ONE_HOUR, TWO_HOURS, THREE_HOURS, FOUR_HOURS, SIX_HOURS
+    QuoteRight,    # BR(前复权/forward), NR(不复权/none)
+    TradingSession,  # PreMarket, Regular, AfterHours
+    TimeInForce,   # DAY, GTC, GTD
+)
+```
+
+### SecurityType 证券类型
+
+| 值 Value | 说明 Description |
+|----------|-----------------|
+| `STK` | 股票/ETF Stock |
+| `OPT` | 期权 Option |
+| `FUT` | 期货 Future |
+| `WAR` | 窝轮 Warrant |
+| `IOPT` | 牛熊证 CBBC/Inline Warrant |
+| `FUND` | 基金 Fund |
+| `CASH` | 外汇 Forex |
+| `CC` | 数字货币 Cryptocurrency |
+| `MLEG` | 组合 Multi-leg Combo |
+
+### OrderStatus 订单状态
+
+| 状态 Status | 说明 Description |
+|------------|-----------------|
+| `Initial` | 初始化 / Created |
+| `PendingSubmit` | 待提交 / Pending submit |
+| `Submitted` | 已提交 / Submitted, awaiting fill |
+| `PartiallyFilled` | 部分成交 / Partially filled |
+| `Filled` | 全部成交 / Fully filled |
+| `Cancelled` | 已取消 / Cancelled |
+| `Inactive` | 已失效 / Rejected by system |
+| `PendingCancel` | 待取消 / Pending cancel |
+
+### BarPeriod K线周期
+
+`day`, `week`, `month`, `year`, `1min`, `3min`, `5min`, `10min`, `15min`, `30min`, `45min`, `60min`, `2hour`, `3hour`, `4hour`, `6hour`
+
+### Market Scanner 相关枚举
+
+```python
+from tigeropen.common.consts import (
+    StockField,       # stockField: Change, ChangeRate, LatestPrice, Volume, Amount, TurnoverRate, FloatShare, FloatMarketValue...
+    AccumulateField,  # accumulateField: ChangeRate, Amount, Volume
+    FinancialField,   # financialField: TotalRevenue, NetIncome, EpsDiluted, ROE, PE_TTM, PB...
+    MultiTagField,    # multiTagField: HasOption, IsETF, IndustryCode, ExchangeCode
+    SortDirection,    # ASC, DESC
+)
+```
+
+## 核心对象参考 / Key Object Reference
+
+### PortfolioAccount 资产对象 (get_prime_assets)
+
+`get_prime_assets()` 返回 `PortfolioAccount` 对象，资产数据在 `segments` 字典中：
+
+```python
+assets = trade_client.get_prime_assets(base_currency='USD')
+# segments 键: 'S' = 综合账户(Standard), 'G' = 环球账户(Global)
+segment = assets.segments.get('S') or assets.segments.get('G')
+print(f"Net: {segment.net_liquidation}, Cash: {segment.cash_balance}")
+```
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `segments` | 账户分组字典 `{'S': ..., 'G': ...}` |
+| `segment.net_liquidation` | 总资产/净清算值 Net liquidation value |
+| `segment.cash_balance` | 现金 Cash balance |
+| `segment.cash_available_for_trade` | 可用资金 Available funds for trading |
+| `segment.buying_power` | 购买力 Buying power |
+| `segment.gross_position_value` | 总持仓价值 Gross position value |
+| `segment.unrealized_pl` | 未实现盈亏 Unrealized P&L |
+| `segment.realized_pl` | 已实现盈亏 Realized P&L |
+| `segment.init_margin` | 初始保证金 Initial margin |
+| `segment.maintain_margin` | 维持保证金 Maintenance margin |
+| `segment.currency_assets` | 多币种资产明细 dict {currency: CurrencyAsset} |
+
+### Position 持仓对象
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `contract` | 合约对象 Contract object |
+| `qty` / `quantity` | 持仓数量 Position quantity |
+| `average_cost` | 持仓均价 Average cost |
+| `market_price` | 市场价 Market price |
+| `market_value` | 市值 Market value |
+| `unrealized_pnl` | 未实现盈亏 Unrealized P&L |
+| `realized_pnl` | 已实现盈亏 Realized P&L |
+| `salable_qty` | 可卖数量 Salable quantity |
+
+### Order 订单对象
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `id` | 全局订单ID Global order ID |
+| `order_id` | 用户订单ID User order ID |
+| `symbol` | 标的代码 Symbol |
+| `action` | BUY/SELL |
+| `order_type` | 订单类型 Order type |
+| `status` | 订单状态 Order status |
+| `quantity` | 下单数量 Order quantity |
+| `filled_quantity` | 成交数量 Filled quantity |
+| `limit_price` | 限价 Limit price |
+| `aux_price` | 触发价/回撤价 Aux price |
+| `avg_fill_price` | 均价 Average fill price |
+| `trade_time` | 交易时间 Trade time |
+| `time_in_force` | 有效期 Time in force |
+| `outside_rth` | 是否盘前盘后 Outside RTH |
+| `order_legs` | 附加订单 Attached orders |
+
+### Contract 合约对象
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `symbol` | 代码 Symbol |
+| `sec_type` | 证券类型 Security type |
+| `currency` | 货币 Currency |
+| `exchange` | 交易所 Exchange |
+| `name` | 名称 Name |
+| `expiry` | 到期日(期权/期货) Expiry |
+| `strike` | 行权价(期权) Strike |
+| `put_call` | 看涨/看跌(期权) Put/Call |
+| `multiplier` | 乘数 Multiplier |
+| `lot_size` | 每手股数 Lot size |
+| `shortable` | 可否卖空 Shortable |
+| `shortable_count` | 可卖空数量 Shortable count |
+| `min_tick` | 最小价格变动 Min tick size |
+
+## 行情权限与限制 / Quote Permissions & Limits
+
+### 权限类型 / Permission Types
+
+- 美股L1 `usQuoteBasic` (Nasdaq Basic), 美股L2 `usStockQuoteLv2Totalview` (40档深度)
+- 港股BMP (手动刷新), 港股L2 `hkStockQuoteLv2` (10档深度, 自动推送)
+- 美期权 `usOptionQuote`, 港期权L2 (随港期货L2)
+- 期货L2: CBOE, HKFE, SGX, OSE
+
+### 配额限制 / Quota Limits (取决于资产/交易量等级)
+
+| 等级 | 历史行情(股票/期货/期权) | 订阅(标准/深度) |
+|------|------------------------|----------------|
+| 基础 | 20/10/10 次 | 20/10 个 |
+| 高级($50K+) | 100/50/100 | 100/50 |
+| 顶级($1M+) | 2000/200/2000 | 2000/500 |
+
+> 行情权限需单独购买，API 与 App 独立。详见 https://docs.itigerup.com/docs/permission
+
+## 请求频率限制 / Rate Limits
+
+60秒滚动窗口 / 60-second rolling window:
+
+| 限制 Limit | 接口 APIs |
+|-----------|----------|
+| 120/min (高频) | 下单/撤单/改单/查询订单, 实时行情, 分时, 逐笔, 期权行情, 期货行情 |
+| 60/min (中频) | 期权链, 深度行情, 合约, K线, 资产, 持仓, 成交 |
+| 10/min (低频) | 行情权限, 市场状态, 代码列表, 股票详情, 期货交易所 |
+
+> 超频返回 code=4/5。持续超频可能导致账户限制。Rate limit exceeded returns code=4/5.
+
+## 错误代码 / Error Codes
+
+| 代码 Code | 说明 Description |
+|-----------|-----------------|
+| 0 | 成功 Success |
+| 1 | 服务器错误 Server error |
+| 2 | 网络超时 Network timeout |
+| 4 | 访问拒绝 Access forbidden (IP白名单/签名失败/订阅超限) |
+| 5 | 频率限制 Rate limit (HTTP 429) |
+| 1000 | 通用参数错误 Common param error |
+| 1010 | 业务参数错误 Business param error |
+| 1100 | 全球账户交易错误 Global account trade error |
+| 1200 | 综合账户交易错误 Comprehensive account trade error |
+| 1300 | 模拟账户交易错误 Paper account trade error |
+| 2100-2300 | 行情数据错误 Market data error |
+| 4000 | 权限不足 Permission denied |
+| 4001 | 被新连接踢出 Kicked out by new connection |
+
+### 频率限制恢复 / Rate Limit Recovery
+
+```python
+import time
+
+def safe_api_call(func, *args, max_retries=3, **kwargs):
+    for attempt in range(max_retries):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            if 'rate limit' in str(e).lower() or '429' in str(e):
+                wait = 2 ** attempt
+                time.sleep(wait)
+            else:
+                raise
+    raise Exception("Max retries exceeded")
+```
+
+## 常见问题 / FAQ
+
+### 私钥格式 / Private Key Format
+
+Python SDK **同时支持 PKCS#1 和 PKCS#8** 格式（DER base64 裸字符串，无 PEM 头尾行）。
+配置文件字段优先级：`private_key_pk1` 先读，若空则读 `private_key_pk8`。
+
+```properties
+# 任选其一即可 / Either format works:
+private_key_pk1=MIICXQIBAAKBgQD...    # PKCS#1 DER base64
+private_key_pk8=MIICdwIBADANBgk...    # PKCS#8 DER base64
+```
+
+如需转换 PEM → DER base64：
+
+```bash
+# PKCS#1 PEM → DER base64
+openssl rsa -in pk1.pem -outform DER | base64 | tr -d '\n'
+
+# PKCS#8 PEM → DER base64
+openssl pkcs8 -topk8 -inform PEM -outform DER -nocrypt -in pk1.pem | base64 | tr -d '\n'
+```
+
+### SSL/证书问题 / SSL Issues
+
+```python
+# macOS 运行 / Run on macOS:
+# /Applications/Python\ 3.x/Install\ Certificates.command
+
+# 或设置环境变量 / Or set env:
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context  # 仅调试 / debug only
+```
+
+### 推送连接问题 / Push Connection Issues
+
+- 同一 tiger_id 只能有一个推送连接，新连接会踢掉旧连接
+- Only one push connection per tiger_id; new connection kicks the old one
+- 断线后 PushClient 自动重连 / Auto-reconnects after disconnection
+
+### Windows 编码问题 / Windows Encoding
+
+```python
+# Windows 终端中文乱码
+import sys, io
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+```
+
+## 注意事项 / Notes
+
+- 认证使用 RSA 签名，Python SDK 支持 PKCS#1 和 PKCS#8 两种格式（DER base64）/ Authentication uses RSA signatures, Python SDK supports both PKCS#1 and PKCS#8 DER base64
+- 私钥可通过 `read_private_key('path/to/pem')` 读取文件，或直接赋值字符串内容 / Private key via `read_private_key()` or direct string
+- `QuoteClient` 应创建一次并复用 / Create once and reuse
+- 行情权限需单独购买，API 与 App 独立 / Quote permissions require separate purchase
+- 交易佣金与 App 一致，无额外 API 费用 / Trading fees same as app
+- `sandbox_debug` 参数已废弃，请勿使用 / `sandbox_debug` is deprecated, do not use
+- 官方文档 / Official docs: https://docs.itigerup.com/docs/prepare
+- 官方支持群 / Support: https://t.me/TigerBrokersAPISupport

--- a/.claude/skills/tigeropen/references/quote.md
+++ b/.claude/skills/tigeropen/references/quote.md
@@ -1,0 +1,883 @@
+
+# Tiger Open API 行情数据 / Market Data
+
+> 中文 | English — 双语技能，代码示例通用。Bilingual skill with shared code examples.
+> 官方文档 Docs: https://docs.itigerup.com/docs/quote-stock
+
+## 初始化 / Initialize
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.quote.quote_client import QuoteClient
+
+client_config = TigerOpenClientConfig(props_path='/path/to/your/tiger_openapi_config.properties')
+quote_client = QuoteClient(client_config=client_config)
+# is_grab_permission 默认 True，自动抢占行情权限 / auto-grabs quote permissions
+# 多设备同账号仅最后抢占的设备收到行情 / last device to grab gets data
+```
+
+> 建议模块级创建一次并复用。Create QuoteClient once and reuse.
+
+---
+
+## 市场状态 / Market Status
+
+```python
+from tigeropen.common.consts import Market
+
+status = quote_client.get_market_status(Market.US)  # US, HK, CN, ALL
+for s in status:
+    print(f"{s.market}: status={s.trading_status}, open={s.open_time}")
+# MarketStatus 属性: market, trading_status, status, open_time
+# trading_status: NOT_YET_OPEN, PRE_HOUR_TRADING, TRADING, MIDDLE_CLOSE, POST_HOUR_TRADING, CLOSING, EARLY_CLOSING
+```
+
+```bash
+# CLI
+tigeropen quote market-status          # 所有市场 / All markets
+tigeropen quote market-status --market US
+tigeropen quote market-status --market HK
+```
+
+## 交易日历 / Trading Calendar
+
+```python
+cal = quote_client.get_trading_calendar(market=Market.US, begin_date='2025-01-01', end_date='2025-12-31')
+# 返回 list[dict] / Returns list of dicts
+# 每项: {'date': '2025-01-02', 'type': 'TRADING'}
+# type: TRADING(交易日) / NON_TRADING(非交易日)
+```
+
+---
+
+## 股票代码与信息 / Stock Symbols & Info
+
+```python
+# 获取所有代码 / Get all symbols
+symbols = quote_client.get_symbols(market=Market.US)  # 返回 symbol 列表
+
+# 获取代码和名称 / Get symbols with names
+names = quote_client.get_symbol_names(market=Market.HK, lang=Language.zh_CN)
+# 返回 DataFrame: symbol, name
+
+# 股票详情 / Stock details
+details = quote_client.get_stock_details(symbols=['AAPL'])
+# 属性: symbol, market, exchange, sec_type, listing_date, float_shares, eps, adr_rate, etf
+```
+
+## 股票基本面 / Stock Fundamentals
+
+```python
+# 基本面指标 / Fundamental indicators
+fundamentals = quote_client.get_stock_fundamental(symbols=['AAPL', 'TSLA'], market='US')
+# 返回 pandas.DataFrame
+```
+
+**get_stock_fundamental 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `symbol` | 股票代码 |
+| `roe` | 净资产收益率 Return on equity |
+| `roa` | 资产收益率 Return on assets |
+| `pb_rate` | 市净率 P/B ratio |
+| `ps_rate` | 市销率 P/S ratio |
+| `divide_rate` | 股息率 Dividend yield |
+| `week52_high` | 52周最高价 52-week high |
+| `week52_low` | 52周最低价 52-week low |
+| `ttm_eps` | TTM每股收益 TTM earnings per share |
+| `lyr_eps` | 上年每股收益 Last year EPS |
+| `volume_ratio` | 量比 Volume ratio |
+| `turnover_rate` | 换手率 Turnover rate |
+| `ttm_pe_rate` | TTM市盈率 TTM P/E ratio |
+| `lyr_pe_rate` | 上年市盈率 Last year P/E ratio |
+| `market_cap` | 总市值 Market capitalization |
+| `float_market_cap` | 流通市值 Float market cap |
+
+> ⚠️ 注意：字段名与 `get_financial_daily` 不同。`get_stock_fundamental` 用 `ttm_pe_rate`，而 `get_financial_daily` 用 `pe_ttm`。
+
+---
+
+## 实时行情 / Real-time Quotes
+
+### 股票 / Stocks
+
+```python
+briefs = quote_client.get_stock_briefs(['AAPL', 'TSLA', '00700'])
+# 返回 pandas.DataFrame / Returns pandas.DataFrame
+for _, row in briefs.iterrows():
+    print(f"{row['symbol']}: price={row['latest_price']}, volume={row['volume']}, "
+          f"open={row['open']}, high={row['high']}, low={row['low']}, pre_close={row['pre_close']}")
+
+# 含盘前盘后 / Include pre/after-hours
+briefs = quote_client.get_stock_briefs(['AAPL'], include_hour_trading=True)
+
+# 延迟行情(无权限时) / Delayed quotes (when no permission)
+delayed = quote_client.get_stock_delay_briefs(symbols=['AAPL'])
+```
+
+**get_stock_briefs 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `symbol` | 股票代码 |
+| `open` | 开盘价 Opening price |
+| `high` | 最高价 Highest price |
+| `low` | 最低价 Lowest price |
+| `close` | 收盘价 Closing price |
+| `pre_close` | 前收价 Previous close |
+| `adj_pre_close` | 复权过的前收价 Adjusted previous close |
+| `latest_price` | 最新价 Latest price |
+| `latest_time` | 最新成交时间（毫秒时间戳） Latest trade time (ms) |
+| `volume` | 成交量 Volume |
+| `ask_price` | 卖一价 Ask price |
+| `ask_size` | 卖一量 Ask size |
+| `bid_price` | 买一价 Bid price |
+| `bid_size` | 买一量 Bid size |
+| `status` | 交易状态: `NORMAL`(正常) / `HALTED`(停牌) / `DELIST`(退市) / `NEW`(新股) / `ALTER`(变更) / `UNKNOWN` |
+| `hour_trading_tag` | 盘前盘后标记（`Pre-Mkt`/`Post-Mkt`） |
+| `hour_trading_latest_price` | 盘前盘后最新价 |
+| `hour_trading_pre_close` | 盘前盘后前收价 |
+| `hour_trading_latest_time` | 盘前盘后最新成交时间 |
+| `hour_trading_volume` | 盘前盘后成交量 |
+| `hour_trading_timestamp` | 盘前盘后时间戳（毫秒） |
+
+> 盘前盘后字段仅在 `include_hour_trading=True` 时有数据。
+```
+
+```bash
+# CLI (需要行情权限 / requires quote permission)
+tigeropen quote briefs AAPL TSLA
+tigeropen quote briefs AAPL --hour-trading   # 含盘前盘后 / include pre/after-hours
+```
+
+### 夜盘行情 / Overnight Quotes
+
+```python
+overnight = quote_client.get_quote_overnight(symbols=['AAPL', 'TSLA'])
+# 返回夜盘交易时段行情 / Returns overnight trading session quotes
+```
+
+### 交易元数据 / Trading Metadata
+
+```python
+metas = quote_client.get_trade_metas(symbols=['AAPL', '00700'])
+# 属性: symbol, market, sec_type, lot_size(每手股数), min_tick(最小价格变动), spread_scale
+```
+
+---
+
+## K线数据 / K-line (Candlestick) Data
+
+```python
+from tigeropen.common.consts import BarPeriod, QuoteRight, TradingSession
+
+# 日K / Daily (返回 DataFrame: symbol, time, open, high, low, close, volume, amount)
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, limit=60)
+
+# 分钟K / Minute
+bars_5m = quote_client.get_bars(['AAPL'], period=BarPeriod.FIVE_MINUTES, limit=100)
+
+# 时间范围 / Time range
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY,
+                              begin_time='2025-01-01', end_time='2025-06-30')
+
+# 复权 / Adjustment: BR(前复权/forward, default), NR(不复权/none)
+bars_nr = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, right=QuoteRight.NR)
+
+# 多股票 / Multiple symbols
+bars = quote_client.get_bars(['AAPL', 'TSLA', 'GOOG'], period=BarPeriod.DAY, limit=30)
+
+# 指定日期的分钟K线 / Minute K-lines for specific date
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.ONE_MINUTE, date='20250618')
+
+# 指定交易时段 / Specific trading session (夜盘 overnight)
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY,
+                              trade_session=TradingSession.OverNight)
+
+# 含基本面数据(PE/换手率) / With fundamental data (PE/turnover)
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, with_fundamental=True)
+
+# 分页(单个标的，使用 page_token) / Pagination (single symbol, via page_token)
+bars = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, limit=100)
+next_token = bars['next_page_token'].iloc[0]
+if next_token:
+    bars_next = quote_client.get_bars(['AAPL'], period=BarPeriod.DAY, limit=100, page_token=next_token)
+```
+
+### 分页获取大量K线 / Paginated K-line for Large Datasets
+
+```python
+# 自动分页获取(注意: symbol 为单个字符串) / Auto-paginated fetch (note: symbol is a single string)
+bars = quote_client.get_bars_by_page(symbol='AAPL', period=BarPeriod.DAY,
+                                      begin_time='2020-01-01', end_time='2025-01-01',
+                                      total=2000)
+# 也支持 trade_session 和 with_fundamental 参数
+# Also supports trade_session and with_fundamental params
+```
+
+**get_bars 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `symbol` | 股票代码 |
+| `time` | K线时间（毫秒时间戳） Timestamp in milliseconds |
+| `open` | 开盘价 Opening price |
+| `high` | 最高价 Highest price |
+| `low` | 最低价 Lowest price |
+| `close` | 收盘价 Closing price |
+| `volume` | 成交量 Trading volume |
+| `amount` | 成交额 Trading amount |
+| `next_page_token` | 下一页令牌（单标的分页时使用） Next page token (single symbol pagination) |
+
+> `with_fundamental=True` 时额外返回 `pe_ttm`、`turnover_rate` 等字段。
+
+**K线周期 / Bar Periods**: `day/week/month/year/1min/3min/5min/10min/15min/30min/45min/60min/2hour/3hour/4hour/6hour`
+
+```bash
+# CLI
+tigeropen quote bars AAPL                               # 日K，251根
+tigeropen quote bars AAPL --period 5min --limit 100    # 5分钟K线
+tigeropen quote bars AAPL --begin-time 2026-01-01 --end-time 2026-03-31  # 时间范围
+tigeropen quote bars AAPL TSLA                   # 多标的
+```
+
+---
+
+## 深度行情 / Depth Quote (Level 2)
+
+```python
+# 美股深度 / US depth (需要 L2 权限 / requires L2 permission)
+depth = quote_client.get_depth_quote(['AAPL'], market=Market.US)
+# 返回 asks(卖盘) 和 bids(买盘)，每档: price, volume, order_count
+# US: 最多40档 / up to 40 levels
+
+# 港股深度 / HK depth
+depth = quote_client.get_depth_quote(['00700'], market=Market.HK)
+# HK: 最多10档 / up to 10 levels
+```
+
+**get_depth_quote 返回结构 / Return Structure**:
+
+单个标的时返回 dict / Single symbol returns a dict:
+```python
+{
+    'symbol': 'AAPL',
+    'asks': [(ask_price1, ask_volume1, order_count1), (ask_price2, ...)],  # 卖盘，从低到高
+    'bids': [(bid_price1, bid_volume1, order_count1), (bid_price2, ...)],  # 买盘，从高到低
+}
+
+# 访问示例 / Access example:
+asks = depth['asks']  # [(226.50, 300, 2), (226.55, 500, 1), ...]
+bids = depth['bids']  # [(226.45, 400, 3), (226.40, 200, 1), ...]
+for price, volume, order_count in asks[:5]:
+    print(f"Ask: price={price}, vol={volume}, orders={order_count}")
+```
+
+多个标的时返回嵌套 dict / Multiple symbols return nested dict:
+```python
+{
+    'AAPL': {'symbol': 'AAPL', 'asks': [...], 'bids': [...]},
+    'TSLA': {'symbol': 'TSLA', 'asks': [...], 'bids': [...]},
+}
+```
+
+```bash
+# CLI (--market 为必选参数 / --market is required)
+tigeropen quote depth AAPL --market US
+tigeropen quote depth 00700 --market HK
+```
+
+## 逐笔成交 / Trade Ticks
+
+```python
+from tigeropen.common.consts import TradingSession
+
+ticks = quote_client.get_trade_ticks(symbols=['AAPL'], limit=50)
+# 返回 DataFrame: symbol, time, price, volume, direction(+/-), index
+
+# 指定交易时段 / Specific trading session
+ticks = quote_client.get_trade_ticks(symbols=['AAPL'], limit=100,
+                                      trade_session=TradingSession.Regular)
+
+# 分页(使用 begin_index/end_index) / Pagination via begin_index/end_index
+ticks = quote_client.get_trade_ticks(symbols=['AAPL'], begin_index=0, end_index=100)
+```
+
+```bash
+# CLI
+tigeropen quote ticks AAPL
+tigeropen quote ticks AAPL --limit 50
+```
+
+## 分时数据 / Timeline (Intraday)
+
+```python
+# 当日分时 / Today's timeline
+timeline = quote_client.get_timeline(['AAPL'], include_hour_trading=True)
+# 返回 DataFrame: symbol, time, price, avg_price, pre_close, volume, trade_session
+
+# 指定交易时段 / Specific trading session
+timeline = quote_client.get_timeline(['AAPL'], trade_session=TradingSession.OverNight)
+
+# 历史某日分时 / Historical date
+timeline = quote_client.get_timeline_history(['AAPL'], date='2025-06-18')
+# 也支持 trade_session 参数 / Also supports trade_session param
+```
+
+```bash
+# CLI
+tigeropen quote timeline AAPL                     # 今日分时
+tigeropen quote timeline AAPL --date 2026-03-20   # 历史某日
+```
+
+---
+
+## 资金流向 / Capital Flow
+
+```python
+from tigeropen.common.consts import CapitalPeriod
+
+# 资金流向 / Capital flow (使用 CapitalPeriod 枚举)
+flow = quote_client.get_capital_flow(symbol='AAPL', market='US',
+                                      period=CapitalPeriod.DAY,
+                                      begin_time='2025-01-01', end_time='2025-06-30')
+# 返回 DataFrame: time, timestamp, net_inflow, symbol, period
+# CapitalPeriod 可选值: INTRADAY, DAY, WEEK, MONTH, YEAR, QUARTER, HALFAYEAR
+
+# 资金分布 / Capital distribution
+distribution = quote_client.get_capital_distribution(symbol='AAPL', market='US')
+# 属性: net_inflow, super_large_net_inflow, large/middle/small_net_inflow
+```
+
+```bash
+# CLI
+tigeropen quote capital flow AAPL --market US --period day
+tigeropen quote capital distribution AAPL --market US
+```
+
+## 港股经纪商 / HK Broker Data
+
+```python
+# 经纪商席位 / Broker seats (返回 StockBroker 对象)
+broker = quote_client.get_stock_broker('00700', limit=40)
+# broker.bid_broker: 买方经纪商列表(LevelBroker: level, price, broker_count, broker)
+# broker.ask_broker: 卖方经纪商列表
+
+# 经纪商持仓(CCASS) / Broker holdings (CCASS) - 独立方法
+hold = quote_client.get_broker_hold(symbol='00700', limit=40)
+```
+
+## 热门交易排行 / Hot Trading Rank
+
+```python
+rank = quote_client.get_trade_rank(market='US')
+# 返回热门交易标的排行
+```
+
+---
+
+## 基本面数据 / Fundamental Data
+
+### 每日财务指标 / Daily Financial Metrics
+
+```python
+financial = quote_client.get_financial_daily(
+    symbols=['AAPL'],
+    fields=['pe_ttm', 'pb', 'ps_ttm', 'market_value', 'shares_outstanding', 'market_capitalization'],
+    begin_date='2025-01-01', end_date='2025-06-30')
+# 返回 DataFrame: symbol, date, 及所选字段
+# 可选字段: market_value, pe_ttm, pb, ps_ttm, pcf_ttm, market_capitalization,
+#          shares_outstanding, total_share, eps_ttm, dividend_ttm, dividend_rate_ttm
+```
+
+### 财务报告 / Financial Reports
+
+```python
+report = quote_client.get_financial_report(
+    symbols=['AAPL'],
+    fields=['total_revenue', 'net_income', 'eps_diluted', 'gross_profit'],
+    period_type='LTM')  # Annual/Quarterly/LTM/CumulativeQuarterly
+# 可选字段类别:
+# Income: total_revenue, cost_of_revenue, gross_profit, operating_income, net_income, eps_diluted, ebitda...
+# Balance: total_assets, total_liabilities, total_equity, cash_and_equivalents, total_debt...
+# CashFlow: operating_cash_flow, capital_expenditure, free_cash_flow, dividends_paid...
+```
+
+```bash
+# CLI
+tigeropen quote fundamental financial AAPL --fields total_revenue,net_income
+tigeropen quote fundamental financial AAPL --period-type QUARTERLY
+tigeropen quote fundamental financial AAPL --begin-date 2024-01-01 --end-date 2026-01-01
+```
+
+### 分红 / Dividends
+
+```python
+dividends = quote_client.get_corporate_dividend(
+    symbols=['AAPL'], market='US',
+    begin_date='2024-01-01', end_date='2025-12-31')
+# 属性: symbol, announce_date, record_date, pay_date, amount, currency
+```
+
+```bash
+# CLI
+tigeropen quote fundamental dividend AAPL --begin-date 2024-01-01 --end-date 2026-01-01
+```
+
+### 拆合股 / Stock Splits
+
+```python
+splits = quote_client.get_corporate_split(
+    symbols=['AAPL'], market='US',
+    begin_date='2020-01-01', end_date='2025-12-31')
+# 属性: symbol, execute_date, from_factor, to_factor
+```
+
+### 财报日历 / Earnings Calendar
+
+```python
+earnings = quote_client.get_corporate_earnings_calendar(
+    market='US', begin_date='2025-06-01', end_date='2025-06-30')
+# 属性: symbol, name, market, earnings_date, timing(BMO/AMC)
+```
+
+```bash
+# CLI
+tigeropen quote fundamental earnings --begin-date 2026-03-01 --end-date 2026-03-31
+tigeropen quote fundamental earnings --market HK --begin-date 2026-03-01 --end-date 2026-03-31
+```
+
+---
+
+## 期权行情 / Option Quotes
+
+> 详细的期权交易功能见 tigeropen-option 技能 / See tigeropen-option skill for trading
+
+```python
+# 到期日 / Expirations (返回 DataFrame: symbol, option_symbol, date, timestamp, period_tag)
+expirations = quote_client.get_option_expirations(symbols=['AAPL'], market='US')
+# period_tag: "m"=月度期权(monthly), "w"=周期权(weekly)
+
+# 期权链 / Option chain
+from tigeropen.quote.domain.filter import OptionFilter
+chain = quote_client.get_option_chain(symbol='AAPL', expiry='2025-08-29', market='US')
+# 带筛选 / With filters
+option_filter = OptionFilter(implied_volatility_min=0.3, delta_min=0.2, open_interest_min=100, in_the_money=True)
+chain = quote_client.get_option_chain(symbol='AAPL', expiry='2025-08-29',
+                                       option_filter=option_filter, return_greek_value=True, market='US')
+
+# 实时行情 / Real-time quotes
+briefs = quote_client.get_option_briefs(identifiers=['AAPL  250829C00150000'])
+
+# K线 / K-lines (支持: day, 1min, 5min, 30min, 60min; 可选 sort_dir)
+bars = quote_client.get_option_bars(identifiers=['AAPL  250829C00150000'], period='day')
+
+# 深度 / Depth
+depth = quote_client.get_option_depth(identifiers=['AAPL  250829C00150000'], market='US')
+
+# 逐笔 / Ticks
+ticks = quote_client.get_option_trade_ticks(identifiers=['AAPL  250829C00150000'])
+
+# 分时 / Timeline
+timeline = quote_client.get_option_timeline(identifiers=['AAPL  250829C00150000'])
+
+# 港股期权代码映射 / HK option symbol mapping
+hk_symbols = quote_client.get_option_symbols(market='HK')  # e.g. 00700 -> TCH.HK
+```
+
+**get_option_chain 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期权完整代码 Full option identifier |
+| `symbol` | 标的代码 Underlying symbol |
+| `expiry` | 到期日毫秒时间戳 Expiration timestamp (ms) |
+| `strike` | 行权价 Strike price |
+| `put_call` | `CALL`(看涨) / `PUT`(看跌) |
+| `multiplier` | 期权乘数（美股通常100） Option multiplier |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 Ask size |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 Bid size |
+| `pre_close` | 前收盘价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `volume` | 成交量 Volume |
+| `open_interest` | 未平仓合约数 Open interest |
+| `last_timestamp` | 最后交易时间戳 Last trade timestamp (ms) |
+| `implied_vol` | 隐含波动率 Implied volatility |
+| `delta` | Delta 值 |
+| `gamma` | Gamma 值 |
+| `theta` | Theta 值（每日时间价值损耗） |
+| `vega` | Vega 值（波动率敏感度） |
+| `rho` | Rho 值（利率敏感度） |
+
+**get_option_briefs 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期权完整代码 Full option identifier |
+| `symbol` | 标的代码 Underlying symbol |
+| `expiry` | 到期日毫秒时间戳 Expiration timestamp (ms) |
+| `strike` | 行权价 Strike price |
+| `put_call` | `CALL` / `PUT` |
+| `multiplier` | 期权乘数 Option multiplier |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 Ask size |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 Bid size |
+| `pre_close` | 前收盘价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `latest_time` | 最新交易时间 Latest trade time |
+| `volume` | 成交量 Volume |
+| `open_interest` | 未平仓数量 Open interest |
+| `open` | 开盘价 Open price |
+| `high` | 最高价 High price |
+| `low` | 最低价 Low price |
+| `change` | 价格变动 Price change |
+| `volatility` | 历史波动率 Historical volatility |
+| `rates_bonds` | 无风险利率 Risk-free interest rate |
+| `mid_price` | 买卖价中间价 Mid price (ask+bid)/2 |
+| `mid_timestamp` | 中间价时间戳 Mid price timestamp (ms) |
+| `mark_price` | 标记价格 Mark price |
+| `mark_timestamp` | 标记价格时间戳 Mark price timestamp (ms) |
+| `pre_mark_price` | 前标记价格 Previous mark price |
+| `selling_return` | 卖出收益率 Selling return |
+
+### 期权分析 / Option Analysis
+
+```python
+from tigeropen.common.consts import OptionAnalysisPeriod
+
+analysis = quote_client.get_option_analysis(symbols=['AAPL'],
+                                             period=OptionAnalysisPeriod.FIFTY_TWO_WEEK)
+# 返回 List[OptionAnalysis]
+# 属性: symbol, implied_vol_30_days, his_volatility, iv_his_v_ratio, call_put_ratio
+# iv_metric: IVMetric(period, percentile, rank)
+```
+
+**期权代码格式 / Option Symbol Format**:
+- 美股 US: `'AAPL  250829C00150000'` (标的 + YYMMDD + C/P + 行权价*1000)
+- 港股 HK: `'TCH.HK 230616C00550000'`
+
+```bash
+# CLI
+tigeropen quote option expirations AAPL                        # 到期日列表
+tigeropen quote option chain AAPL 2026-06-19                   # 期权链
+tigeropen quote option briefs "AAPL  260619C00150000"          # 实时行情
+tigeropen quote option bars "AAPL  260619C00150000" --period day --limit 10  # K线
+```
+
+---
+
+## 期货行情 / Futures Quotes
+
+```python
+# 期货交易所 / Exchanges
+exchanges = quote_client.get_future_exchanges()
+# CME, NYMEX, COMEX, CBOT, CBOE, HKFE, SGX, OSE
+
+# 交易所合约 / Exchange contracts
+contracts = quote_client.get_future_contracts(exchange='CME')
+
+# 指定合约 / Specific contract
+contract = quote_client.get_future_contract(symbol='CL2509')
+
+# 主力合约 / Current/main contract
+current = quote_client.get_current_future_contract(contract_type='CL')
+
+# 连续合约 / Continuous contracts
+continuous = quote_client.get_future_continuous_contracts(contract_type='CL')
+
+# 所有合约(某品种) / All contracts for a type
+all_contracts = quote_client.get_all_future_contracts(contract_type='CL')
+
+# 交易时间 / Trading times
+times = quote_client.get_future_trading_times(symbol='CL2509')
+
+# 实时行情 / Real-time quotes
+brief = quote_client.get_future_brief(identifiers=['CL2509'])
+
+# 深度行情 / Depth
+depth = quote_client.get_future_depth(identifiers=['CL2509'])
+# 单个合约返回: {'identifier': 'CL2509', 'asks': [{'price': 63.07, 'size': 10}, ...], 'bids': [...]}
+# 多个合约返回: {'CL2509': {'asks': [...], 'bids': [...]}, 'ES2509': {...}}
+
+# 逐笔 / Ticks
+ticks = quote_client.get_future_trade_ticks(identifier='CL2509', limit=50)
+
+# K线 / K-lines
+bars = quote_client.get_future_bars(identifier='CL2509', period=BarPeriod.DAY, limit=60)
+
+# 分页K线 / Paginated K-lines
+bars = quote_client.get_future_bars_by_page(identifier='CL2509', period=BarPeriod.DAY,
+                                             begin_time='2025-01-01', end_time='2025-06-30')
+```
+
+**get_future_brief 返回字段 / Return Fields** (pandas.DataFrame):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `identifier` | 期货合约代码 Contract code (e.g. `CL2509`) |
+| `ask_price` | 卖价 Ask price |
+| `ask_size` | 卖量 Ask size |
+| `bid_price` | 买价 Bid price |
+| `bid_size` | 买量 Bid size |
+| `pre_close` | 前收价 Previous close |
+| `latest_price` | 最新价 Latest price |
+| `latest_size` | 最新成交量 Latest trade volume |
+| `latest_time` | 最新成交时间（毫秒时间戳） Latest time (ms) |
+| `volume` | 当日累计成交手数 Total volume today |
+| `open_interest` | 未平仓合约数量 Open interest |
+| `open_interest_change` | 未平仓合约变化量 Open interest change |
+| `open` | 开盘价 Open price |
+| `high` | 最高价 High price |
+| `low` | 最低价 Low price |
+| `settlement` | 结算价 Settlement price |
+| `limit_up` | 涨停价 Upper price limit |
+| `limit_down` | 跌停价 Lower price limit |
+| `avg_price` | 均价 Average price |
+
+```bash
+# CLI
+tigeropen quote future exchanges                       # 交易所列表
+tigeropen quote future contracts CME                  # 交易所合约
+tigeropen quote future briefs ES2606 CL2509           # 实时报价
+tigeropen quote future bars CL2509 --period day --limit 20  # K线
+```
+
+---
+
+## 基金行情 / Fund Quotes
+
+> CLI 暂不支持，请使用 Python SDK。No CLI equivalent — use Python SDK.
+
+```python
+# 基金代码 / Fund symbols
+symbols = quote_client.get_fund_symbols()
+
+# 基金合约 / Fund contracts
+contracts = quote_client.get_fund_contracts(symbols=['ARKK'])
+
+# 最新行情 / Latest quote
+quote = quote_client.get_fund_quote(symbols=['ARKK'])
+
+# 历史行情 / Historical quotes
+history = quote_client.get_fund_history_quote(symbols=['ARKK'],
+                                               begin_date='2025-01-01', end_date='2025-06-30')
+```
+
+---
+
+## 数字货币行情 / Cryptocurrency Quotes
+
+> CLI 暂不支持，请使用 Python SDK。No CLI equivalent — use Python SDK.
+
+```python
+from tigeropen.common.consts import SecurityType
+
+# 代码列表 / Symbols
+symbols = quote_client.get_symbols(market=Market.US, sec_type=SecurityType.CC)
+
+# 实时行情 / Real-time quotes
+briefs = quote_client.get_cc_briefs(symbols=['BTC/USD', 'ETH/USD'])
+
+# K线 / K-lines
+bars = quote_client.get_bars(['BTC/USD'], period=BarPeriod.DAY, limit=30, sec_type=SecurityType.CC)
+
+# 分时 / Timeline
+timeline = quote_client.get_timeline(['BTC/USD'], sec_type=SecurityType.CC)
+```
+
+---
+
+## 窝轮/牛熊证行情 / Warrant & CBBC Quotes
+
+> CLI 暂不支持，请使用 Python SDK。No CLI equivalent — use Python SDK.
+
+```python
+# 窝轮筛选器 / Warrant scanner
+warrants = quote_client.get_warrant_filter(
+    symbol='00700', filter_type='warrant',  # warrant/cbbc/inline
+    sort_field='changeRate', sort_dir='DESC')
+
+# 窝轮行情 / Warrant quotes
+briefs = quote_client.get_warrant_briefs(symbols=['12345'])
+```
+
+---
+
+## 选股器 / Market Scanner
+
+### 选股工作流 / Scanner Workflow
+
+```
+1. 确定筛选条件 → 2. 构造 StockFilter 对象列表 → 3. 设置排序 SortFilterData → 4. 调用 market_scanner → 5. 分页读取结果
+```
+
+```python
+from tigeropen.quote.domain.filter import StockFilter, SortFilterData
+from tigeropen.common.consts.filter_fields import (
+    StockField, AccumulateField, FinancialField, MultiTagField,
+    AccumulatePeriod, FinancialPeriod
+)
+from tigeropen.common.consts import Market, SortDirection
+
+# ── 基础筛选: 市值 + PE ─────────────────────────────────────────────────────────
+f_cap   = StockFilter(StockField.MarketValue, filter_min=1e10)          # 总市值 > 100亿
+f_pe    = StockFilter(StockField.PeTTM, filter_max=30)                  # PE TTM < 30
+sort    = SortFilterData(StockField.MarketValue, sort_dir=SortDirection.DESC)
+
+result = quote_client.market_scanner(
+    market=Market.US,
+    filters=[f_cap, f_pe],
+    sort_field_data=sort,
+    page_size=20
+)
+
+print(f"共 {result.total_count} 条 / Total: {result.total_count}")
+for item in result.items:
+    print(f"{item.symbol}: 市值={item[f_cap]:.2e}, PE={item[f_pe]:.1f}")
+
+# ── 分页读取 / Pagination ───────────────────────────────────────────────────────
+cursor_id = result.cursor_id
+while result.page < result.total_page - 1 and cursor_id:
+    result = quote_client.market_scanner(
+        market=Market.US, filters=[f_cap, f_pe],
+        sort_field_data=sort, page_size=20, cursor_id=cursor_id
+    )
+    cursor_id = result.cursor_id
+    for item in result.items:
+        print(item.symbol, item[f_cap])
+```
+
+```python
+# ── 今日涨幅筛选 / Today's gainers ────────────────────────────────────────────
+# 使用 StockField.current_ChangeRate (盘中涨跌幅) 筛选当日涨幅 > 3%
+f_change = StockFilter(StockField.current_ChangeRate, filter_min=3)
+sort     = SortFilterData(StockField.current_ChangeRate, sort_dir=SortDirection.DESC)
+result   = quote_client.market_scanner(market=Market.US, filters=[f_change],
+                                        sort_field_data=sort, page_size=20)
+for item in result.items:
+    print(f"{item.symbol}: +{item[f_change]:.1f}%")
+```
+
+```python
+# ── 高 ROE 筛选 / High ROE (annual) ──────────────────────────────────────────
+# AccumulateField.ROE 需要指定 accumulate_period，返回值为小数 (0.15 = 15%)
+f_roe  = StockFilter(AccumulateField.ROE, filter_min=0.15,
+                     accumulate_period=AccumulatePeriod.ANNUAL)
+sort   = SortFilterData(AccumulateField.ROE, sort_dir=SortDirection.DESC,
+                        period=AccumulatePeriod.ANNUAL)
+result = quote_client.market_scanner(market=Market.US, filters=[f_roe],
+                                      sort_field_data=sort, page_size=20)
+for item in result.items:
+    print(f"{item.symbol}: ROE={item[f_roe]*100:.1f}%")
+```
+
+```python
+# ── FinancialField (LTM 口径) ─────────────────────────────────────────────────
+f_roe_fin = StockFilter(FinancialField.ReturnOnEquityRate, filter_min=0.15,
+                        financial_period=FinancialPeriod.LTM)
+result    = quote_client.market_scanner(market=Market.US, filters=[f_roe_fin], page_size=20)
+
+# ── MultiTagField: 有期权且非 ETF ─────────────────────────────────────────────
+f_opts = StockFilter(MultiTagField.OptionsAvailable, tag_list=['1'])
+f_etf  = StockFilter(MultiTagField.Type, tag_list=['0'])  # 0 = 普通股
+result = quote_client.market_scanner(market=Market.US,
+                                      filters=[f_opts, f_etf], page_size=20)
+```
+
+### 字段类型说明 / Field Types
+
+| 类型 | 导入路径 | 适用场景 | 是否需要 period |
+|------|---------|---------|----------------|
+| `StockField` | `filter_fields.StockField` | 价格、成交量、市值、PE等实时指标 | 否 |
+| `AccumulateField` | `filter_fields.AccumulateField` | ROE、营收增长、涨跌幅（带周期）| 是（`accumulate_period`）|
+| `FinancialField` | `filter_fields.FinancialField` | LTM 财务指标（净利率、ROE等）| 固定 `FinancialPeriod.LTM` |
+| `MultiTagField` | `filter_fields.MultiTagField` | 行业、概念、期权可用等标签 | 否（`tag_list`）|
+
+### 常用字段速查 / Common Fields
+
+**StockField（价格/市场数据）**
+
+| 字段 | 说明 |
+|------|-----|
+| `MarketValue` | 总市值 Total market cap |
+| `FloatMarketVal` | 流通市值 Float market cap |
+| `current_ChangeRate` | 今日涨跌幅% Intraday change rate |
+| `Volume` | 成交量 Volume |
+| `Amount` | 成交额 Turnover amount |
+| `TurnoverRate` | 换手率 Turnover rate |
+| `PeTTM` | 市盈率 TTM P/E ratio |
+| `CurPrice` | 最新价 Latest price |
+| `Week52High` / `Week52Low` | 52周高/低 52-week high/low |
+
+**AccumulateField（需指定 `accumulate_period`）**
+
+| 字段 | 说明 | 值说明 |
+|------|-----|-------|
+| `ChangeRate` | 涨跌幅（含周期）| 百分比数值，如 5.0 |
+| `ROE` | 净资产收益率 | 小数，如 0.15 = 15% |
+| `ROA` | 总资产收益率 | 小数 |
+| `NetIncome_Ratio_Annual` | 净利润同比增长率 | 百分比 |
+| `GrossProfitRate` | 毛利率 | 小数 |
+| `Total_Revenue` | 营业收入 | 绝对值 |
+
+**AccumulatePeriod 常用值**: `ANNUAL`（年度）、`QUARTERLY`（季度）、`SEMIANNUAL`（半年）、`Five_Days`、`Beginning_Of_The_Year_To_Now`
+
+```bash
+# CLI
+# 今日涨幅 > 3%, 按涨幅降序
+tigeropen quote scanner --filter current_ChangeRate:3: --sort current_ChangeRate --sort-dir DESC --limit 20
+
+# 大市值且 PE < 30（美股）
+tigeropen quote scanner --filter MarketValue:1e10: --filter PeTTM::30 --sort MarketValue --limit 20
+
+# 高 ROE 筛选（年度，ROE > 15%）
+tigeropen quote scanner --filter acc.ROE:0.15::ANNUAL --sort acc.ROE:ANNUAL --sort-dir DESC --limit 20
+
+# 港股选股
+tigeropen quote scanner --market HK --filter MarketValue:1e9: --sort MarketValue --limit 20
+
+# 大市值 + 高 ROE + 低 PE（组合筛选）
+tigeropen quote scanner --filter MarketValue:1e10: --filter acc.ROE:0.15::ANNUAL --filter PeTTM::30 --sort MarketValue --limit 20
+```
+
+> **filter 格式 / Filter format**:
+> - `FIELD:min:max` — StockField 范围，如 `MarketValue:1e9:1e12`、`PeTTM::20`
+> - `acc.FIELD:min:max:PERIOD` — AccumulateField，如 `acc.ROE:0.15::ANNUAL`
+> - `fin.FIELD:min:max` — FinancialField (LTM)，如 `fin.ReturnOnEquityRate:0.15:`
+> - `tag.FIELD:tag1,tag2` — MultiTagField，如 `tag.OptionsAvailable:1`
+
+---
+
+## 行情权限管理 / Quote Permission Management
+
+```python
+# 查询权限 / Query permissions
+permissions = quote_client.get_quote_permission()
+for p in permissions:
+    print(f"{p['name']}: expires={p['expire_at']}")  # -1 = 永不过期 never expires
+
+# 抢占权限 / Grab permissions (多设备切换时 / multi-device)
+quote_client.grab_quote_permission()
+
+# K线配额 / K-line quota
+quota = quote_client.get_kline_quota(with_details=True)
+for q in quota:
+    print(f"{q['method']}: used={q['used']}, remain={q['remain']}")
+```
+
+**权限类型**: `usQuoteBasic`, `usStockQuoteLv2Totalview`, `hkStockQuoteLv2`, `usOptionQuote`, `hkFutureQuoteLv2`, `CBOEFuturesQuoteLv2`
+
+---
+
+## 注意事项 / Notes
+
+- 行情权限需单独购买，API 与 App 独立 / Quote permissions require separate purchase
+- 多设备同账号：最后抢占的设备获取权限 / Last device to grab gets permissions
+- K线有配额限制，大量数据用 `get_bars_by_page` / Use paginated fetch for large datasets
+- 港股代码5位数 `00700`(腾讯) / HK codes are 5-digit like `00700`
+- 深度行情需 L2 权限 / Depth quotes require Level 2 permission
+- 更多详情见 / More details: https://docs.itigerup.com/docs/quote-stock

--- a/.claude/skills/tigeropen/references/trade.md
+++ b/.claude/skills/tigeropen/references/trade.md
@@ -1,0 +1,786 @@
+
+# Tiger Open API 交易 / Trading
+
+> 中文 | English — 双语技能，代码通用。Bilingual skill with shared code examples.
+> 官方文档 Docs: https://docs.itigerup.com/docs/place-order
+
+## 安全规范 / Safety Rules
+
+> **默认使用模拟账户。Default to Paper Trading.**
+
+### 模拟交易 vs 实盘交易 / Paper vs Live Trading
+
+| 特性 Feature | 模拟 Paper | 实盘 Live |
+|------|------|------|
+| 资金 Funds | 虚拟，无风险 Virtual, no risk | 真实资金 Real money |
+| 账户类型 `account_type` | `PAPER` | `STANDARD` / `GLOBAL` |
+| 默认 Default | **是** Yes | 需用户明确要求 User must explicitly request |
+
+### 实盘下单工作流 / Live Order Workflow
+
+当用户要求实盘交易时，**必须执行以下流程** / When user requests live trading, follow these steps:
+
+1. **确认账户 Verify account**: 调用 `get_managed_accounts()` 获取账户列表，筛选 `account_type != 'PAPER'` 的实盘账户 / Call `get_managed_accounts()`, filter for non-PAPER accounts
+2. **二次确认 Confirm with user**: 下单前必须与用户确认：标的代码、买卖方向、数量、价格、账户类型 / Confirm symbol, action, quantity, price, account type
+3. **预览订单 Preview**: 建议先调用 `preview_order()` 查看预估佣金和保证金 / Call `preview_order()` for commission and margin estimates
+4. **执行下单 Execute**: 确认后执行 `place_order()` / Place the order after confirmation
+5. **检查状态 Check status**: `place_order()` 返回成功仅表示提交，需通过 `get_orders()` 确认成交 / Submission success ≠ execution; poll `get_orders()` to confirm fill
+
+---
+
+## 初始化 / Initialize
+
+```python
+from tigeropen.tiger_open_config import TigerOpenClientConfig
+from tigeropen.trade.trade_client import TradeClient
+
+client_config = TigerOpenClientConfig(props_path='/path/to/your/tiger_openapi_config.properties')
+trade_client = TradeClient(client_config=client_config)
+
+# 获取管理的账户 / Get managed accounts
+accounts = trade_client.get_managed_accounts()
+# 返回 AccountProfile 列表 / Returns list of AccountProfile objects
+for a in accounts:
+    print(f"{a.account}: type={a.account_type}, capability={a.capability}, status={a.status}")
+```
+
+**AccountProfile 属性 / AccountProfile Attributes**:
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `account` | 交易账户ID Trading account ID |
+| `account_type` | 账户类型: `PAPER`(模拟) / `STANDARD`(美股标准) / `GLOBAL`(全球) |
+| `capability` | 保证金类型: `CASH`(现金账户) / `MGRN`(Reg T 保证金) / `PMGRN`(投资组合保证金) |
+| `status` | 账户状态: `New`/`Funded`/`Open`/`Pending`/`Abandoned`/`Rejected`/`Closed`/`Unknown` |
+
+
+
+---
+
+## 合约 / Contracts
+
+交易前必须获取合约对象。Contracts must be obtained before trading.
+
+### 本地构造 / Local Construction
+
+```python
+from tigeropen.common.util.contract_utils import (
+    stock_contract, option_contract, option_contract_by_symbol,
+    future_contract, war_contract_by_symbol, iopt_contract_by_symbol,
+    fund_contract, cc_contract
+)
+
+# 股票 / Stock
+contract = stock_contract(symbol='AAPL', currency='USD')
+
+# 港股 / HK Stock
+contract = stock_contract(symbol='00700', currency='HKD')
+
+# 期权 / Option
+opt = option_contract_by_symbol(symbol='AAPL', expiry='20250829',
+                                 strike=150.0, put_call='CALL', currency='USD')
+
+# 期货 / Future
+fut = future_contract(symbol='CL2509', currency='USD')
+
+# 窝轮 / Warrant
+war = war_contract_by_symbol(symbol='12345', currency='HKD')
+
+# 牛熊证 / CBBC
+iopt = iopt_contract_by_symbol(symbol='56789', currency='HKD')
+
+# 基金 / Fund
+fund = fund_contract(symbol='ARKK', currency='USD')
+
+# 数字货币 / Crypto
+cc = cc_contract(symbol='BTC/USD', currency='USD')
+```
+
+### 远程获取 / Remote Fetch
+
+```python
+# 单个合约 / Single contract
+contract = trade_client.get_contract(symbol='AAPL', sec_type='STK')
+contract = trade_client.get_contract(symbol='AAPL', sec_type='OPT',
+                                      expiry='20250829', strike=150.0, put_call='CALL')
+
+# 批量合约 / Multiple contracts
+contracts = trade_client.get_contracts(symbols=['AAPL', 'TSLA'], sec_type='STK')
+
+# 衍生品合约列表 / Derivative contracts
+derivatives = trade_client.get_derivative_contracts(symbol='AAPL', sec_type='OPT')
+```
+
+### Contract 对象属性 / Contract Attributes
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `symbol` | 代码 Symbol |
+| `sec_type` | 证券类型 Security type (STK/OPT/FUT/WAR/IOPT) |
+| `currency` | 货币 Currency |
+| `exchange` | 交易所 Exchange |
+| `name` | 名称 Name |
+| `expiry` | 到期日 Expiry (options/futures) |
+| `strike` | 行权价 Strike (options) |
+| `put_call` | CALL/PUT (options) |
+| `multiplier` | 乘数 Multiplier |
+| `lot_size` | 每手股数 Lot size |
+| `shortable` | 可否卖空 Shortable |
+| `shortable_count` | 可卖空数量 Shortable count |
+| `min_tick` | 最小价格变动 Min tick size |
+
+---
+
+## 下单 / Place Orders
+<!-- 当用户提到 "买入"、"卖出"、"下单"、"buy"、"sell"、"order"、"place order" 时 -->
+
+### 限价单 LMT / Limit Order
+
+```python
+from tigeropen.common.util.order_utils import limit_order
+
+order = limit_order(account=client_config.account, contract=contract,
+                    action='BUY', quantity=100, limit_price=150.0)
+trade_client.place_order(order)
+print(f"Order ID: {order.id}")
+```
+
+### 市价单 MKT / Market Order
+
+```python
+from tigeropen.common.util.order_utils import market_order, market_order_by_amount
+
+order = market_order(account=client_config.account, contract=contract,
+                     action='BUY', quantity=100)
+trade_client.place_order(order)
+
+# 按金额下单(碎股) / By amount (fractional shares)
+order = market_order_by_amount(account=client_config.account, contract=contract,
+                               action='BUY', amount=5000)  # 买入 $5000 的股票
+trade_client.place_order(order)
+```
+
+> 也有 `limit_order_by_amount` 用于按金额的限价单。
+> There's also `limit_order_by_amount` for limit orders by amount.
+
+### 止损单 STP / Stop Order
+
+```python
+from tigeropen.common.util.order_utils import stop_order
+
+order = stop_order(account=client_config.account, contract=contract,
+                   action='SELL', quantity=100, aux_price=140.0)
+# aux_price = 触发价 / trigger price
+trade_client.place_order(order)
+```
+
+### 止损限价单 STP_LMT / Stop Limit Order
+
+```python
+from tigeropen.common.util.order_utils import stop_limit_order
+
+order = stop_limit_order(account=client_config.account, contract=contract,
+                         action='SELL', quantity=100,
+                         limit_price=139.0, aux_price=140.0)
+# 价格到 aux_price 时触发，以 limit_price 限价委托
+trade_client.place_order(order)
+```
+
+### 跟踪止损单 TRAIL / Trailing Stop
+
+```python
+from tigeropen.common.util.order_utils import trail_order
+
+# 百分比跟踪 / Percentage trailing
+order = trail_order(account=client_config.account, contract=contract,
+                    action='SELL', quantity=100, trailing_percent=5.0)
+
+# 金额跟踪 / Amount trailing
+order = trail_order(account=client_config.account, contract=contract,
+                    action='SELL', quantity=100, aux_price=3.0)
+trade_client.place_order(order)
+```
+
+### 算法单 TWAP/VWAP / Algo Orders
+
+```python
+from tigeropen.common.util.order_utils import algo_order, algo_order_params
+
+params = algo_order_params(start_time=1625097600000, end_time=1625184000000,
+                            participation_rate=0.1)
+order = algo_order(account=client_config.account, contract=contract,
+                   action='BUY', quantity=1000, strategy='TWAP',  # 或 'VWAP'
+                   algo_params=params)
+trade_client.place_order(order)
+```
+
+### 附加订单(止盈止损) / Bracket Orders (Take Profit / Stop Loss)
+
+```python
+from tigeropen.common.util.order_utils import limit_order_with_legs, order_leg
+
+# 推荐使用 limit_order_with_legs / Recommended: use limit_order_with_legs
+legs = [
+    order_leg(leg_type='PROFIT', price=170.0),              # 止盈 / Take profit
+    order_leg(leg_type='LOSS', price=140.0),                 # 止损 / Stop loss
+    # 也可用跟踪止损 / Or trailing stop loss:
+    # order_leg(leg_type='LOSS', trailing_percent=5.0),
+]
+order = limit_order_with_legs(account=client_config.account, contract=contract,
+                              action='BUY', quantity=100, limit_price=150.0,
+                              order_legs=legs)
+trade_client.place_order(order)
+```
+
+> 附加订单仅支持限价单作为主订单，最多2个 leg。子订单在主订单全部成交后自动生效。
+> Bracket orders only support limit as primary, max 2 legs. Legs activate after primary is fully filled.
+
+### order_leg 参数 / order_leg Parameters
+
+| 参数 Parameter | 说明 Description |
+|---------------|-----------------|
+| `leg_type` | `PROFIT`(止盈) 或 `LOSS`(止损) |
+| `price` | 触发价格 Trigger price |
+| `limit_price` | 限价(可选) Limit price (optional) |
+| `trailing_percent` | 跟踪止损百分比 Trailing percent |
+| `trailing_amount` | 跟踪止损金额 Trailing amount |
+| `quantity` | 数量(默认同主单) Quantity (default: same as primary) |
+
+---
+
+### 下单参数总览 / Order Parameters Overview
+
+| 参数 Parameter | 说明 Description | 必填 Required |
+|---------------|-----------------|--------------|
+| `account` | 交易账户 Trading account | ✅ |
+| `contract` | 合约对象 Contract | ✅ |
+| `action` | `BUY` / `SELL` | ✅ |
+| `quantity` | 数量 Quantity | ✅ |
+| `limit_price` | 限价 Limit price | LMT/STP_LMT |
+| `aux_price` | 触发价/跟踪金额 Trigger/trailing amount | STP/STP_LMT/TRAIL |
+| `trailing_percent` | 跟踪止损百分比 Trailing percent | TRAIL |
+| `time_in_force` | `DAY`/`GTC`(撤销前有效)/`GTD`(指定日期) | - |
+| `outside_rth` | 盘前盘后 Pre/after hours (仅美股 US only) | - |
+| `trading_session_type` | 交易时段 `TradingSessionType` 枚举值(PRE_RTH_POST/OVERNIGHT/RTH/FULL/HK_AUC/HK_CTS/HK_AUC_CTS) | - |
+| `order_id` | 自定义订单ID Custom order ID | - |
+| `user_mark` | 自定义标记 Custom mark | - |
+| `quantity_scale` | 数量精度(碎股) Quantity scale (fractional) | - |
+| `total_cash_amount` | 按金额下单 Order by amount | - |
+| `expire_time` | GTD到期时间 GTD expire time | GTD |
+
+### 各市场支持的订单类型 / Order Types by Market
+
+| 订单类型 | 美股 US | 港股 HK | 新加坡 SG | 期货 Futures | 期权 Options |
+|---------|---------|---------|----------|-------------|-------------|
+| MKT 市价 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| LMT 限价 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| STP 止损 | ✅ | - | - | ✅ | ✅ |
+| STP_LMT 止损限价 | ✅ | - | - | ✅ | ✅ |
+| TRAIL 跟踪止损 | ✅ | - | - | - | - |
+| TWAP/VWAP 算法 | ✅ | - | - | - | - |
+| AL 竞价限价 | - | ✅ | - | - | - |
+| AM 竞价市价 | - | ✅ | - | - | - |
+| OCA 一撤全撤 | ✅ | ✅ | - | - | - |
+
+```bash
+# CLI 下单 / Place orders via CLI
+tigeropen trade order place --symbol AAPL --action buy --order-type lmt --quantity 10 --limit-price 150
+tigeropen trade order place --symbol AAPL --action sell --order-type mkt --quantity 10
+tigeropen trade order place --symbol 00700 --action buy --order-type lmt --quantity 100 --limit-price 350 --sec-type stk
+tigeropen trade order place --symbol AAPL --action buy --order-type lmt --quantity 10 --limit-price 150 -y  # 跳过确认 skip confirm
+```
+
+### 特殊下单场景 / Special Order Scenarios
+
+```python
+# 盘前盘后 / Pre/after-hours (美股 US only)
+order = limit_order(account=client_config.account, contract=contract,
+                    action='BUY', quantity=100, limit_price=150.0)
+order.outside_rth = True
+trade_client.place_order(order)
+
+# 夜盘(通宵) / Overnight trading (使用 TradingSessionType 枚举)
+from tigeropen.common.consts import TradingSessionType
+order = limit_order(account=client_config.account, contract=contract,
+                    action='BUY', quantity=100, limit_price=150.0)
+order.trading_session_type = TradingSessionType.OVERNIGHT.value
+trade_client.place_order(order)
+# TradingSessionType 可选值: PRE_RTH_POST, OVERNIGHT, RTH, FULL, HK_AUC, HK_CTS, HK_AUC_CTS
+
+# GTC 订单 / Good Till Cancelled
+order = limit_order(account=client_config.account, contract=contract,
+                    action='BUY', quantity=100, limit_price=150.0)
+order.time_in_force = 'GTC'
+trade_client.place_order(order)
+
+# 港股下单 / HK stock order (注意: 数量须为 lot_size 的整数倍，可通过 get_trade_metas 查询)
+hk_contract = stock_contract(symbol='00700', currency='HKD')
+order = limit_order(account=client_config.account, contract=hk_contract,
+                    action='BUY', quantity=100, limit_price=350.0)
+trade_client.place_order(order)
+
+# 期货下单 / Futures order
+fut_contract = future_contract(symbol='CL2509', currency='USD')
+order = limit_order(account=client_config.account, contract=fut_contract,
+                    action='BUY', quantity=1, limit_price=70.0)
+trade_client.place_order(order)
+
+# 价格修正工具 / Price correction utility
+from tigeropen.common.util.price_util import PriceUtil
+price_util = PriceUtil(trade_client)
+corrected = price_util.correct_price(symbol='AAPL', price=150.123)
+```
+
+### 港股竞价单 / HK Auction Orders
+
+```python
+from tigeropen.common.util.order_utils import auction_limit_order, auction_market_order
+
+# 竞价限价单 AL / Auction Limit Order
+order = auction_limit_order(account=client_config.account, contract=hk_contract,
+                            action='BUY', quantity=100, limit_price=350.0)
+trade_client.place_order(order)
+
+# 竞价市价单 AM / Auction Market Order
+order = auction_market_order(account=client_config.account, contract=hk_contract,
+                             action='BUY', quantity=100)
+trade_client.place_order(order)
+```
+
+> 竞价单用于港股竞价时段(开盘竞价/收盘竞价)。`time_in_force` 支持 `DAY` 和 `OPG`。
+> Auction orders for HK pre-opening/closing auction sessions. `time_in_force` supports `DAY` and `OPG`.
+
+### OCA 订单(一撤全撤) / OCA Order (One-Cancels-All)
+
+```python
+from tigeropen.common.util.order_utils import oca_order, order_leg
+
+# OCA 订单: 多个子订单中任一成交，其余自动撤销
+# OCA order: when any leg fills, others are automatically cancelled
+legs = [
+    order_leg(leg_type='LMT', limit_price=160.0),   # 限价单
+    order_leg(leg_type='STP', price=140.0),           # 止损单
+]
+order = oca_order(account=client_config.account, contract=contract,
+                  action='SELL', order_legs=legs, quantity=100)
+trade_client.place_order(order)
+```
+
+---
+
+## 预览订单 / Preview Order
+<!-- 当用户提到 "预览"、"佣金"、"保证金"、"preview"、"commission" 时 -->
+
+```python
+preview = trade_client.preview_order(order)
+# 返回 dict / Returns dict
+```
+
+**preview_order 返回字段 / Return Fields** (dict):
+
+| 字段 Field | 说明 Description |
+|-----------|-----------------|
+| `init_margin_before` | 下单前账户初始保证金 Initial margin before order |
+| `init_margin` | 下单后预计初始保证金 Estimated initial margin after order |
+| `maint_margin_before` | 下单前维持保证金 Maintenance margin before order |
+| `maint_margin` | 下单后预计维持保证金 Estimated maintenance margin after order |
+| `margin_currency` | 保证金货币 Margin currency (e.g. `USD`) |
+| `equity_with_loan_before` | 下单前含借贷值股权 Equity with loan value before |
+| `equity_with_loan` | 下单后含借贷值股权 Equity with loan value after |
+| `min_commission` | 预期最低佣金 Minimum estimated commission |
+| `max_commission` | 预期最高佣金 Maximum estimated commission |
+| `commission_currency` | 佣金货币 Commission currency |
+| `warning_text` | 无法下单原因（仅在拒绝时返回）Rejection reason (only when rejected) |
+
+> 若无法下单，仅返回 `warning_text` 字段。
+
+```bash
+# CLI
+tigeropen trade order preview --symbol AAPL --action buy --order-type lmt --quantity 10 --limit-price 150
+```
+
+## 修改订单 / Modify Order
+<!-- 当用户提到 "改单"、"修改订单"、"modify"、"change order" 时 -->
+
+```python
+order = trade_client.get_order(id=123456789)
+trade_client.modify_order(order,
+                           quantity=200,
+                           limit_price=155.0,
+                           time_in_force='GTC',
+                           outside_rth=True)
+```
+
+```bash
+# CLI (ORDER_ID 为全局订单 id / global order id)
+tigeropen trade order modify ORDER_ID --limit-price 155 --quantity 200
+```
+
+> 订单类型不可修改。仅 `Submitted` 或 `PartiallyFilled` 状态可改。
+> Order type cannot be changed. Only Submitted/PartiallyFilled orders can be modified.
+
+## 撤销订单 / Cancel Order
+<!-- 当用户提到 "撤单"、"取消订单"、"cancel order" 时 -->
+
+```python
+trade_client.cancel_order(id=123456789)
+
+# 批量撤销 / Batch cancel
+for order in trade_client.get_open_orders():
+    trade_client.cancel_order(id=order.id)
+```
+
+```bash
+# CLI
+tigeropen trade order cancel ORDER_ID
+tigeropen trade order cancel ORDER_ID -y   # 跳过确认 / skip confirmation
+```
+
+> 撤销为异步操作。使用 `id` (全局订单ID)。Cancellation is async. Use global order `id`.
+
+---
+
+## 查询订单 / Query Orders
+<!-- 当用户提到 "订单"、"委托"、"orders"、"order status"、"order list" 时 -->
+
+```python
+# 所有订单 / All orders
+orders = trade_client.get_orders(limit=100)
+
+# 待成交 / Open (pending) orders
+open_orders = trade_client.get_open_orders()
+
+# 已成交 / Filled orders (需指定时间，最多90天)
+filled = trade_client.get_filled_orders(start_time='2025-01-01', end_time='2025-03-31')
+
+# 已取消 / Cancelled orders
+cancelled = trade_client.get_cancelled_orders()
+
+# 指定订单 / Single order
+order = trade_client.get_order(id=123456789)
+
+# 条件筛选 / Filtered query
+orders = trade_client.get_orders(
+    symbol='AAPL', sec_type='STK', market='US',
+    states=['Filled', 'Cancelled'],
+    sort_by='latest_time',  # latest_time(默认) / limit_price
+    limit=100,
+    is_brief=False  # True: 精简模式 / brief mode
+)
+
+# 分页查询 / Pagination
+orders = trade_client.get_orders(limit=20)
+# 使用 page_token 翻页 / Use page_token for next page
+if hasattr(orders, 'page_token') and orders.page_token:
+    next_page = trade_client.get_orders(limit=20, page_token=orders.page_token)
+```
+
+### Order 对象属性 / Order Attributes
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `id` | 全局订单ID Global order ID |
+| `order_id` | 用户订单ID User order ID |
+| `account` | 交易账户ID Account ID |
+| `symbol` | 标的代码 Symbol |
+| `sec_type` | 证券类型 Security type |
+| `action` | BUY/SELL |
+| `order_type` | MKT/LMT/STP/STP_LMT/TRAIL |
+| `status` | 订单状态 Order status (见下方 Status 表) |
+| `quantity` | 下单数量 Order quantity |
+| `filled_quantity` | 成交数量 Filled quantity |
+| `remaining_quantity` | 剩余数量 Remaining quantity |
+| `limit_price` | 限价 Limit price |
+| `aux_price` | 触发价/跟踪金额 Aux/trigger price |
+| `avg_fill_price` | 平均成交价 Average fill price |
+| `trade_time` | 最新成交时间 Last trade time |
+| `time_in_force` | DAY/GTC/GTD |
+| `outside_rth` | 是否盘前盘后 Outside regular trading hours |
+| `trading_session_type` | 交易时段类型 Trading session type |
+| `order_legs` | 附加订单列表 Attached order legs |
+| `algo_params` | 算法参数 Algo parameters |
+| `user_mark` | 自定义标记 Custom mark |
+| `reason` | 拒绝/错误原因 Rejection reason |
+| `commission` | 实际佣金 Actual commission |
+| `combo_type` | 组合类型 Combo type |
+| `currency` | 货币 Currency |
+| `exchange` | 交易所 Exchange |
+| `contract` | 合约对象 Contract object |
+
+### 订单状态 / Order Status
+
+| 状态 Status | 说明 Description |
+|------------|-----------------|
+| `Initial` | 初始化 Created |
+| `PendingSubmit` | 待提交 Pending submit |
+| `Submitted` | 已提交 Submitted |
+| `PartiallyFilled` | 部分成交 Partially filled |
+| `Filled` | 全部成交 Fully filled |
+| `Cancelled` | 已取消 Cancelled |
+| `Inactive` | 已失效/拒绝 Rejected |
+| `PendingCancel` | 待取消 Pending cancel |
+
+```bash
+# CLI
+tigeropen trade order list                                   # 所有订单
+tigeropen trade order list --status Filled                   # 已成交
+tigeropen trade order list --status Submitted                # 持仓中
+tigeropen trade order list --symbol AAPL --limit 10         # 按标的筛选
+tigeropen trade order get ORDER_ID                           # 查单个订单
+```
+
+---
+
+## 成交记录 / Transaction Records
+
+```python
+# 按标的查询 / By symbol
+transactions = trade_client.get_transactions(
+    symbol='AAPL', sec_type='STK',
+    start_time=1625097600000, end_time=1625184000000)
+
+# 按订单查询 / By order ID
+transactions = trade_client.get_transactions(order_id='123456789',
+                                              start_time=1625097600000,
+                                              end_time=1625184000000)
+# 分页 / Pagination
+response = trade_client.get_transactions(symbol='AAPL', start_time=..., end_time=..., page_token='')
+next_page = response.page_token  # 下一页令牌
+```
+
+**Transaction 对象属性 / Transaction Attributes**:
+
+| 属性 Attribute | 说明 Description |
+|---------------|-----------------|
+| `id` | 成交记录ID Transaction ID |
+| `account` | 交易账户ID Account ID |
+| `order_id` | 关联订单ID Related order ID |
+| `contract` | 合约对象 Contract object |
+| `action` | BUY/SELL |
+| `filled_quantity` | 成交数量 Filled quantity |
+| `filled_quantity_scale` | 数量精度 Quantity scale (fractional shares) |
+| `filled_price` | 成交价格 Filled price |
+| `filled_amount` | 成交金额 Filled amount |
+| `transacted_at` | 成交时间（毫秒时间戳） Transaction time (ms) |
+
+```bash
+# CLI (--symbol 为必填 / --symbol is required)
+tigeropen trade transaction list --symbol AAPL
+tigeropen trade transaction list --symbol AAPL --start-time 2025-01-01 --end-time 2025-06-30
+tigeropen trade transaction list --symbol AAPL --limit 20
+```
+
+---
+
+## 账户资产 / Account Assets
+<!-- 当用户提到 "资产"、"资金"、"余额"、"购买力"、"assets"、"balance"、"buying power"、"cash" 时 -->
+
+### 综合资产(推荐) / Prime Assets (Recommended)
+
+```python
+assets = trade_client.get_prime_assets(base_currency='USD', consolidated=True)
+# ⚠️ 资产字段在 segments 字典中，不在 assets 对象上
+# Fields are on segment objects, NOT directly on assets
+# segments 键: 'S'=证券(Standard), 'G'=环球(Global), 'C'=商品/期货, 'F'=基金, 'D'=数字货币
+seg = assets.segments.get('S') or assets.segments.get('G')
+print(f"总资产 Net: {seg.net_liquidation}")
+print(f"可用资金 Available: {seg.cash_available_for_trade}")
+print(f"购买力 Buying Power: {seg.buying_power}")
+print(f"现金 Cash: {seg.cash_balance}")
+print(f"维持保证金 Margin: {seg.maintain_margin}")
+print(f"未实现盈亏 Unrealized PnL: {seg.unrealized_pl}")
+print(f"已实现盈亏 Realized PnL: {seg.realized_pl}")
+
+# 每个 Segment.currency_assets 包含各币种明细
+for currency, ca in seg.currency_assets.items():
+    print(f"  {currency}: net={ca.net_liquidation}, forex_rate={ca.forex_rate}")
+```
+
+### Segment 关键字段 / Segment Key Fields
+
+| 字段 Field | 说明 Description | APP 对应 |
+|------------|-----------------|----------|
+| `net_liquidation` | 总资产（净清算价值） Net liquidation | 总资产 |
+| `cash_balance` | 现金额 Cash balance | 现金 |
+| `cash_available_for_trade` | 可用资金（含保证金额度） Available funds | 可用资金 |
+| `cash_available_for_withdrawal` | 可提现金额 Withdrawable cash | 可提金额 |
+| `gross_position_value` | 证券总价值 Total position value | 市值 |
+| `buying_power` | 购买力 Buying power | 购买力 |
+| `unrealized_pl` | 浮动盈亏 Unrealized P&L | 未实现盈亏 |
+| `realized_pl` | 已实现盈亏 Realized P&L | 已实现盈亏 |
+| `init_margin` | 初始保证金 Initial margin | 初始保证金 |
+| `maintain_margin` | 维持保证金 Maintenance margin | 维持保证金 |
+| `overnight_margin` | 隔夜保证金 Overnight margin | - |
+| `excess_liquidation` | 剩余流动性 Excess liquidity (= equity - maintain_margin) | 剩余流动性 |
+| `leverage` | 杠杆倍数 Leverage | 杠杆 |
+| `locked_funds` | 锁定资金 Locked funds | - |
+
+> **多币种注意 / Multi-currency Note**: 持仓涉及多币种时（如同时持有 USD 和 HKD 标的），查询资产时指定 `base_currency` 统一币种口径，避免直接累加不同币种的数值。每个 Segment 的 `currency_assets` 包含各币种明细和 `forex_rate` 汇率。
+> When positions span multiple currencies, specify `base_currency` in the query. Do not sum values across currencies directly. Use `currency_assets` for per-currency breakdown with `forex_rate`.
+
+### 全球资产 / Global Assets
+
+```python
+assets_list = trade_client.get_assets()
+for a in assets_list:
+    print(f"Buying Power: {a.buying_power}")
+    print(f"Maintenance Margin: {a.maintenance_margin_requirement}")
+    print(f"Unrealized PnL: {a.unrealized_pnl}")
+```
+
+### 资产分析 / Asset Analytics
+
+```python
+analytics = trade_client.get_analytics_asset(
+    start_date='2025-01-01', end_date='2025-06-30',
+    seg_type='SEC',  # SEC(证券)/FUT(期货)/ALL
+    currency='USD')
+# 返回 summary(pnl, pnl_percentage, annualized_return) 和 history(每日资产/盈亏)
+```
+
+```bash
+# CLI
+tigeropen account assets                                      # 综合资产（推荐）
+tigeropen account assets --currency USD                      # 指定计价货币
+tigeropen account analytics --start-date 2025-01-01 --end-date 2025-12-31  # 资产分析
+```
+
+---
+
+## 持仓 / Positions
+<!-- 当用户提到 "持仓"、"仓位"、"我的股票"、"positions"、"holdings"、"portfolio" 时 -->
+
+```python
+from tigeropen.common.consts import SecurityType, Market
+
+# 所有持仓 / All positions
+positions = trade_client.get_positions()
+
+# 按类型 / By security type
+positions = trade_client.get_positions(sec_type=SecurityType.STK)
+for p in positions:
+    print(f"{p.contract.symbol}: qty={p.qty}, cost={p.average_cost}, "
+          f"price={p.market_price}, value={p.market_value}, "
+          f"pnl={p.unrealized_pnl}, salable={p.salable_qty}")
+
+# 按市场 / By market
+us_pos = trade_client.get_positions(sec_type=SecurityType.STK, market=Market.US)
+hk_pos = trade_client.get_positions(sec_type=SecurityType.STK, market=Market.HK)
+
+# 按代码 / By symbol
+aapl_pos = trade_client.get_positions(sec_type=SecurityType.STK, symbol='AAPL')
+
+# 期权持仓 / Option positions
+opt_pos = trade_client.get_positions(sec_type=SecurityType.OPT)
+
+# 期货持仓 / Futures positions
+fut_pos = trade_client.get_positions(sec_type=SecurityType.FUT)
+```
+
+### Position 对象属性 / Position Attributes
+
+| 属性 Attribute | 说明 Description | APP 对应 |
+|---------------|-----------------|----------|
+| `contract` | 合约对象 Contract | - |
+| `qty` / `position_qty` | 持仓数量 Quantity | 持有数量 |
+| `average_cost` | 含佣金持仓均价 Average cost (incl. commission) | 平均成本 |
+| `average_cost_by_average` | 均价成本（不含佣金） Average cost (excl. commission) | - |
+| `market_price` | 最新价格 Market price | 现价 |
+| `market_value` | 市值 Market value | 市值 |
+| `unrealized_pnl` | 浮动盈亏 Unrealized P&L (FIFO) | 未实现盈亏 |
+| `unrealized_pnl_by_average` | 均价成本浮动盈亏 Unrealized P&L (avg cost) | - |
+| `unrealized_pnl_percent` | 浮动盈亏率 Unrealized P&L % | 盈亏百分比 |
+| `realized_pnl` | 已实现盈亏 Realized P&L (FIFO) | 已实现盈亏 |
+| `salable_qty` | 可卖数量 Salable quantity | 可卖 |
+| `today_pnl` | 今日盈亏额 Today's P&L | 今日盈亏 |
+| `today_pnl_percent` | 今日盈亏率 Today's P&L % | - |
+| `ratio` | 持仓占比 Position ratio | - |
+| `latest_price` | 最新成交价 Latest trade price | - |
+| `currency` | 币种 Currency | - |
+
+```bash
+# CLI
+tigeropen trade position list                                 # 所有股票持仓
+tigeropen trade position list --sec-type opt                  # 期权持仓
+tigeropen trade position list --sec-type fut                  # 期货持仓
+tigeropen trade position list --market hk                     # 港股持仓
+tigeropen trade position list --symbol AAPL                  # 指定标的
+```
+
+---
+
+## 预估可交易数量 / Estimate Tradable Quantity
+
+```python
+result = trade_client.get_estimate_tradable_quantity(
+    symbol='AAPL', sec_type='STK', order_type='LMT',
+    action='BUY', limit_price=150.0)
+# 返回: tradable_quantity(可交易), financing_quantity(融资可交易), position_quantity(持仓数量)
+```
+
+## 资金划转 / Fund Transfer (Between Segments)
+
+```python
+# 查询可划转金额 / Query transferable amount
+available = trade_client.get_segment_fund_available(
+    from_segment='SEC', to_segment='FUT', currency='USD')
+
+# 划转 / Transfer
+trade_client.transfer_segment_fund(
+    from_segment='SEC', to_segment='FUT', amount=10000.0, currency='USD')
+
+# 取消划转 / Cancel transfer
+trade_client.cancel_segment_fund(id='transfer_id')
+
+# 划转历史 / Transfer history
+history = trade_client.get_segment_fund_history()
+```
+
+## 出入金记录 / Deposit/Withdrawal Records
+
+```python
+records = trade_client.get_funding_history(
+    start_time='2025-01-01', end_time='2025-06-30', currency='USD')
+```
+
+## 换汇下单 / Forex Order
+
+```python
+from tigeropen.common.consts import SegmentType
+
+trade_client.place_forex_order(
+    seg_type=SegmentType.SEC,  # SEC(证券板块) 或 FUT(期货板块)
+    source_currency='USD', target_currency='HKD', source_amount=10000.0)
+```
+
+---
+
+## 交易时间参考 / Trading Hours Reference
+
+| 市场 Market | 时段 Session | 时间 Time (当地/Local) |
+|-------------|-------------|----------------------|
+| 美股 US | 盘前 Pre-market | 04:00-09:30 ET |
+| | 常规 Regular | 09:30-16:00 ET |
+| | 盘后 After-hours | 16:00-20:00 ET |
+| | 夜盘 Overnight | 20:00-04:00 ET |
+| 港股 HK | 竞价 Pre-opening | 09:00-09:30 |
+| | 上午 Morning | 09:30-12:00 |
+| | 下午 Afternoon | 13:00-16:00 |
+| | 收盘竞价 Closing | 16:00-16:10 |
+| 新加坡 SG | 全天 Full | 09:00-17:16 |
+
+> 更多交易规则见 / More: https://docs.itigerup.com/docs/trade-rules
+
+---
+
+## 注意事项 / Notes
+
+- `place_order` 返回成功仅表示提交成功，需查询确认成交。可检查 `order.id` 和 `order.status` / Success only means submitted; check `order.id` and `order.status`
+- 市价单(MKT)和止损单(STP)不支持盘前盘后 / MKT and STP don't support pre/after-hours
+- 同一证券不能同时持有多头和空头 / Cannot hold long and short simultaneously
+- 下单前建议 `preview_order` / Use preview before placing real orders
+- 交易佣金与 App 一致，无额外费用 / Trading fees same as app
+- 已成交订单查询需指定时间范围，最多90天 / Filled orders require time range, max 90 days
+- 港股下单数量须为 `lot_size` 的整数倍，可通过 `get_trade_metas` 查询 / HK orders must be multiples of `lot_size`
+- `quantity_scale` 用于碎股精度控制 / `quantity_scale` controls fractional share precision
+- `adjust_limit` 参数可用于价格自动修正 / `adjust_limit` for automatic price adjustment

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ statements/
 *.bak
 
 .kilo
+.playwright-cli

--- a/.opencode/commands/opsx-apply.md
+++ b/.opencode/commands/opsx-apply.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx-apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx-continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx-archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.opencode/commands/opsx-archive.md
+++ b/.opencode/commands/opsx-archive.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx-archive` (e.g., `/opsx-archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.opencode/commands/opsx-explore.md
+++ b/.opencode/commands/opsx-explore.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx-explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.opencode/commands/opsx-propose.md
+++ b/.opencode/commands/opsx-propose.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx-apply
+
+---
+
+**Input**: The argument after `/opsx-propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx-apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.opencode/skills/openspec-archive-change/SKILL.md
+++ b/.opencode/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.opencode/skills/openspec-explore/SKILL.md
+++ b/.opencode/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx-explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx-apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx-apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.zed/scripts/init-worktree.ts
+++ b/.zed/scripts/init-worktree.ts
@@ -1,0 +1,28 @@
+import { execSync } from 'node:child_process'
+import path from 'node:path'
+import fs from 'node:fs'
+
+const wt = process.env.ZED_WORKTREE_ROOT
+if (!wt) {
+  console.error('ZED_WORKTREE_ROOT is not set')
+  process.exit(1)
+}
+
+const output = execSync(`git -C "${wt}" worktree list`, { encoding: 'utf-8' })
+const firstLine = output.split('\n')[0]
+if (!firstLine) {
+  console.error('No output from git worktree list')
+  process.exit(1)
+}
+const main = firstLine.trim().split(' ')[0]
+if (!main) {
+  console.error('Could not determine main repo path')
+  process.exit(1)
+}
+
+const src = path.join(main, 'apps', 'web', '.env')
+const dst = path.join(wt, 'apps', 'web', '.env')
+
+if (fs.existsSync(src)) {
+  fs.copyFileSync(src, dst)
+}

--- a/.zed/scripts/package.json
+++ b/.zed/scripts/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "private": true
+}

--- a/.zed/scripts/tsconfig.json
+++ b/.zed/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,22 @@
+{
+  "formatter": {
+    "language_server": {
+      "name": "biome"
+    }
+  },
+  "code_actions_on_format": {
+    "source.fixAll.biome": true,
+    "source.organizeImports.biome": true
+  },
+  "languages": {
+    "JavaScript": {
+      "language_servers": ["biome", "tsx", "..."]
+    },
+    "TypeScript": {
+      "language_servers": ["biome", "tsx", "..."]
+    },
+    "TSX": {
+      "language_servers": ["biome", "tsx", "..."]
+    }
+  }
+}

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,5 +1,14 @@
 [
   {
+    "label": "Init new worktree",
+    "command": "node",
+    "args": ["--strip-types", ".zed/scripts/init-worktree.ts"],
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "hooks": ["create_worktree"],
+    "reveal": "no_focus",
+    "hide": "on_success"
+  },
+  {
     "label": "pnpm install in new worktree",
     "command": "pnpm",
     "args": ["install"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ pnpm workspaces + Turborepo. Packages: `apps/web` (Vite + React 19), `packages/p
 ```bash
 pnpm dev      # start all dev servers (turbo)
 pnpm build    # build all packages
-pnpm lint     # typecheck all packages
+pnpm lint     # lint, format all packages
 pnpm test     # build then test all packages (turbo test dependsOn ^build)
 ```
 
@@ -28,13 +28,3 @@ Test file pattern: `*.test.ts`. Run single package: `pnpm --filter <pkg> test`.
 - **PDF parsing**: runs in a Web Worker via `pdfjs-dist`. Worker path set with `new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url)`.
 - **Parser auto-detection**: `detectParser(text)` in `parser-core` tries each bank's `detect()` in order, returns first match.
 - **Rule engine**: Manual Override → General Rules (ascending priority) → Uncategorized. No hash-pinned rules.
-
-## Style
-
-Prettier (semi: false, singleQuote, trailingComma: es5). No ESLint config detected — `lint` script uses `tsc --noEmit`.
-
-## Key Files
-
-- `docs/architecture.md` — full architecture doc with ADRs
-- `CLAUDE.md` — shell command conventions (no compound commands, use `git -C`)
-- `.claude/commands/conventional-commit.md` — commit convention

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,14 @@
+# Tiger OpenAPI credentials for the verification script.
+# 
+# Copy this to .env and fill in your values. The script auto-loads .env.
+# Use your PKCS#8 private key, not PKCS#1.
+#
+# The key can be the raw base64 string from the Tiger Developer Center —
+# no PEM headers needed. The script auto-wraps it.
+#
+#   cp .env.example .env
+#   pnpm --filter @lokfi/web test-tiger
+
+TIGER_ID=your_developer_id
+TIGER_PRIVATE_KEY=MIIEvQIBADANBgkqhkiG...
+TIGER_ACCOUNT=U1234567

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,6 +1,13 @@
-# React + TypeScript + Vite
+# Lokfi Web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Personal finance dashboard built with React + TypeScript + Vite.
+
+## Features
+
+- **Unified transaction view** — Bank transactions and brokerage data (trades, dividends, fees) are merged into a single timeline on `/transactions`. Switch between **All**, **Bank**, and **Brokerage** tabs. Brokerage rows are read-only and visually distinct (neutral gray for BUY/SELL, green for DIVIDEND, red for FEE).
+- **Brokerage settings** — Configure Tiger Brokers API credentials, test connectivity, trigger manual sync, and set historical lookback days at `/settings/brokerage`. Credentials are encrypted with AES-256-GCM via the Web Crypto API.
+- **Rule engine** — Auto-categorise bank transactions based on custom rules with priority ordering.
+- **PDF import** — Parse bank statements directly in the browser using `pdfjs-dist` in a Web Worker.
 
 Currently, two official plugins are available:
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -5,6 +5,7 @@ Personal finance dashboard built with React + TypeScript + Vite.
 ## Features
 
 - **Unified transaction view** — Bank transactions and brokerage data (trades, dividends, fees) are merged into a single timeline on `/transactions`. Switch between **All**, **Bank**, and **Brokerage** tabs. Brokerage rows are read-only and visually distinct (neutral gray for BUY/SELL, green for DIVIDEND, red for FEE).
+- **Portfolio hub** — Tabbed `/portfolio` page with Overview (KPI cards, asset allocation donut chart, currency breakdown, performance sparkline), Holdings (grouped positions table with P&L), Transactions (enhanced unified view with Type/Symbol/Qty/Price columns), and Dividends (YTD summary, monthly bar chart, yield-on-cost). Supports currency conversion via cached FX rates.
 - **Brokerage settings** — Configure Tiger Brokers API credentials, test connectivity, trigger manual sync, and set historical lookback days at `/settings/brokerage`. Credentials are encrypted with AES-256-GCM via the Web Crypto API.
 - **Rule engine** — Auto-categorise bank transactions based on custom rules with priority ordering.
 - **PDF import** — Parse bank statements directly in the browser using `pdfjs-dist` in a Web Worker.

--- a/apps/web/bin/test-tiger.ts
+++ b/apps/web/bin/test-tiger.ts
@@ -1,0 +1,370 @@
+/**
+ * Tiger API Verification Script
+ *
+ * Usage:
+ *   pnpm --filter @lokfi/web test-tiger
+ *
+ * Credentials are loaded from, in order:
+ *   1. A .env file in apps/web/ (copy .env.example to .env)
+ *   2. Shell environment variables
+ *
+ * The .env file is recommended — copy apps/web/.env.example to apps/web/.env
+ * and fill in your values:
+ *
+ *   TIGER_ID=your_developer_id
+ *   TIGER_PRIVATE_KEY=MIIEvQIBA...  (PKCS8 base64, no PEM headers needed)
+ *   TIGER_ACCOUNT=U1234567
+ *
+ * Or set inline:
+ *   $env:TIGER_ID="your_id"; $env:TIGER_PRIVATE_KEY="MIIEvQI..."; pnpm --filter @lokfi web test-tiger
+ */
+
+import 'dotenv/config'
+import * as fs from 'node:fs'
+import { TigerAuthError, TigerHttpClient, TigerHttpError } from '../src/lib/brokerage/tiger/tiger-http-client'
+import type { TigerAsset, TigerCorpAction, TigerOrder, TigerPosition } from '../src/lib/brokerage/tiger/tiger-types'
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Tiger API wraps many responses in { items: T[] } */
+interface ItemResponse<T> {
+  items?: T[]
+}
+
+/** Unwrap a response that may be a direct array or { items: T[] } */
+function unwrapItems<T>(raw: ItemResponse<T> | T[] | undefined): T[] {
+  if (Array.isArray(raw)) return raw
+  return raw?.items ?? []
+}
+
+const bold = (s: string) => `\x1b[1m${s}\x1b[22m`
+const green = (s: string) => `\x1b[32m${s}\x1b[39m`
+const red = (s: string) => `\x1b[31m${s}\x1b[39m`
+const yellow = (s: string) => `\x1b[33m${s}\x1b[39m`
+const dim = (s: string) => `\x1b[2m${s}\x1b[22m`
+const cyan = (s: string) => `\x1b[36m${s}\x1b[39m`
+
+function check(text: string): string {
+  return `${green('✓')} ${text}`
+}
+
+function fail(text: string): string {
+  return `${red('✗')} ${text}`
+}
+
+function section(title: string): void {
+  console.log(`\n${bold(cyan('───'))} ${bold(title)} ${bold(cyan('─'.repeat(Math.max(0, 60 - title.length))))}`)
+}
+
+function fmtMoney(n: number | undefined, currency: string): string {
+  if (n === undefined) return dim('N/A')
+  return n.toLocaleString('en-US', { style: 'currency', currency })
+}
+
+function fmtPercent(n: number | undefined): string {
+  if (n === undefined) return dim('N/A')
+  const sign = n >= 0 ? '+' : ''
+  return `${sign}${n.toFixed(2)}%`
+}
+
+function readPrivateKey(value: string): string {
+  // Case 1: Already a PEM string with headers — use as-is
+  if (value.includes('-----BEGIN')) {
+    return value
+  }
+
+  // Case 2: It's an existing file on disk — read it
+  try {
+    if (fs.existsSync(value)) {
+      return fs.readFileSync(value, 'utf-8')
+    }
+  } catch {
+    // not a valid path
+  }
+
+  // Case 3: Raw base64 string (from .env or env var) — wrap with PKCS8 envelope
+  const body = value.replace(/\s/g, '')
+  return `-----BEGIN PRIVATE KEY-----\n${body}\n-----END PRIVATE KEY-----`
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log(bold('Tiger OpenAPI — Connection Verification\n'))
+  console.log(dim(`API Base: https://openapi.tigerfintech.com`))
+  console.log(dim(`SDK Ref:  @tigeropenapi/tigeropen v0.1.0\n`))
+
+  // ── Load credentials ──────────────────────────────────────────────────
+
+  const tigerId = process.env.TIGER_ID
+  const privateKeyRaw = process.env.TIGER_PRIVATE_KEY
+  const account = process.env.TIGER_ACCOUNT
+
+  if (!tigerId || !privateKeyRaw || !account) {
+    console.log(red('Missing credentials. Set the following environment variables:\n'))
+    console.log(`  ${cyan('TIGER_ID')}          — your Tiger developer ID`)
+    console.log(`  ${cyan('TIGER_PRIVATE_KEY')} — PKCS8 private key (base64 string, or path to PEM file)`)
+    console.log(`  ${cyan('TIGER_ACCOUNT')}     — your Tiger trading account number`)
+    console.log(`\n${yellow('Use your PKCS#8 key, not PKCS#1.')} The key can be the raw base64 string `)
+    console.log(`${yellow('from the Tiger Developer Center — no PEM headers needed.')}`)
+    console.log(`\n${dim('Example (PowerShell):')}`)
+    console.log(dim('  $env:TIGER_ID="your_id"'))
+    console.log(dim('  $env:TIGER_PRIVATE_KEY="MIIEvQIBADANBgkqhkiG..."  # raw base64 from Tiger'))
+    console.log(dim('  $env:TIGER_ACCOUNT="U1234567"'))
+    process.exit(1)
+  }
+
+  const privateKey = readPrivateKey(privateKeyRaw)
+
+  console.log(dim(`Tiger ID:  ${tigerId.slice(0, 4)}...`))
+  console.log(dim(`Account:   ${account}`))
+  console.log(
+    dim(
+      `Key:       ${
+        privateKeyRaw.includes('-----BEGIN')
+          ? privateKeyRaw.includes('BEGIN PRIVATE KEY')
+            ? 'PKCS8 PEM'
+            : 'PKCS1 PEM (may need conversion)'
+          : privateKeyRaw.includes('\\') || privateKeyRaw.includes('/') || privateKeyRaw.includes('\n')
+            ? 'File (loaded)'
+            : 'raw base64 (auto-wrapped as PKCS8)'
+      }`
+    )
+  )
+
+  // ── Initialize client ─────────────────────────────────────────────────
+
+  const client = new TigerHttpClient({
+    tigerId,
+    privateKey,
+    account,
+    language: 'en_US',
+  })
+
+  // Helper: build bizContent with account injected
+  const biz = (extra?: Record<string, unknown>) => JSON.stringify({ account, ...extra })
+
+  // ── Step 1: Validate connection ───────────────────────────────────────
+
+  section('1. Connection Check')
+
+  try {
+    const assets = unwrapItems(
+      await client.execute<ItemResponse<TigerAsset>>({
+        method: 'assets',
+        bizContent: biz(),
+      })
+    )
+    console.log(check(`Authenticated successfully — received ${assets.length} asset record(s)`))
+    if (assets.length > 0 && assets[0]) {
+      console.log(
+        dim(
+          `   A/C ${assets[0].currency}: netLiq=${assets[0].netLiquidation} cash=${assets[0].cashValue} unrealPnL=${assets[0].unrealizedPnL}`
+        )
+      )
+    }
+  } catch (err) {
+    if (err instanceof TigerAuthError) {
+      console.log(fail(`Authentication failed: ${err.message}`))
+      console.log(dim('\n   Troubleshooting:'))
+      console.log(dim('   - Ensure the private key is PKCS8 format (BEGIN PRIVATE KEY)'))
+      console.log(dim('   - Verify the public key is uploaded in the Tiger Developer Center'))
+      console.log(dim('   - Check that your tiger_id is correct'))
+    } else if (err instanceof TigerHttpError) {
+      console.log(fail(`API error: [${err.code}] ${err.message}`))
+    } else {
+      console.log(fail(`Connection failed: ${err instanceof Error ? err.message : String(err)}`))
+    }
+    process.exit(1)
+  }
+
+  // ── Step 2: Positions ─────────────────────────────────────────────────
+
+  section('2. Positions')
+
+  try {
+    const positions = unwrapItems(
+      await client.execute<ItemResponse<TigerPosition>>({
+        method: 'positions',
+        bizContent: biz(),
+      })
+    )
+    console.log(check(`Fetched ${bold(String(positions.length))} position(s)`))
+
+    if (positions.length > 0 && positions.length < 500) {
+      console.log()
+      // Table header
+      console.log(
+        `  ${bold('Symbol'.padEnd(12))} ${bold('Qty'.padStart(10))} ${bold('AvgCost'.padStart(12))} ${bold('MktVal'.padStart(14))} ${bold('P&L'.padStart(12))} ${bold('P&L%'.padStart(8))}  ${bold('Currency')}`
+      )
+      console.log(`  ${'─'.repeat(80)}`)
+      for (const p of positions) {
+        const pnlColor = (p.unrealizedPnl ?? 0) >= 0 ? green : red
+        const name = (p.name || p.symbol).slice(0, 12)
+        console.log(
+          `  ${name.padEnd(12)} ${String(p.position).padStart(10)} ${fmtMoney(p.averageCost, p.currency || 'USD').padStart(12)} ${fmtMoney(p.marketValue, p.currency || 'USD').padStart(14)} ${pnlColor(fmtMoney(p.unrealizedPnl, p.currency || 'USD').padStart(12))} ${pnlColor(fmtPercent(p.unrealizedPnlPercent).padStart(8))}  ${p.currency || 'USD'}`
+        )
+      }
+      // Totals
+      const totalMktVal = positions.reduce((sum, p) => sum + (p.marketValue ?? 0), 0)
+      const totalPnl = positions.reduce((sum, p) => sum + (p.unrealizedPnl ?? 0), 0)
+      const pnlColor = totalPnl >= 0 ? green : red
+      console.log(`  ${'─'.repeat(80)}`)
+      console.log(
+        `  ${'TOTAL'.padEnd(12)} ${''.padStart(10)} ${''.padStart(12)} ${fmtMoney(totalMktVal, 'USD').padStart(14)} ${pnlColor(fmtMoney(totalPnl, 'USD').padStart(12))}`
+      )
+    } else {
+      console.log(dim('   No open positions found.'))
+    }
+  } catch (err) {
+    console.log(fail(`Failed to fetch positions: ${err instanceof Error ? err.message : String(err)}`))
+  }
+
+  // ── Step 3: Account Summary ───────────────────────────────────────────
+
+  section('3. Account Summary')
+
+  try {
+    const items = unwrapItems(
+      await client.execute<ItemResponse<TigerAsset>>({
+        method: 'assets',
+        bizContent: biz(),
+      })
+    )
+
+    if (items.length > 0) {
+      // Show top-level asset summary
+      console.log()
+      console.log(
+        `  ${bold('Currency'.padStart(8))} ${bold('NetLiq'.padStart(14))} ${bold('Cash'.padStart(14))} ${bold('BuyingPwr'.padStart(14))} ${bold('UnrealPnL'.padStart(14))}`
+      )
+      console.log(`  ${'─'.repeat(65)}`)
+      for (const a of items) {
+        console.log(
+          `  ${(a.currency || 'USD').padStart(8)} ${fmtMoney(a.netLiquidation, a.currency || 'USD').padStart(14)} ${fmtMoney(a.cashValue, a.currency || 'USD').padStart(14)} ${fmtMoney(a.buyingPower, a.currency || 'USD').padStart(14)} ${fmtMoney(a.unrealizedPnL, a.currency || 'USD').padStart(14)}`
+        )
+      }
+
+      // Show per-segment breakdown
+      for (const a of items) {
+        if (a.segments && a.segments.length > 0) {
+          console.log(`\n  ${bold('Segments:')}`)
+          console.log(
+            `  ${bold('Category'.padEnd(12))} ${bold('NetLiq'.padStart(14))} ${bold('Cash'.padStart(14))} ${bold('Avail'.padStart(14))} ${bold('InitMargin'.padStart(14))}`
+          )
+          console.log(`  ${'─'.repeat(70)}`)
+          for (const seg of a.segments) {
+            const cat = seg.category === 'S' ? 'Stocks' : seg.category === 'C' ? 'Futures' : seg.category
+            console.log(
+              `  ${(cat || 'N/A').padEnd(12)} ${fmtMoney(seg.netLiquidation, a.currency || 'USD').padStart(14)} ${fmtMoney(seg.cashValue, a.currency || 'USD').padStart(14)} ${fmtMoney(seg.availableFunds, a.currency || 'USD').padStart(14)} ${fmtMoney(seg.initMarginReq, a.currency || 'USD').padStart(14)}`
+            )
+          }
+        }
+      }
+    } else {
+      console.log(dim('   No account data returned.'))
+    }
+  } catch (err) {
+    console.log(fail(`Failed to fetch account: ${err instanceof Error ? err.message : String(err)}`))
+  }
+
+  // ── Step 4: Recent Orders ─────────────────────────────────────────────
+
+  section('4. Recent Filled Orders (last 30 days)')
+
+  try {
+    const since = new Date()
+    since.setDate(since.getDate() - 30)
+
+    // Tiger API uses start_date/end_date, response is { items: [...] }
+    const orders = unwrapItems(
+      await client.execute<ItemResponse<TigerOrder>>({
+        method: 'filled_orders',
+        bizContent: biz({
+          start_date: since.toISOString().slice(0, 10),
+          end_date: new Date().toISOString().slice(0, 10),
+        }),
+      })
+    )
+
+    console.log(check(`Fetched ${bold(String(orders.length))} filled order(s)`))
+
+    if (orders.length > 0) {
+      console.log()
+      console.log(
+        `  ${bold('Time'.padEnd(22))} ${bold('Symbol'.padEnd(10))} ${bold('Type'.padStart(5))} ${bold('Action'.padStart(6))} ${bold('Qty'.padStart(8))} ${bold('Price'.padStart(10))} ${bold('Status'.padStart(16))}`
+      )
+      console.log(`  ${'─'.repeat(80)}`)
+
+      const recent = orders.slice(-10)
+      for (const o of recent) {
+        const time = o.latestTime
+          ? new Date(o.latestTime).toISOString().replace('T', ' ').slice(0, 19)
+          : dim('N/A'.padStart(19))
+        const actionColor = (o.action || '').toUpperCase() === 'BUY' ? green : red
+        const type = (o.secType || '').padStart(5)
+        console.log(
+          `  ${time.padEnd(22)} ${(o.symbol || '').padEnd(10)} ${type} ${actionColor((o.action || '').padStart(6))} ${String(o.totalQuantity).padStart(8)} ${fmtMoney(o.avgFillPrice, o.currency || 'USD').padStart(10)} ${(o.status || '').padStart(16)}`
+        )
+      }
+    } else {
+      console.log(dim('   No filled orders in this period.'))
+    }
+  } catch (err) {
+    console.log(fail(`Failed to fetch orders: ${err instanceof Error ? err.message : String(err)}`))
+  }
+
+  // ── Step 5: Corporate Actions ─────────────────────────────────────────
+
+  section('5. Corporate Actions (last 90 days)')
+
+  try {
+    const since = new Date()
+    since.setDate(since.getDate() - 90)
+    const start = since.toISOString().slice(0, 10)
+    const end = new Date().toISOString().slice(0, 10)
+
+    const actions = unwrapItems(
+      await client.execute<ItemResponse<TigerCorpAction>>({
+        method: 'fund_details',
+        bizContent: biz({
+          fund_type: 'CORPORATE_ACTION',
+          seg_types: ['SEC'],
+          start_date: start,
+          end_date: end,
+          limit: 100,
+        }),
+      })
+    )
+
+    if (actions.length > 0) {
+      console.log(check(`Fetched ${bold(String(actions.length))} corporate action(s)`))
+      console.log()
+      for (const a of actions) {
+        console.log(
+          `  ${dim(a.businessDate || 'N/A')}  ${yellow(a.desc || 'Unknown')}  ${fmtMoney(a.amount, a.currency || 'USD')}`
+        )
+      }
+    } else {
+      console.log(dim('   No corporate actions in this period.'))
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(yellow(`⚠ Corporate actions unavailable: ${msg}`))
+    console.log(dim('   The fund_details endpoint returns "server error" (code 1) for this'))
+    console.log(dim('   account. This may require additional permissions from Tiger.'))
+  }
+
+  // ── Summary ───────────────────────────────────────────────────────────
+
+  section('Result')
+
+  console.log(`\n  ${green('✓ Connection working')}  — Tiger OpenAPI is accessible with your credentials.\n`)
+  console.log(dim('  The lokfi sync pipeline uses these same API calls through the'))
+  console.log(dim('  TigerProvider → SyncOrchestrator → Dexie pipeline.\n'))
+}
+
+main().catch((err) => {
+  console.error(red(`\nFatal error: ${err instanceof Error ? err.message : String(err)}`))
+  process.exit(1)
+})

--- a/apps/web/bin/test-tiger.ts
+++ b/apps/web/bin/test-tiger.ts
@@ -22,7 +22,7 @@
 import 'dotenv/config'
 import * as fs from 'node:fs'
 import { TigerAuthError, TigerHttpClient, TigerHttpError } from '../src/lib/brokerage/tiger/tiger-http-client'
-import type { TigerAsset, TigerCorpAction, TigerOrder, TigerPosition } from '../src/lib/brokerage/tiger/tiger-types'
+import type { TigerAsset, TigerFundDetail, TigerOrder, TigerPosition } from '../src/lib/brokerage/tiger/tiger-types'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -183,16 +183,47 @@ async function main(): Promise<void> {
   section('2. Positions')
 
   try {
-    const positions = unwrapItems(
-      await client.execute<ItemResponse<TigerPosition>>({
-        method: 'positions',
-        bizContent: biz(),
-      })
-    )
+    const rawResponse = await client.execute<unknown>({
+      method: 'positions',
+      bizContent: biz(),
+    })
+
+    // ── DEBUG: Dump raw response shape ──────────────────────────────────
+    console.log(`\n  ${bold(yellow('RAW RESPONSE DEBUG'))}`)
+    console.log(`  ${yellow(`typeof rawResponse: ${typeof rawResponse}`)}`)
+    console.log(`  ${yellow(`isArray: ${Array.isArray(rawResponse)}`)}`)
+    if (rawResponse && typeof rawResponse === 'object') {
+      const keys = Object.keys(rawResponse as Record<string, unknown>)
+      console.log(`  ${yellow(`keys: [${keys.join(', ')}]`)}`)
+      for (const k of keys) {
+        const val = (rawResponse as Record<string, unknown>)[k]
+        console.log(
+          `  ${yellow(`  ${k}: typeof=${typeof val}, isArray=${Array.isArray(val)}, length=${(val as unknown[])?.length ?? 'N/A'}`)}`
+        )
+      }
+    }
+    fs.writeFileSync('tiger-positions-raw.json', JSON.stringify(rawResponse, null, 2))
+    console.log(`  ${yellow('Full raw response written to tiger-positions-raw.json')}\n`)
+
+    // ── End debug ───────────────────────────────────────────────────────
+
+    const positions = unwrapItems(rawResponse as ItemResponse<TigerPosition>)
     console.log(check(`Fetched ${bold(String(positions.length))} position(s)`))
 
     if (positions.length > 0 && positions.length < 500) {
+      // Debug: print each position's secType + symbol + option fields
+      console.log(`\n  ${bold('secType debug:')}`)
+      for (const p of positions) {
+        const isOpt = p.secType === 'OPT'
+        const extra = isOpt
+          ? `  identifier=${yellow(p.identifier ?? '(none)')}  contractId=${p.contractId ?? '(none)'}  multiplier=${p.multiplier ?? '(none)'}`
+          : ''
+        console.log(
+          `  secType=${yellow((p.secType || '(none)').padEnd(6))}  symbol=${yellow(p.symbol.padEnd(24))}  qty=${String(p.position).padStart(8)}  currency=${p.currency || 'USD'}${extra}`
+        )
+      }
       console.log()
+
       // Table header
       console.log(
         `  ${bold('Symbol'.padEnd(12))} ${bold('Qty'.padStart(10))} ${bold('AvgCost'.padStart(12))} ${bold('MktVal'.padStart(14))} ${bold('P&L'.padStart(12))} ${bold('P&L%'.padStart(8))}  ${bold('Currency')}`
@@ -314,9 +345,9 @@ async function main(): Promise<void> {
     console.log(fail(`Failed to fetch orders: ${err instanceof Error ? err.message : String(err)}`))
   }
 
-  // ── Step 5: Corporate Actions ─────────────────────────────────────────
+  // ── Step 5: Fund Details ───────────────────────────────────────────
 
-  section('5. Corporate Actions (last 90 days)')
+  section('5. Fund Details (last 90 days)')
 
   try {
     const since = new Date()
@@ -325,10 +356,10 @@ async function main(): Promise<void> {
     const end = new Date().toISOString().slice(0, 10)
 
     const actions = unwrapItems(
-      await client.execute<ItemResponse<TigerCorpAction>>({
+      await client.execute<ItemResponse<TigerFundDetail>>({
         method: 'fund_details',
         bizContent: biz({
-          fund_type: 'CORPORATE_ACTION',
+          fund_type: 'ALL',
           seg_types: ['SEC'],
           start_date: start,
           end_date: end,
@@ -336,9 +367,9 @@ async function main(): Promise<void> {
         }),
       })
     )
-
+    fs.writeFileSync('fund_details.json', JSON.stringify(actions))
     if (actions.length > 0) {
-      console.log(check(`Fetched ${bold(String(actions.length))} corporate action(s)`))
+      console.log(check(`Fetched ${bold(String(actions.length))} fund detail record(s)`))
       console.log()
       for (const a of actions) {
         console.log(
@@ -346,11 +377,11 @@ async function main(): Promise<void> {
         )
       }
     } else {
-      console.log(dim('   No corporate actions in this period.'))
+      console.log(dim('   No fund detail records in this period.'))
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    console.log(yellow(`⚠ Corporate actions unavailable: ${msg}`))
+    console.log(yellow(`⚠ Fund details unavailable: ${msg}`))
     console.log(dim('   The fund_details endpoint returns "server error" (code 1) for this'))
     console.log(dim('   account. This may require additional permissions from Tiger.'))
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,9 +9,11 @@
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test-tiger": "tsx bin/test-tiger.ts"
   },
   "dependencies": {
+    "@lokfi/brokerage-core": "workspace:*",
     "@lokfi/parser-core": "workspace:*",
     "@tanstack/react-router": "^1.167.4",
     "clsx": "^2.1.1",
@@ -31,6 +33,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@playwright/mcp": "^0.0.73",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -41,9 +44,11 @@
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "^2.1.9",
     "autoprefixer": "^10.4.27",
+    "dotenv": "^17.4.2",
     "jsdom": "^25.0.1",
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19",
+    "tsx": "^4.21.0",
     "typescript": "~5.9.3",
     "vite": "^8.0.0",
     "vitest": "^2.1.9"

--- a/apps/web/src/layouts/AppShell.tsx
+++ b/apps/web/src/layouts/AppShell.tsx
@@ -1,5 +1,17 @@
 import { Link, useRouterState } from '@tanstack/react-router'
-import { LayoutDashboard, List, type LucideIcon, Moon, Pin, PinOff, Sun, Upload, User, Wand2 } from 'lucide-react'
+import {
+  LayoutDashboard,
+  List,
+  type LucideIcon,
+  Moon,
+  Pin,
+  PinOff,
+  Sun,
+  TrendingUp,
+  Upload,
+  User,
+  Wand2,
+} from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { useState } from 'react'
 import { Toaster } from 'sonner'
@@ -12,6 +24,7 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { label: 'Dashboard', path: '/dashboard', icon: LayoutDashboard },
+  { label: 'Portfolio', path: '/portfolio', icon: TrendingUp },
   { label: 'Import', path: '/import', icon: Upload },
   { label: 'Transactions', path: '/transactions', icon: List },
   { label: 'Rules', path: '/rules', icon: Wand2 },

--- a/apps/web/src/lib/brokerage/README.md
+++ b/apps/web/src/lib/brokerage/README.md
@@ -1,0 +1,177 @@
+# Brokerage Integration Guide
+
+## Overview
+
+Each brokerage integration lives in its own subdirectory under `src/lib/brokerage/` and consists of:
+
+- **Provider** — implements `BrokerageProvider` from `@lokfi/brokerage-core`; the only interface the sync pipeline talks to
+- **Adapters** — map raw API shapes to normalized `Brokerage*` types
+- **HTTP client** (optional) — handles auth, signing, and transport for the brokerage's specific API
+- **Types** (optional) — raw API response types
+
+Shared infrastructure lives at the `brokerage/` root:
+
+| File | Role |
+|------|------|
+| `sync-orchestrator.ts` | Coordinates multi-category sync with retry + throttle |
+| `credential-manager.ts` | AES-256-GCM encryption + PBKDF2 key derivation for API keys |
+| `dexie-credential-store.ts` | Dexie-backed `CredentialStore` for encrypted blobs |
+| `dexie-sync-adapter.ts` | Dexie-backed `SyncDatabase` for positions/transactions/etc. |
+
+## The Contract: `BrokerageProvider`
+
+Every integration implements this interface from `@lokfi/brokerage-core`:
+
+```ts
+interface BrokerageProvider {
+  readonly source: string        // e.g. 'tiger', 'cdc'
+  readonly displayName: string   // e.g. 'Tiger Brokers'
+
+  fetchPositions(): Promise<BrokeragePosition[]>
+  fetchTransactions(since: Date): Promise<BrokerageTransaction[]>
+  fetchCorpActions(since: Date): Promise<BrokerageCorpAction[]>
+  fetchAccount(): Promise<BrokerageAccount[]>
+  validateConnection(): Promise<boolean>
+}
+```
+
+The `source` string is the discriminator stored in every record — it must be unique per brokerage.
+
+## Normalized Types
+
+All raw API data maps to these types from `@lokfi/brokerage-core`:
+
+- **`BrokeragePosition`** — holdings with `id: "${symbol}_${source}"`, `quantity`, `avgCost`, `marketValue`
+- **`BrokerageTransaction`** — order fills with `id: "${source}_${orderId}"`, `action: 'BUY'|'SELL'`, `price`, `quantity`
+- **`BrokerageCorpAction`** — dividends/splits/rights with `type: 'DIVIDEND'|'SPLIT'|'RIGHTS'|'OTHER'`
+- **`BrokerageAccount`** — per-currency asset snapshots with `cashBalance`, `netLiquidation`
+
+Provider-specific fields go into `BrokeragePositionExtension` (EAV pattern — `positionId + key + value`).
+
+## Adding a New Brokerage
+
+### 1. Scaffold the directory
+
+```
+src/lib/brokerage/<name>/
+  <name>-provider.ts       ← BrokerageProvider implementation
+  <name>-adapter.ts        ← raw → normalized type mappers
+  <name>-types.ts          ← raw API response types (if needed)
+  <name>-http-client.ts    ← auth + HTTP transport (if needed)
+  <name>-provider.test.ts  ← tests
+```
+
+### 2. Implement the provider
+
+```ts
+// <name>-provider.ts
+import type { BrokerageProvider, BrokerageAccount, BrokerageCorpAction, BrokeragePosition, BrokerageTransaction } from '@lokfi/brokerage-core'
+
+export const SOURCE = 'my_brokerage'
+
+export class MyProvider implements BrokerageProvider {
+  readonly source = SOURCE
+  readonly displayName = 'My Brokerage'
+
+  async fetchPositions(): Promise<BrokeragePosition[]> {
+    // 1. Call API
+    // 2. Map raw responses via adapter functions
+    // 3. Return normalized BrokeragePosition[]
+  }
+
+  async fetchTransactions(since: Date): Promise<BrokerageTransaction[]> {
+    // ...
+  }
+
+  async fetchCorpActions(since: Date): Promise<BrokerageCorpAction[]> {
+    // Return [] if the brokerage does not expose corp actions
+    return []
+  }
+
+  async fetchAccount(): Promise<BrokerageAccount[]> {
+    // ...
+  }
+
+  async validateConnection(): Promise<boolean> {
+    try {
+      // Lightweight auth check (e.g. fetch a single asset)
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+```
+
+### 3. Create adapters
+
+Keep the mapping logic in a separate adapter file. This keeps the provider clean and makes the mapping testable in isolation:
+
+```ts
+// <name>-adapter.ts
+import type { BrokeragePosition } from '@lokfi/brokerage-core'
+import type { RawPosition } from './<name>-types'
+import { SOURCE } from './<name>-provider'
+
+export function adaptPosition(raw: RawPosition): BrokeragePosition {
+  return {
+    id: `${raw.symbol}_${SOURCE}`,
+    source: SOURCE,
+    symbol: raw.symbol,
+    quantity: raw.quantity,
+    avgCost: raw.averageCost,
+    currency: raw.currency ?? 'USD',
+    updatedAt: new Date().toISOString(),
+  }
+}
+```
+
+### 4. Export from the barrel
+
+Add your provider to `index.ts` so consumers can import from `@lokfi/web`:
+
+```ts
+// index.ts
+export { MyProvider } from './<name>/<name>-provider'
+export type { MyProviderOptions } from './<name>/<name>-provider'
+```
+
+No other registration is needed — consumers construct your provider directly and pass it to `SyncOrchestrator`.
+
+### 5. Wire credentials
+
+If your brokerage needs API keys:
+
+1. The user enters credentials via the UI
+2. The UI calls `CredentialManager.store(source, credentials, passphrase)` which encrypts with AES-256-GCM + PBKDF2
+3. On sync, the UI calls `CredentialManager.retrieve(source, passphrase)` to get plaintext credentials
+4. Your provider constructor receives whatever config it needs
+
+Example credential flow in the consumer:
+
+```ts
+const passphrase = promptUserForPassphrase()
+const creds = await credentialManager.retrieve('my_brokerage', passphrase)
+const provider = new MyProvider({ apiKey: creds.apiKey, apiSecret: creds.apiSecret })
+const orchestrator = new SyncOrchestrator({ provider, database: dexieAdapter })
+await orchestrator.sync()
+```
+
+## How Sync Works
+
+```
+SyncOrchestrator.sync(categories?)
+  ├─ throttle(category)      ← rate-limit per API tier
+  ├─ provider.fetch*()       ← your provider
+  ├─ db.upsert*()            ← persists to Dexie
+  └─ db.insertSyncLog()      ← audit trail (success/failure)
+
+Categories fail independently — positions can succeed even if transactions fail.
+```
+
+The `SyncOrchestrator` accepts any `BrokerageProvider` — switching brokerages is just a different provider instance.
+
+## Existing Implementations
+
+- **`tiger/`** — Full implementation. Tiger OpenAPI with RSA-signed requests via Web Crypto. Shows the complete pattern: typed HTTP client, adapter functions, provider class, credential store.
+- **`cdc/`** — Stub placeholder (`CdcStubProvider`) returning empty arrays. Ready to be filled in with a real Crypto.com Exchange API integration.

--- a/apps/web/src/lib/brokerage/SyncProgressBar.tsx
+++ b/apps/web/src/lib/brokerage/SyncProgressBar.tsx
@@ -1,0 +1,154 @@
+import type { SyncCategory } from '@lokfi/brokerage-core'
+import { CheckCircle, Loader2, XCircle } from 'lucide-react'
+import type { SyncProgress } from './sync-orchestrator'
+
+const CATEGORY_LABELS: Record<SyncCategory, string> = {
+  positions: 'Positions',
+  transactions: 'Transactions',
+  fund_details: 'Fund Details',
+  account: 'Account',
+}
+
+const DEFAULT_ORDER: SyncCategory[] = ['positions', 'transactions', 'fund_details', 'account']
+
+type CategoryStatus = 'pending' | 'active' | 'success' | 'error'
+
+interface SyncProgressBarProps {
+  /** Progress events emitted so far */
+  progress: SyncProgress[]
+  /** Whether a sync is currently in progress */
+  syncing: boolean
+}
+
+export function SyncProgressBar({ progress, syncing }: SyncProgressBarProps) {
+  if (progress.length === 0 && !syncing) return null
+
+  // Separate "complete" events (category finished) from "progress" events (in-flight)
+  // Complete events have their category at a `completed` count higher than before.
+  // Progress events are everything else (start-of-category, sub-category messages).
+
+  const categoryComplete = new Map<SyncCategory, SyncProgress>()
+  const activeMessages: string[] = []
+
+  for (const event of progress) {
+    if (event.error || event.completed > categoryComplete.size) {
+      // This is a completion event (success or failure) — clear stale messages
+      const prev = categoryComplete.get(event.category)
+      if (!prev) {
+        categoryComplete.set(event.category, event)
+        activeMessages.length = 0 // clear sub-messages when a category finishes
+      }
+    } else if (event.message) {
+      // Sub-category progress message — collect for display
+      if (activeMessages.length === 0 || activeMessages[activeMessages.length - 1] !== event.message) {
+        activeMessages.push(event.message)
+      }
+    } else {
+      // Start-of-category event — no-op for status tracking
+    }
+  }
+
+  // Determine per-category status
+  const statuses = new Map<SyncCategory, { status: CategoryStatus; error?: string }>()
+
+  for (const cat of DEFAULT_ORDER) {
+    const complete = categoryComplete.get(cat)
+    if (complete) {
+      statuses.set(cat, {
+        status: complete.error ? 'error' : 'success',
+        error: complete.error,
+      })
+    } else {
+      statuses.set(cat, { status: 'pending' })
+    }
+  }
+
+  // The first pending category while syncing is "active"
+  if (syncing) {
+    for (const cat of DEFAULT_ORDER) {
+      const s = statuses.get(cat)
+      if (s?.status === 'pending') {
+        statuses.set(cat, { status: 'active' })
+        break
+      }
+    }
+  }
+
+  const completed = categoryComplete.size
+  const total =
+    progress.length > 0
+      ? progress.reduce((max, p) => (p.total > max ? p.total : max), DEFAULT_ORDER.length)
+      : DEFAULT_ORDER.length
+  const pct = total > 0 ? Math.round((completed / total) * 100) : 0
+
+  // Latest active message
+  const latestMessage = activeMessages[activeMessages.length - 1]
+
+  return (
+    <div
+      className="rounded-xl border p-4 space-y-3"
+      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+    >
+      {/* Progress bar */}
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: 'var(--border)' }}>
+          <div
+            className="h-full rounded-full transition-all duration-500 ease-out"
+            style={{
+              width: `${pct}%`,
+              backgroundColor: 'var(--accent)',
+            }}
+          />
+        </div>
+        <span className="text-xs font-mono text-gray-500 dark:text-gray-400 tabular-nums min-w-[3rem] text-right">
+          {completed}/{total}
+        </span>
+      </div>
+
+      {/* Category indicators */}
+      <div className="flex items-center gap-3">
+        {DEFAULT_ORDER.map((cat) => {
+          const s = statuses.get(cat)
+          return (
+            <div key={cat} className="flex items-center gap-1.5" title={s?.error}>
+              <StatusIcon status={s?.status ?? 'pending'} />
+              <span
+                className="text-xs font-medium"
+                style={{
+                  color:
+                    s?.status === 'active'
+                      ? 'var(--accent)'
+                      : s?.status === 'error'
+                        ? '#ef4444'
+                        : s?.status === 'success'
+                          ? '#10b981'
+                          : 'inherit',
+                }}
+              >
+                {CATEGORY_LABELS[cat]}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* In-progress message — only show while actively syncing */}
+      {latestMessage && syncing && (
+        <div className="text-xs text-gray-500 dark:text-gray-400 font-mono animate-pulse">{latestMessage}</div>
+      )}
+    </div>
+  )
+}
+
+function StatusIcon({ status }: { status: CategoryStatus }) {
+  switch (status) {
+    case 'active':
+      return <Loader2 size={12} className="text-amber-500 animate-spin" />
+    case 'success':
+      return <CheckCircle size={12} className="text-emerald-500" />
+    case 'error':
+      return <XCircle size={12} className="text-red-500" />
+    case 'pending':
+      return <div className="w-3 h-3 rounded-full border" style={{ borderColor: 'var(--border)' }} />
+  }
+}

--- a/apps/web/src/lib/brokerage/cdc/cdc-stub.ts
+++ b/apps/web/src/lib/brokerage/cdc/cdc-stub.ts
@@ -1,0 +1,51 @@
+/**
+ * CDC (Crypto.com) stub provider.
+ *
+ * Implements BrokerageProvider to prove the abstraction works across
+ * multiple brokerages. All methods return empty arrays — this is a
+ * placeholder that can be replaced with a real Crypto.com Exchange API
+ * integration later.
+ */
+
+import type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokeragePosition,
+  BrokerageTransaction,
+} from '@lokfi/brokerage-core'
+import type { BrokerageProvider } from '@lokfi/brokerage-core'
+
+const SOURCE = 'cdc'
+
+export class CdcStubProvider implements BrokerageProvider {
+  readonly source = SOURCE
+  readonly displayName = 'Crypto.com'
+
+  async fetchPositions(): Promise<BrokeragePosition[]> {
+    // Real implementation would call CDC Exchange API:
+    // GET /v1/private/get-account-summary
+    return []
+  }
+
+  async fetchTransactions(since: Date): Promise<BrokerageTransaction[]> {
+    // Real implementation: GET /v1/private/get-trades
+    void since // intentionally unused in stub
+    return []
+  }
+
+  async fetchCorpActions(since: Date): Promise<BrokerageCorpAction[]> {
+    // Crypto.com does not have traditional corporate actions
+    void since
+    return []
+  }
+
+  async fetchAccount(): Promise<BrokerageAccount[]> {
+    // Real implementation: GET /v1/private/get-account-summary
+    return []
+  }
+
+  async validateConnection(): Promise<boolean> {
+    // Real implementation would call a lightweight API health check
+    return false
+  }
+}

--- a/apps/web/src/lib/brokerage/cdc/cdc-stub.ts
+++ b/apps/web/src/lib/brokerage/cdc/cdc-stub.ts
@@ -9,11 +9,11 @@
 
 import type {
   BrokerageAccount,
-  BrokerageCorpAction,
+  BrokerageFundDetail,
   BrokeragePosition,
   BrokerageTransaction,
 } from '@lokfi/brokerage-core'
-import type { BrokerageProvider } from '@lokfi/brokerage-core'
+import type { BrokerageProvider, ProviderProgress } from '@lokfi/brokerage-core'
 
 const SOURCE = 'cdc'
 
@@ -21,26 +21,19 @@ export class CdcStubProvider implements BrokerageProvider {
   readonly source = SOURCE
   readonly displayName = 'Crypto.com'
 
-  async fetchPositions(): Promise<BrokeragePosition[]> {
-    // Real implementation would call CDC Exchange API:
-    // GET /v1/private/get-account-summary
+  async fetchPositions(_onProgress?: ProviderProgress): Promise<BrokeragePosition[]> {
     return []
   }
 
-  async fetchTransactions(since: Date): Promise<BrokerageTransaction[]> {
-    // Real implementation: GET /v1/private/get-trades
-    void since // intentionally unused in stub
+  async fetchTransactions(_since: Date, _onProgress?: ProviderProgress): Promise<BrokerageTransaction[]> {
     return []
   }
 
-  async fetchCorpActions(since: Date): Promise<BrokerageCorpAction[]> {
-    // Crypto.com does not have traditional corporate actions
-    void since
+  async fetchFundDetails(_since: Date, _onProgress?: ProviderProgress): Promise<BrokerageFundDetail[]> {
     return []
   }
 
-  async fetchAccount(): Promise<BrokerageAccount[]> {
-    // Real implementation: GET /v1/private/get-account-summary
+  async fetchAccount(_onProgress?: ProviderProgress): Promise<BrokerageAccount[]> {
     return []
   }
 

--- a/apps/web/src/lib/brokerage/credential-manager.ts
+++ b/apps/web/src/lib/brokerage/credential-manager.ts
@@ -1,0 +1,152 @@
+/**
+ * Encrypted credential manager for brokerage API keys.
+ *
+ * Uses Web Crypto API (AES-256-GCM) for encryption and PBKDF2 for key
+ * derivation. Credentials are stored encrypted in Dexie's
+ * `brokerage_credentials` table — plaintext never touches persistent storage.
+ *
+ * Flow:
+ *   1. User provides credentials (e.g. tigerId + privateKey) + passphrase
+ *   2. PBKDF2 derives an AES key from the passphrase + random salt
+ *   3. Credentials JSON is encrypted with AES-GCM (random IV)
+ *   4. Encrypted blob + salt + IV are stored in Dexie
+ *
+ * On sync:
+ *   1. App prompts for passphrase
+ *   2. PBKDF2 re-derives the AES key
+ *   3. Encrypted blob is decrypted
+ *   4. Plaintext credentials are passed to the provider (in-memory only)
+ */
+
+import type { BrokerageCredentials, BrokerageSource } from '@lokfi/brokerage-core'
+
+const ALGORITHM = 'AES-GCM'
+const KEY_LENGTH = 256
+const PBKDF2_ITERATIONS = 600_000
+const PBKDF2_HASH = 'SHA-256'
+
+export class CredentialDecryptError extends Error {
+  constructor() {
+    super('Wrong passphrase or corrupted credentials')
+    this.name = 'CredentialDecryptError'
+  }
+}
+
+export interface CredentialStore {
+  get(source: BrokerageSource): Promise<BrokerageCredentials | undefined>
+  put(record: BrokerageCredentials): Promise<void>
+  delete(source: BrokerageSource): Promise<void>
+}
+
+export class CredentialManager {
+  private credStore: CredentialStore
+
+  constructor(store: CredentialStore) {
+    this.credStore = store
+  }
+
+  /**
+   * Encrypt credentials and persist to the store.
+   *
+   * @param source - Brokerage identifier (e.g. 'tiger')
+   * @param credentials - Plaintext credentials object
+   * @param passphrase - User-supplied passphrase for key derivation
+   */
+  async store(source: BrokerageSource, credentials: Record<string, string>, passphrase: string): Promise<void> {
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const key = await deriveKey(passphrase, salt)
+
+    const iv = crypto.getRandomValues(new Uint8Array(12))
+    const plaintext = new TextEncoder().encode(JSON.stringify(credentials))
+    const ciphertext = await crypto.subtle.encrypt({ name: ALGORITHM, iv }, key, plaintext)
+
+    const record: BrokerageCredentials = {
+      id: source,
+      encryptedData: arrayBufferToBase64(ciphertext),
+      iv: arrayBufferToBase64(iv.buffer),
+      salt: arrayBufferToBase64(salt.buffer),
+    }
+
+    await this.credStore.put(record)
+  }
+
+  /**
+   * Retrieve and decrypt credentials.
+   *
+   * @param source - Brokerage identifier
+   * @param passphrase - User-supplied passphrase
+   * @returns Plaintext credentials, or null if not found or decryption fails
+   */
+  async retrieve(source: BrokerageSource, passphrase: string): Promise<Record<string, string> | null> {
+    const record = await this.credStore.get(source)
+    if (!record) return null
+
+    try {
+      const salt = base64ToArrayBuffer(record.salt)
+      const key = await deriveKey(passphrase, new Uint8Array(salt))
+
+      const iv = new Uint8Array(base64ToArrayBuffer(record.iv))
+      const ciphertext = base64ToArrayBuffer(record.encryptedData)
+
+      const plaintext = await crypto.subtle.decrypt({ name: ALGORITHM, iv }, key, ciphertext)
+      const json = new TextDecoder().decode(plaintext)
+      return JSON.parse(json) as Record<string, string>
+    } catch {
+      // Decryption failure — wrong passphrase or corrupted data
+      throw new CredentialDecryptError()
+    }
+  }
+
+  /**
+   * Check if credentials exist for a given brokerage.
+   */
+  async hasCredentials(source: BrokerageSource): Promise<boolean> {
+    const record = await this.credStore.get(source)
+    return record !== undefined
+  }
+
+  /**
+   * Remove stored credentials.
+   */
+  async remove(source: BrokerageSource): Promise<void> {
+    await this.credStore.delete(source)
+  }
+}
+
+// ── Crypto Helpers ────────────────────────────────────────────────────────
+
+async function deriveKey(passphrase: string, salt: BufferSource): Promise<CryptoKey> {
+  const material = new TextEncoder().encode(passphrase)
+  const baseKey = await crypto.subtle.importKey('raw', material, 'PBKDF2', false, ['deriveKey'])
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: PBKDF2_ITERATIONS,
+      hash: PBKDF2_HASH,
+    },
+    baseKey,
+    { name: ALGORITHM, length: KEY_LENGTH },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!)
+  }
+  return btoa(binary)
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes.buffer
+}

--- a/apps/web/src/lib/brokerage/dexie-credential-store.ts
+++ b/apps/web/src/lib/brokerage/dexie-credential-store.ts
@@ -1,0 +1,27 @@
+/**
+ * Dexie-backed CredentialStore adapter for CredentialManager.
+ */
+
+import type { BrokerageCredentials, BrokerageSource } from '@lokfi/brokerage-core'
+import type { LokfiDatabase } from '../db/db'
+import type { CredentialStore } from './credential-manager'
+
+export class DexieCredentialStore implements CredentialStore {
+  private db: LokfiDatabase
+
+  constructor(db: LokfiDatabase) {
+    this.db = db
+  }
+
+  async get(source: BrokerageSource): Promise<BrokerageCredentials | undefined> {
+    return this.db.brokerageCredentials.get(source)
+  }
+
+  async put(record: BrokerageCredentials): Promise<void> {
+    await this.db.brokerageCredentials.put(record)
+  }
+
+  async delete(source: BrokerageSource): Promise<void> {
+    await this.db.brokerageCredentials.delete(source)
+  }
+}

--- a/apps/web/src/lib/brokerage/dexie-sync-adapter.ts
+++ b/apps/web/src/lib/brokerage/dexie-sync-adapter.ts
@@ -1,0 +1,64 @@
+/**
+ * Dexie-backed SyncDatabase adapter.
+ *
+ * Implements the SyncDatabase interface used by SyncOrchestrator,
+ * translating calls into Dexie table operations on the brokerage_* stores.
+ */
+
+import type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokeragePosition,
+  BrokeragePositionExtension,
+  BrokerageSyncLog,
+  BrokerageTransaction,
+} from '@lokfi/brokerage-core'
+import type { LokfiDatabase } from '../db/db'
+import type { SyncDatabase } from './sync-orchestrator'
+
+export class DexieSyncAdapter implements SyncDatabase {
+  private db: LokfiDatabase
+
+  constructor(db: LokfiDatabase) {
+    this.db = db
+  }
+
+  async upsertPositions(positions: BrokeragePosition[]): Promise<void> {
+    await this.db.brokeragePositions.bulkPut(positions)
+  }
+
+  async upsertPositionExtensions(extensions: BrokeragePositionExtension[]): Promise<void> {
+    if (extensions.length === 0) return
+    // Use composite key (positionId + key) for upsert
+    const tx = this.db.brokeragePositionExtensions
+    for (const ext of extensions) {
+      await tx.put(ext)
+    }
+  }
+
+  async appendTransactions(transactions: BrokerageTransaction[]): Promise<void> {
+    if (transactions.length === 0) return
+    // Use bulkPut with natural ID — if an orderId already exists, it won't
+    // overwrite because the ID is based on orderId which is unique per fill.
+    // New order fills (same orderId but different execution) would need
+    // a separate mechanism — but the SDK's order transactions use unique IDs.
+    await this.db.brokerageTransactions.bulkPut(transactions)
+  }
+
+  async appendCorpActions(actions: BrokerageCorpAction[]): Promise<void> {
+    if (actions.length === 0) return
+    await this.db.brokerageCorpActions.bulkPut(actions)
+  }
+
+  async upsertAccounts(accounts: BrokerageAccount[]): Promise<void> {
+    await this.db.brokerageAccounts.bulkPut(accounts)
+  }
+
+  async insertSyncLog(log: BrokerageSyncLog): Promise<void> {
+    await this.db.brokerageSyncLog.add(log)
+  }
+
+  async getSyncLogs(source: string): Promise<BrokerageSyncLog[]> {
+    return this.db.brokerageSyncLog.where('source').equals(source).toArray()
+  }
+}

--- a/apps/web/src/lib/brokerage/dexie-sync-adapter.ts
+++ b/apps/web/src/lib/brokerage/dexie-sync-adapter.ts
@@ -7,7 +7,7 @@
 
 import type {
   BrokerageAccount,
-  BrokerageCorpAction,
+  BrokerageFundDetail,
   BrokeragePosition,
   BrokeragePositionExtension,
   BrokerageSyncLog,
@@ -24,6 +24,13 @@ export class DexieSyncAdapter implements SyncDatabase {
   }
 
   async upsertPositions(positions: BrokeragePosition[]): Promise<void> {
+    if (positions.length === 0) return
+    const source = positions[0].source
+    // Clear old positions for this source first so orphaned records from
+    // previous ID formats (e.g. old `${symbol}_${source}` without secType)
+    // don't linger alongside the new `${symbol}_${secType}_${source}` keys.
+    // Note: source is not indexed on brokeragePositions, so use filter() instead of where()
+    await this.db.brokeragePositions.filter((p) => p.source === source).delete()
     await this.db.brokeragePositions.bulkPut(positions)
   }
 
@@ -45,9 +52,9 @@ export class DexieSyncAdapter implements SyncDatabase {
     await this.db.brokerageTransactions.bulkPut(transactions)
   }
 
-  async appendCorpActions(actions: BrokerageCorpAction[]): Promise<void> {
+  async appendFundDetails(actions: BrokerageFundDetail[]): Promise<void> {
     if (actions.length === 0) return
-    await this.db.brokerageCorpActions.bulkPut(actions)
+    await this.db.brokerageFundDetails.bulkPut(actions)
   }
 
   async upsertAccounts(accounts: BrokerageAccount[]): Promise<void> {

--- a/apps/web/src/lib/brokerage/index.ts
+++ b/apps/web/src/lib/brokerage/index.ts
@@ -22,7 +22,7 @@ export type {
   TigerOrder,
   TigerOrderTransaction,
   TigerAsset,
-  TigerCorpAction,
+  TigerFundDetail,
   TigerApiRequest,
   TigerApiResponse,
   TigerMarket,
@@ -35,7 +35,7 @@ export { CredentialManager } from './credential-manager'
 export type { CredentialStore } from './credential-manager'
 
 export { SyncOrchestrator } from './sync-orchestrator'
-export type { SyncOrchestratorOptions, SyncDatabase } from './sync-orchestrator'
+export type { SyncOrchestratorOptions, SyncDatabase, SyncProgress } from './sync-orchestrator'
 
 export { DexieSyncAdapter } from './dexie-sync-adapter'
 export { DexieCredentialStore } from './dexie-credential-store'

--- a/apps/web/src/lib/brokerage/index.ts
+++ b/apps/web/src/lib/brokerage/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Brokerage module barrel export.
+ *
+ * Public API for the brokerage data pipeline:
+ *   - SyncOrchestrator: coordinates multi-category sync with retry + throttle
+ *   - TigerProvider: Tiger Brokers OpenAPI integration
+ *   - CdcStubProvider: Crypto.com stub provider
+ *   - CredentialManager: encrypted credential storage
+ *   - DexieSyncAdapter, DexieCredentialStore: Dexie-backed adapters
+ */
+
+export { TigerProvider } from './tiger/tiger-provider'
+export type { TigerProviderOptions } from './tiger/tiger-provider'
+
+export { CdcStubProvider } from './cdc/cdc-stub'
+
+export { TigerHttpClient, TigerHttpError, TigerAuthError } from './tiger/tiger-http-client'
+
+export type { TigerClientConfig } from './tiger/tiger-types'
+export type {
+  TigerPosition,
+  TigerOrder,
+  TigerOrderTransaction,
+  TigerAsset,
+  TigerCorpAction,
+  TigerApiRequest,
+  TigerApiResponse,
+  TigerMarket,
+  TigerSecType,
+  TigerCurrency,
+  TigerOrderStatus,
+} from './tiger/tiger-types'
+
+export { CredentialManager } from './credential-manager'
+export type { CredentialStore } from './credential-manager'
+
+export { SyncOrchestrator } from './sync-orchestrator'
+export type { SyncOrchestratorOptions, SyncDatabase } from './sync-orchestrator'
+
+export { DexieSyncAdapter } from './dexie-sync-adapter'
+export { DexieCredentialStore } from './dexie-credential-store'

--- a/apps/web/src/lib/brokerage/sync-orchestrator.test.ts
+++ b/apps/web/src/lib/brokerage/sync-orchestrator.test.ts
@@ -1,0 +1,272 @@
+import type {
+  BrokeragePosition,
+  BrokerageProvider,
+  BrokerageSyncLog,
+  BrokerageTransaction,
+} from '@lokfi/brokerage-core'
+import { describe, expect, it, vi } from 'vitest'
+import { type SyncDatabase, SyncOrchestrator } from './sync-orchestrator'
+
+// ── Mock Provider ─────────────────────────────────────────────────────────────
+
+function createMockProvider(overrides?: Partial<BrokerageProvider>): BrokerageProvider {
+  return {
+    source: 'mock',
+    displayName: 'Mock Broker',
+    fetchPositions: vi.fn().mockResolvedValue([]),
+    fetchTransactions: vi.fn().mockResolvedValue([]),
+    fetchCorpActions: vi.fn().mockResolvedValue([]),
+    fetchAccount: vi.fn().mockResolvedValue([]),
+    validateConnection: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  }
+}
+
+// ── Mock SyncDatabase ─────────────────────────────────────────────────────────
+
+function createMockDatabase(): SyncDatabase {
+  const logs: BrokerageSyncLog[] = []
+  return {
+    upsertPositions: vi.fn().mockResolvedValue(undefined),
+    upsertPositionExtensions: vi.fn().mockResolvedValue(undefined),
+    appendTransactions: vi.fn().mockResolvedValue(undefined),
+    appendCorpActions: vi.fn().mockResolvedValue(undefined),
+    upsertAccounts: vi.fn().mockResolvedValue(undefined),
+    insertSyncLog: vi.fn().mockImplementation((log: BrokerageSyncLog) => {
+      logs.push(log)
+      return Promise.resolve()
+    }),
+    getSyncLogs: vi.fn().mockImplementation(() => Promise.resolve([...logs])),
+  }
+}
+
+// ── Test Data ─────────────────────────────────────────────────────────────────
+
+const mockPosition: BrokeragePosition = {
+  id: 'AAPL_mock',
+  source: 'mock',
+  symbol: 'AAPL',
+  currency: 'USD',
+  quantity: 100,
+  avgCost: 150,
+  updatedAt: '2025-01-01T00:00:00.000Z',
+}
+
+const mockTransaction: BrokerageTransaction = {
+  id: 'mock_123',
+  source: 'mock',
+  orderId: '123',
+  symbol: 'AAPL',
+  action: 'BUY',
+  quantity: 100,
+  price: 150,
+  currency: 'USD',
+  executedAt: '2025-01-01T10:00:00.000Z',
+}
+
+describe('SyncOrchestrator', () => {
+  describe('sync() defaults', () => {
+    it('sync() defaults to all 4 categories', async () => {
+      const provider = createMockProvider()
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      await orchestrator.sync()
+
+      // All four categories should have been attempted
+      const logCalls = vi.mocked(db.insertSyncLog).mock.calls
+      const categories = logCalls.map((call) => (call[0] as BrokerageSyncLog).category)
+
+      expect(categories).toContain('positions')
+      expect(categories).toContain('transactions')
+      expect(categories).toContain('corp_actions')
+      expect(categories).toContain('account')
+    })
+  })
+
+  describe('sync() with specific categories', () => {
+    it('sync() with specific categories only syncs those', async () => {
+      const provider = createMockProvider({
+        fetchPositions: vi.fn().mockResolvedValue([mockPosition]),
+      })
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      await orchestrator.sync(['positions'])
+
+      const logCalls = vi.mocked(db.insertSyncLog).mock.calls
+      const categories = logCalls.map((call) => (call[0] as BrokerageSyncLog).category)
+
+      expect(categories).toContain('positions')
+      expect(categories).not.toContain('transactions')
+      expect(categories).not.toContain('corp_actions')
+      expect(categories).not.toContain('account')
+    })
+  })
+
+  describe('sync() fetches and persists data', () => {
+    it('sync() fetches positions and upserts them', async () => {
+      const provider = createMockProvider({
+        fetchPositions: vi.fn().mockResolvedValue([mockPosition]),
+      })
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      await orchestrator.sync(['positions'])
+
+      expect(provider.fetchPositions).toHaveBeenCalled()
+      expect(db.upsertPositions).toHaveBeenCalledWith([mockPosition])
+    })
+  })
+
+  describe('sync() logging', () => {
+    it('sync() logs success on completion', async () => {
+      const provider = createMockProvider({
+        fetchPositions: vi.fn().mockResolvedValue([mockPosition]),
+      })
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      await orchestrator.sync(['positions'])
+
+      const logCalls = vi.mocked(db.insertSyncLog).mock.calls
+      const successLogs = logCalls.filter((call) => (call[0] as BrokerageSyncLog).status === 'success')
+
+      expect(successLogs.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('sync() error isolation', () => {
+    it('sync() isolates errors — if positions succeed but transactions fail, positions still get upserted', async () => {
+      const provider = createMockProvider({
+        fetchPositions: vi.fn().mockResolvedValue([mockPosition]),
+        fetchTransactions: vi.fn().mockRejectedValue(new Error('Network error')),
+      })
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      // Should not throw
+      await orchestrator.sync(['positions', 'transactions'])
+
+      // Positions should have been upserted despite transaction failure
+      expect(db.upsertPositions).toHaveBeenCalledWith([mockPosition])
+    })
+
+    it('sync() logs failure for failed categories', async () => {
+      const provider = createMockProvider({
+        fetchTransactions: vi.fn().mockRejectedValue(new Error('Network error')),
+      })
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      await orchestrator.sync(['transactions'])
+
+      const logCalls = vi.mocked(db.insertSyncLog).mock.calls
+      const failureLogs = logCalls.filter((call) => (call[0] as BrokerageSyncLog).status === 'failure')
+
+      expect(failureLogs.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('sync() retry', () => {
+    it('sync() retries failed requests once', async () => {
+      let attempts = 0
+      const provider = createMockProvider({
+        fetchPositions: vi.fn().mockImplementation(() => {
+          attempts++
+          if (attempts === 1) {
+            return Promise.reject(new Error('Transient error'))
+          }
+          return Promise.resolve([mockPosition])
+        }),
+      })
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      await orchestrator.sync(['positions'])
+
+      expect(provider.fetchPositions).toHaveBeenCalledTimes(2)
+      expect(db.upsertPositions).toHaveBeenCalledWith([mockPosition])
+    })
+
+    it('sync() retries with delay when using fake timers', async () => {
+      vi.useFakeTimers()
+      try {
+        let attempts = 0
+        const provider = createMockProvider({
+          fetchPositions: vi.fn().mockImplementation(() => {
+            attempts++
+            if (attempts === 1) {
+              // Advance time to pass the throttle before rejecting
+              vi.advanceTimersByTime(1100)
+              return Promise.reject(new Error('Transient error'))
+            }
+            return Promise.resolve([mockPosition])
+          }),
+        })
+        // Reset Date.now for consistent throttle behavior
+        vi.setSystemTime(0)
+        const db = createMockDatabase()
+        const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+        const syncPromise = orchestrator.sync(['positions'])
+
+        // Advance past throttle + retry delay
+        await vi.advanceTimersByTimeAsync(5000)
+
+        await syncPromise
+
+        expect(provider.fetchPositions).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  describe('getSyncStatus()', () => {
+    it('getSyncStatus() returns null for never-synced categories', async () => {
+      const provider = createMockProvider()
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      const status = await orchestrator.getSyncStatus()
+
+      expect(status.positions.lastSyncAt).toBeNull()
+      expect(status.positions.status).toBeNull()
+      expect(status.transactions.lastSyncAt).toBeNull()
+      expect(status.transactions.status).toBeNull()
+    })
+
+    it('getSyncStatus() returns last sync timestamps and status', async () => {
+      const provider = createMockProvider({
+        fetchPositions: vi.fn().mockResolvedValue([mockPosition]),
+      })
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      await orchestrator.sync(['positions'])
+
+      const status = await orchestrator.getSyncStatus()
+
+      expect(status.positions.lastSyncAt).not.toBeNull()
+      expect(status.positions.status).toBe('success')
+    })
+  })
+
+  describe('sync() throttling', () => {
+    it('sync() makes requests sequentially for same category (throttling)', async () => {
+      const provider = createMockProvider({
+        fetchPositions: vi.fn().mockResolvedValue([mockPosition]),
+        fetchTransactions: vi.fn().mockResolvedValue([mockTransaction]),
+      })
+      const db = createMockDatabase()
+      const orchestrator = new SyncOrchestrator({ provider, database: db })
+
+      await orchestrator.sync(['positions', 'transactions'])
+
+      // Both calls should have been made (order varies due to sequential execution)
+      expect(provider.fetchPositions).toHaveBeenCalled()
+      expect(provider.fetchTransactions).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/web/src/lib/brokerage/sync-orchestrator.test.ts
+++ b/apps/web/src/lib/brokerage/sync-orchestrator.test.ts
@@ -15,7 +15,7 @@ function createMockProvider(overrides?: Partial<BrokerageProvider>): BrokeragePr
     displayName: 'Mock Broker',
     fetchPositions: vi.fn().mockResolvedValue([]),
     fetchTransactions: vi.fn().mockResolvedValue([]),
-    fetchCorpActions: vi.fn().mockResolvedValue([]),
+    fetchFundDetails: vi.fn().mockResolvedValue([]),
     fetchAccount: vi.fn().mockResolvedValue([]),
     validateConnection: vi.fn().mockResolvedValue(true),
     ...overrides,
@@ -30,7 +30,7 @@ function createMockDatabase(): SyncDatabase {
     upsertPositions: vi.fn().mockResolvedValue(undefined),
     upsertPositionExtensions: vi.fn().mockResolvedValue(undefined),
     appendTransactions: vi.fn().mockResolvedValue(undefined),
-    appendCorpActions: vi.fn().mockResolvedValue(undefined),
+    appendFundDetails: vi.fn().mockResolvedValue(undefined),
     upsertAccounts: vi.fn().mockResolvedValue(undefined),
     insertSyncLog: vi.fn().mockImplementation((log: BrokerageSyncLog) => {
       logs.push(log)
@@ -79,7 +79,7 @@ describe('SyncOrchestrator', () => {
 
       expect(categories).toContain('positions')
       expect(categories).toContain('transactions')
-      expect(categories).toContain('corp_actions')
+      expect(categories).toContain('fund_details')
       expect(categories).toContain('account')
     })
   })
@@ -99,7 +99,7 @@ describe('SyncOrchestrator', () => {
 
       expect(categories).toContain('positions')
       expect(categories).not.toContain('transactions')
-      expect(categories).not.toContain('corp_actions')
+      expect(categories).not.toContain('fund_details')
       expect(categories).not.toContain('account')
     })
   })

--- a/apps/web/src/lib/brokerage/sync-orchestrator.ts
+++ b/apps/web/src/lib/brokerage/sync-orchestrator.ts
@@ -1,0 +1,240 @@
+/**
+ * SyncOrchestrator — coordinates brokerage data sync with:
+ *   - Per-category error isolation
+ *   - Rate-limit-aware throttling (per API tier)
+ *   - Retry with exponential backoff
+ *   - Sync audit log (sync_log)
+ *   - Staleness detection via getSyncStatus()
+ */
+
+import type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokeragePosition,
+  BrokeragePositionExtension,
+  BrokerageSyncLog,
+  BrokerageTransaction,
+  SyncCategory,
+  SyncStatus,
+} from '@lokfi/brokerage-core'
+import type { BrokerageProvider } from '@lokfi/brokerage-core'
+
+/** Database interface — abstracts Dexie for testability */
+export interface SyncDatabase {
+  /** Upsert positions (natural key: id) */
+  upsertPositions(positions: BrokeragePosition[]): Promise<void>
+  /** Upsert position extensions */
+  upsertPositionExtensions(extensions: BrokeragePositionExtension[]): Promise<void>
+  /** Append transactions (never overwrite) */
+  appendTransactions(transactions: BrokerageTransaction[]): Promise<void>
+  /** Append corporate actions (never overwrite) */
+  appendCorpActions(actions: BrokerageCorpAction[]): Promise<void>
+  /** Replace account records (one per source+currency) */
+  upsertAccounts(accounts: BrokerageAccount[]): Promise<void>
+  /** Insert sync log entry (auto-increment id) */
+  insertSyncLog(log: BrokerageSyncLog): Promise<void>
+  /** Query sync logs for staleness */
+  getSyncLogs(source: string): Promise<BrokerageSyncLog[]>
+}
+
+/** Rate limit tiers matching Tiger OpenAPI documentation */
+const RATE_LIMITS: Record<string, number> = {
+  positions: 1100, // Medium tier: 60/min → ~1.1s between requests
+  transactions: 600, // High tier: 120/min → 600ms (used more aggressively)
+  account: 1100, // Medium tier
+  corp_actions: 1100, // Medium tier
+}
+
+/**
+ * Maximum number of retries per API call (1 retry = 2 total attempts per the spec).
+ */
+const MAX_RETRIES = 1
+
+/**
+ * Base delay for exponential backoff (ms).
+ */
+const BASE_BACKOFF_MS = 1000
+
+export interface SyncOrchestratorOptions {
+  provider: BrokerageProvider
+  database: SyncDatabase
+  /** Transaction/corp action lookback window (days). Default: 90 */
+  lookbackDays?: number
+}
+
+export class SyncOrchestrator {
+  private provider: BrokerageProvider
+  private db: SyncDatabase
+  private lookbackDays: number
+
+  // Track the last request timestamp per category for basic rate limiting
+  private lastRequestTime: Map<SyncCategory, number> = new Map()
+
+  constructor(options: SyncOrchestratorOptions) {
+    this.provider = options.provider
+    this.db = options.database
+    this.lookbackDays = options.lookbackDays ?? 90
+  }
+
+  /**
+   * Sync all categories (or specified subset).
+   * Categories fail independently — if one fails, others continue.
+   */
+  async sync(categories?: SyncCategory[]): Promise<void> {
+    const toSync = categories ?? (['positions', 'transactions', 'corp_actions', 'account'] as SyncCategory[])
+    const since = new Date()
+    since.setDate(since.getDate() - this.lookbackDays)
+
+    // Execute categories sequentially to respect rate limits.
+    // Each category is independently wrapped in error isolation.
+    for (const category of toSync) {
+      try {
+        await this.syncCategory(category, since)
+      } catch (err) {
+        // Error already logged in syncCategory. Continue to next category.
+        console.error(`[SyncOrchestrator] Category "${category}" failed, continuing:`, err)
+      }
+    }
+  }
+
+  /**
+   * Get staleness report per category.
+   * Returns the last sync time and status for each category.
+   */
+  async getSyncStatus(): Promise<Record<SyncCategory, { lastSyncAt: string | null; status: SyncStatus | null }>> {
+    const logs = await this.db.getSyncLogs(this.provider.source)
+    const result: Record<SyncCategory, { lastSyncAt: string | null; status: SyncStatus | null }> = {
+      positions: { lastSyncAt: null, status: null },
+      transactions: { lastSyncAt: null, status: null },
+      corp_actions: { lastSyncAt: null, status: null },
+      account: { lastSyncAt: null, status: null },
+    }
+
+    for (const log of logs) {
+      if (log.category in result) {
+        result[log.category] = {
+          lastSyncAt: log.lastSyncAt,
+          status: log.status,
+        }
+      }
+    }
+
+    return result
+  }
+
+  // ── Private ────────────────────────────────────────────────────────────
+
+  private async syncCategory(category: SyncCategory, since: Date): Promise<void> {
+    // Log start
+    const logEntry: BrokerageSyncLog = {
+      source: this.provider.source,
+      category,
+      status: 'in_progress',
+      lastSyncAt: new Date().toISOString(),
+    }
+    await this.db.insertSyncLog(logEntry)
+
+    try {
+      // Throttle
+      await this.throttle(category)
+
+      switch (category) {
+        case 'positions':
+          await this.syncPositionsWithRetry()
+          break
+        case 'transactions':
+          await this.syncTransactionsWithRetry(since)
+          break
+        case 'corp_actions':
+          await this.syncCorpActionsWithRetry(since)
+          break
+        case 'account':
+          await this.syncAccountWithRetry()
+          break
+      }
+
+      // Log success
+      await this.db.insertSyncLog({
+        source: this.provider.source,
+        category,
+        status: 'success',
+        lastSyncAt: new Date().toISOString(),
+      })
+    } catch (err) {
+      // Log failure
+      const message = err instanceof Error ? err.message : String(err)
+      await this.db.insertSyncLog({
+        source: this.provider.source,
+        category,
+        status: 'failure',
+        lastSyncAt: new Date().toISOString(),
+        errorMessage: message,
+      })
+      throw err // Re-throw so outer loop can continue
+    }
+  }
+
+  // ── Category sync methods with retry ────────────────────────────────────
+
+  private async syncPositionsWithRetry(): Promise<void> {
+    await this.withRetry(async () => {
+      const positions = await this.provider.fetchPositions()
+      await this.db.upsertPositions(positions)
+    })
+  }
+
+  private async syncTransactionsWithRetry(since: Date): Promise<void> {
+    await this.withRetry(async () => {
+      const transactions = await this.provider.fetchTransactions(since)
+      if (transactions.length > 0) {
+        await this.db.appendTransactions(transactions)
+      }
+    })
+  }
+
+  private async syncCorpActionsWithRetry(since: Date): Promise<void> {
+    await this.withRetry(async () => {
+      const actions = await this.provider.fetchCorpActions(since)
+      if (actions.length > 0) {
+        await this.db.appendCorpActions(actions)
+      }
+    })
+  }
+
+  private async syncAccountWithRetry(): Promise<void> {
+    await this.withRetry(async () => {
+      const accounts = await this.provider.fetchAccount()
+      await this.db.upsertAccounts(accounts)
+    })
+  }
+
+  // ── Retry with exponential backoff ──────────────────────────────────────
+
+  private async withRetry(fn: () => Promise<void>): Promise<void> {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        await fn()
+        return
+      } catch (err) {
+        if (attempt === MAX_RETRIES) throw err
+        const delay = BASE_BACKOFF_MS * 2 ** attempt
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+  }
+
+  // ── Rate limiting ──────────────────────────────────────────────────────
+
+  private async throttle(category: SyncCategory): Promise<void> {
+    const minInterval = RATE_LIMITS[category] ?? 1000
+    const lastTime = this.lastRequestTime.get(category) ?? 0
+    const elapsed = Date.now() - lastTime
+    const remaining = minInterval - elapsed
+
+    if (remaining > 0) {
+      await new Promise((resolve) => setTimeout(resolve, remaining))
+    }
+
+    this.lastRequestTime.set(category, Date.now())
+  }
+}

--- a/apps/web/src/lib/brokerage/sync-orchestrator.ts
+++ b/apps/web/src/lib/brokerage/sync-orchestrator.ts
@@ -9,7 +9,7 @@
 
 import type {
   BrokerageAccount,
-  BrokerageCorpAction,
+  BrokerageFundDetail,
   BrokeragePosition,
   BrokeragePositionExtension,
   BrokerageSyncLog,
@@ -27,8 +27,8 @@ export interface SyncDatabase {
   upsertPositionExtensions(extensions: BrokeragePositionExtension[]): Promise<void>
   /** Append transactions (never overwrite) */
   appendTransactions(transactions: BrokerageTransaction[]): Promise<void>
-  /** Append corporate actions (never overwrite) */
-  appendCorpActions(actions: BrokerageCorpAction[]): Promise<void>
+  /** Append fund details (never overwrite) */
+  appendFundDetails(actions: BrokerageFundDetail[]): Promise<void>
   /** Replace account records (one per source+currency) */
   upsertAccounts(accounts: BrokerageAccount[]): Promise<void>
   /** Insert sync log entry (auto-increment id) */
@@ -40,9 +40,9 @@ export interface SyncDatabase {
 /** Rate limit tiers matching Tiger OpenAPI documentation */
 const RATE_LIMITS: Record<string, number> = {
   positions: 1100, // Medium tier: 60/min → ~1.1s between requests
-  transactions: 600, // High tier: 120/min → 600ms (used more aggressively)
-  account: 1100, // Medium tier
-  corp_actions: 1100, // Medium tier
+  transactions: 600, // High tier: 120/min → 600ms
+  account: 1100, // Medium tier: 60/min → ~1.1s
+  fund_details: 6100, // Low tier: 10/min → 6.1s between requests
 }
 
 /**
@@ -55,17 +55,52 @@ const MAX_RETRIES = 1
  */
 const BASE_BACKOFF_MS = 1000
 
+/**
+ * Create a progress callback that forwards provider-level messages
+ * to the orchestrator's onProgress callback.
+ */
+function makeProgress(
+  onProgress: ((progress: SyncProgress) => void) | undefined,
+  category: SyncCategory
+): (message: string) => void {
+  return (message: string) => {
+    onProgress?.({
+      category,
+      completed: 0,
+      total: 0,
+      completedAt: new Date().toISOString(),
+      message,
+    })
+  }
+}
+
 export interface SyncOrchestratorOptions {
   provider: BrokerageProvider
   database: SyncDatabase
   /** Transaction/corp action lookback window (days). Default: 90 */
   lookbackDays?: number
+  /** Called after each category completes with progress info */
+  onProgress?: (progress: SyncProgress) => void
+}
+
+/** Progress event emitted by the orchestrator during sync */
+export interface SyncProgress {
+  category: SyncCategory
+  completed: number
+  total: number
+  /** ISO timestamp when this event was emitted */
+  completedAt: string
+  /** Error message if this category failed, undefined on success */
+  error?: string
+  /** Sub-category progress message (e.g. pagination status) */
+  message?: string
 }
 
 export class SyncOrchestrator {
   private provider: BrokerageProvider
   private db: SyncDatabase
   private lookbackDays: number
+  private onProgress?: (progress: SyncProgress) => void
 
   // Track the last request timestamp per category for basic rate limiting
   private lastRequestTime: Map<SyncCategory, number> = new Map()
@@ -74,6 +109,7 @@ export class SyncOrchestrator {
     this.provider = options.provider
     this.db = options.database
     this.lookbackDays = options.lookbackDays ?? 90
+    this.onProgress = options.onProgress
   }
 
   /**
@@ -81,18 +117,41 @@ export class SyncOrchestrator {
    * Categories fail independently — if one fails, others continue.
    */
   async sync(categories?: SyncCategory[]): Promise<void> {
-    const toSync = categories ?? (['positions', 'transactions', 'corp_actions', 'account'] as SyncCategory[])
+    const toSync = categories ?? (['positions', 'transactions', 'fund_details', 'account'] as SyncCategory[])
     const since = new Date()
     since.setDate(since.getDate() - this.lookbackDays)
+
+    let completed = 0
+    const total = toSync.length
 
     // Execute categories sequentially to respect rate limits.
     // Each category is independently wrapped in error isolation.
     for (const category of toSync) {
+      let error: string | undefined
+
+      // Emit start-of-category progress
+      this.onProgress?.({
+        category,
+        completed,
+        total,
+        completedAt: new Date().toISOString(),
+      })
+
       try {
         await this.syncCategory(category, since)
       } catch (err) {
         // Error already logged in syncCategory. Continue to next category.
         console.error(`[SyncOrchestrator] Category "${category}" failed, continuing:`, err)
+        error = err instanceof Error ? err.message : String(err)
+      } finally {
+        completed++
+        this.onProgress?.({
+          category,
+          completed,
+          total,
+          completedAt: new Date().toISOString(),
+          error,
+        })
       }
     }
   }
@@ -106,7 +165,7 @@ export class SyncOrchestrator {
     const result: Record<SyncCategory, { lastSyncAt: string | null; status: SyncStatus | null }> = {
       positions: { lastSyncAt: null, status: null },
       transactions: { lastSyncAt: null, status: null },
-      corp_actions: { lastSyncAt: null, status: null },
+      fund_details: { lastSyncAt: null, status: null },
       account: { lastSyncAt: null, status: null },
     }
 
@@ -145,8 +204,8 @@ export class SyncOrchestrator {
         case 'transactions':
           await this.syncTransactionsWithRetry(since)
           break
-        case 'corp_actions':
-          await this.syncCorpActionsWithRetry(since)
+        case 'fund_details':
+          await this.syncFundDetailsWithRetry(since)
           break
         case 'account':
           await this.syncAccountWithRetry()
@@ -178,32 +237,32 @@ export class SyncOrchestrator {
 
   private async syncPositionsWithRetry(): Promise<void> {
     await this.withRetry(async () => {
-      const positions = await this.provider.fetchPositions()
+      const positions = await this.provider.fetchPositions(makeProgress(this.onProgress, 'positions'))
       await this.db.upsertPositions(positions)
     })
   }
 
   private async syncTransactionsWithRetry(since: Date): Promise<void> {
     await this.withRetry(async () => {
-      const transactions = await this.provider.fetchTransactions(since)
+      const transactions = await this.provider.fetchTransactions(since, makeProgress(this.onProgress, 'transactions'))
       if (transactions.length > 0) {
         await this.db.appendTransactions(transactions)
       }
     })
   }
 
-  private async syncCorpActionsWithRetry(since: Date): Promise<void> {
+  private async syncFundDetailsWithRetry(since: Date): Promise<void> {
     await this.withRetry(async () => {
-      const actions = await this.provider.fetchCorpActions(since)
-      if (actions.length > 0) {
-        await this.db.appendCorpActions(actions)
+      const fundDetails = await this.provider.fetchFundDetails(since, makeProgress(this.onProgress, 'fund_details'))
+      if (fundDetails.length > 0) {
+        await this.db.appendFundDetails(fundDetails)
       }
     })
   }
 
   private async syncAccountWithRetry(): Promise<void> {
     await this.withRetry(async () => {
-      const accounts = await this.provider.fetchAccount()
+      const accounts = await this.provider.fetchAccount(makeProgress(this.onProgress, 'account'))
       await this.db.upsertAccounts(accounts)
     })
   }

--- a/apps/web/src/lib/brokerage/tiger/README.md
+++ b/apps/web/src/lib/brokerage/tiger/README.md
@@ -1,0 +1,223 @@
+# Tiger Brokers OpenAPI — Setup for Lokfi
+
+This document covers how to configure Tiger Brokers market data access for the Lokfi portfolio sync pipeline.
+
+## Prerequisites
+
+1. **Tiger Brokers account** — a funded trading account with Tiger Brokers (SG, HK, US, NZ, or AU license).
+2. **OpenAPI access activated** — visit [developer.tigerbrokers.com.sg](https://developer.tigerbrokers.com.sg) (or the equivalent for your region: `developer.tigerbrokers.com`, `developer.itigerup.com`). Go to **Developer Center → My Apps** and create an application to receive your `tiger_id`.
+
+## Step 1 — Generate an RSA Key Pair
+
+The Tiger OpenAPI uses RSA signature authentication. You need a 2048-bit RSA key pair.
+
+```bash
+# Generate a 2048-bit RSA private key
+openssl genrsa -out tiger_private.pem 2048
+
+# Extract the public key
+openssl rsa -in tiger_private.pem -pubout -out tiger_public.pem
+```
+
+**Important:** Lokfi requires the private key in **PKCS8** format. If you generated a PKCS1 key (header says `BEGIN RSA PRIVATE KEY`), convert it:
+
+```bash
+openssl pkcs8 -topk8 -inform PEM -outform PEM -in tiger_private.pem -out tiger_private_pkcs8.pem -nocrypt
+```
+
+## Step 2 — Upload Public Key
+
+In the Tiger Developer Center, go to your app and upload the **public key** (`tiger_public.pem`). Tiger will use this to verify your API request signatures.
+
+## Step 3 — Configure Lokfi
+
+The Tiger provider expects three pieces of configuration:
+
+| Field | Description | Example |
+|---|---|---|
+| `tigerId` | Your developer ID from the Tiger Developer Center | `12345` |
+| `privateKey` | RSA private key in PKCS8 PEM format | `-----BEGIN PRIVATE KEY-----\n...` |
+| `account` | Your Tiger trading account number | `U1234567` |
+| `serverUrl` | (Optional) API base URL | `https://openapi.tigerfintech.com` (default) |
+
+These credentials are encrypted with a user-supplied passphrase using Web Crypto (AES-256-GCM + PBKDF2) and stored in IndexedDB. They **never** appear in plaintext in any persistent store.
+
+## API Activation
+
+**OpenAPI access is free** — no additional subscription needed. After your Tiger account is opened and funded:
+
+1. Visit [developer.tigerbrokers.com.sg](https://developer.tigerbrokers.com.sg)
+2. Go to **Developer Center → My Apps** → create an application → upload your RSA public key
+3. API access is activated immediately — no endpoint-specific permissions required
+
+The `fund_details` (corporate actions) endpoint is included in standard OpenAPI access. No separate activation needed.
+
+## API Endpoints Used (Read-Only)
+
+All endpoints are accessed via `POST https://openapi.tigerfintech.com/gateway` with JSON body and RSA-signed authentication.
+
+| Data | Tiger API Method | Key Parameters |
+|---|---|---|
+| Positions | `positions` | `account` (in bizContent) |
+| Orders (filled) | `filled_orders` | `account`, `start_date`, `end_date` (yyyy-MM-dd) |
+| Order transactions | `order_transactions` | `account`, `id` (orderId) |
+| Account assets | `assets` | `account` |
+| Prime assets | `prime_assets` | `account` |
+| Corporate actions | `fund_details` | `account`, `fund_type: "CORPORATE_ACTION"`, `seg_types: ["SEC"]`, `start_date`, `end_date` |
+
+## Rate Limits
+
+Tiger enforces per-method tiered rate limits on a 60-second rolling window:
+
+| Tier | Limit | Methods |
+|---|---|---|
+| High | 120 req/min | Order queries, trading |
+| **Medium** | **60 req/min** | **Positions, assets, fund details** |
+| Low | 10 req/min | Market status, symbol info |
+
+Lokfi's sync orchestrator implements tier-aware throttling:
+- **Medium-tier** (positions, assets, corp actions): 1100ms between requests
+- **High-tier** (orders, transactions): 600ms between requests
+
+Exceeding limits persistently may result in your `tiger_id` being blacklisted automatically. Contact Tiger support for higher limits.
+
+## Corporate Actions
+
+### What's Available
+
+Tiger's standard OpenAPI provides account-level corporate action history via the `fund_details` endpoint. Each record includes:
+
+- `amount` — value of the action (dividend payout, etc.)
+- `currency` — USD, SGD, HKD, etc.
+- `desc` — description (e.g. "XDTE-DIVIDEND", "MSTY-DIVIDEND")
+- `businessDate` — Tiger-defined business date when the action was applied
+- `segType` — `SEC` (securities) or `FUT` (futures)
+- `type` — fund type label
+
+**Correct parameter format** (based on Tiger's official Python/Java SDK docs):
+
+```json
+{
+  "fund_type": "CORPORATE_ACTION",
+  "seg_types": ["SEC"],
+  "start_date": "2026-02-01",
+  "end_date": "2026-05-01",
+  "limit": 100
+}
+```
+
+Key: `seg_types` is an **array of strings** using Tiger's enum values `SEC`/`FUT` (not `S`/`C`), and `fund_type` is the **string** `"CORPORATE_ACTION"` (not the integer `7`).
+
+### What's NOT Available via Standard API
+
+The standard API provides fund-change records (dividend receipts, fee debits) but does **not** include structured metadata like ex-date, pay-date, or symbol-level corporate action details. This structured data is available through the **Enterprise API** (`GET /corp-actions`) but that endpoint requires OAuth2 token authentication — a separate authorization tier.
+
+The Tiger provider maps `fund_details` records to normalized `BrokerageCorpAction` entries with best-effort type classification (dividend/split/rights/other) based on the description text. For detailed corporate action tracking, upgrading to the Enterprise API tier would be needed.
+
+## Market/Account Segmentation
+
+Tiger returns account data segmented by:
+
+- **Currency** — USD, HKD, SGD, CNH (one record per currency)
+- **Segment** — `S` (Securities/Stocks) and `C` (Commodities/Futures)
+
+Lokfi stores these as separate `BrokerageAccount` records with `segType` field, enabling per-segment balance queries.
+
+## Verification (Quick Test)
+
+Run the verification script to confirm your credentials work and pull real data:
+
+**PowerShell:**
+```powershell
+$env:TIGER_ID="your_developer_id"
+$env:TIGER_PRIVATE_KEY="C:\Users\you\.ssh\tiger_private_pkcs8.pem"
+$env:TIGER_ACCOUNT="U1234567"
+pnpm --filter @lokfi/web test-tiger
+```
+
+**Bash/Linux:**
+```bash
+export TIGER_ID=your_developer_id
+export TIGER_PRIVATE_KEY="$(cat ~/.ssh/tiger_private_pkcs8.pem)"
+export TIGER_ACCOUNT=U1234567
+pnpm --filter @lokfi/web test-tiger
+```
+
+The script will:
+1. **Connection check** — authenticates with the API via the `assets` endpoint
+2. **Positions** — displays all current holdings with P&L breakdown
+3. **Account summary** — cash balance, net liquidation by currency segment
+4. **Recent orders** — last 30 days of filled orders
+5. **Corporate actions** — last 90 days of dividends/splits
+
+### What success looks like
+
+```
+Tiger OpenAPI — Connection Verification
+
+─── 1. Connection Check ──────────────────────────────────────
+✓ Authenticated successfully — received 2 asset record(s)
+
+─── 2. Positions ─────────────────────────────────────────────
+✓ Fetched 5 position(s)
+
+  Symbol           Qty     AvgCost        MktVal         P&L     P&L%  Currency
+  ─────────────────────────────────────────────────────────────────
+  AAPL              100     $150.00     $17,500.00   +$2,500.00  +16.67%  USD
+  TSLA               50     $220.00     $10,000.00    -$1,000.00  -9.09%  USD
+  ...
+
+─── 3. Account Summary ───────────────────────────────────────
+  Segment   Currency          Cash        NetLiq     BuyingPwr
+  ──────────────────────────────────────────────
+  Stocks        USD     $5,000.00    $45,000.00    $10,000.00
+  Futures       USD       $500.00     $2,000.00          N/A
+
+─── 4. Recent Filled Orders ──────────────────────────────────
+✓ Fetched 3 filled order(s)
+...
+
+─── 5. Corporate Actions ─────────────────────────────────────
+✓ Fetched 1 corporate action(s)
+  2025-03-15  AAPL Dividend  $24.00
+
+─── Result ───────────────────────────────────────────────────
+✓ Connection working
+```
+
+### Troubleshooting
+
+| Symptom | Likely fix |
+|---|---|
+| `Authentication failed` | Key is PKCS1 — convert to PKCS8: `openssl pkcs8 -topk8 -inform PEM -outform PEM -in key.pem -out key_pkcs8.pem -nocrypt` |
+| `API error [-1]` | `tiger_id` or account number is wrong, or public key not uploaded in Developer Center |
+| `HTTP 403` | OpenAPI access not activated — visit `developer.tigerbrokers.com.sg` |
+| `Corporate actions unavailable` | `fund_details` endpoint requires specific account permissions |
+
+## Validation (Programmatic)
+
+Use the `validateConnection()` method to confirm credentials work without fetching full datasets:
+
+```typescript
+const provider = new TigerProvider({
+  config: { tigerId, privateKey, account },
+})
+const ok = await provider.validateConnection()
+// ok === true means auth + connectivity are working
+```
+
+## Environment Variables (Reference)
+
+For development/tooling purposes (not for the browser app), you can export:
+
+```bash
+export TIGER_ID=your_developer_id
+export TIGER_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n..."
+export TIGER_ACCOUNT=U1234567
+```
+
+These are **not** consumed by the browser app. The app uses the encrypted credential manager instead.
+
+## SDK Note
+
+The official `@tigeropenapi/tigeropen` npm package (v0.1.0) is Node.js-only — it uses `crypto.createSign` and `fs.readFile` which are not available in browsers. Lokfi implements a browser-compatible HTTP client that replicates the SDK's RSA signing flow using the Web Crypto API (`crypto.subtle`), keeping the same request structure and API method names. The type definitions in `tiger-types.ts` mirror the SDK's internal models.

--- a/apps/web/src/lib/brokerage/tiger/README.md
+++ b/apps/web/src/lib/brokerage/tiger/README.md
@@ -50,7 +50,7 @@ These credentials are encrypted with a user-supplied passphrase using Web Crypto
 2. Go to **Developer Center → My Apps** → create an application → upload your RSA public key
 3. API access is activated immediately — no endpoint-specific permissions required
 
-The `fund_details` (corporate actions) endpoint is included in standard OpenAPI access. No separate activation needed.
+The `fund_details` (fund details / corporate actions) endpoint is included in standard OpenAPI access. No separate activation needed.
 
 ## API Endpoints Used (Read-Only)
 
@@ -63,7 +63,7 @@ All endpoints are accessed via `POST https://openapi.tigerfintech.com/gateway` w
 | Order transactions | `order_transactions` | `account`, `id` (orderId) |
 | Account assets | `assets` | `account` |
 | Prime assets | `prime_assets` | `account` |
-| Corporate actions | `fund_details` | `account`, `fund_type: "CORPORATE_ACTION"`, `seg_types: ["SEC"]`, `start_date`, `end_date` |
+| Fund details | `fund_details` | `account`, `fund_type: "ALL"`, `seg_types: ["SEC"]`, `start_date`, `end_date` |
 
 ## Rate Limits
 
@@ -72,33 +72,34 @@ Tiger enforces per-method tiered rate limits on a 60-second rolling window:
 | Tier | Limit | Methods |
 |---|---|---|
 | High | 120 req/min | Order queries, trading |
-| **Medium** | **60 req/min** | **Positions, assets, fund details** |
-| Low | 10 req/min | Market status, symbol info |
+| **Medium** | **60 req/min** | **Positions, assets** |
+| **Low** | **10 req/min** | **Fund details**, market status, symbol info |
 
 Lokfi's sync orchestrator implements tier-aware throttling:
-- **Medium-tier** (positions, assets, corp actions): 1100ms between requests
+- **Medium-tier** (positions, assets, account): 1100ms between requests
+- **Low-tier** (fund details): 6100ms between requests
 - **High-tier** (orders, transactions): 600ms between requests
 
 Exceeding limits persistently may result in your `tiger_id` being blacklisted automatically. Contact Tiger support for higher limits.
 
-## Corporate Actions
+## Fund Details
 
 ### What's Available
 
-Tiger's standard OpenAPI provides account-level corporate action history via the `fund_details` endpoint. Each record includes:
+Tiger's standard OpenAPI provides account-level cash ledger history via the `fund_details` endpoint with `fund_type: 'ALL'`. This returns 13 distinct transaction types including trades, dividends, dividend tax, fees (Commission, Platform Fee, GST, SEC Fee, etc.), transfers, and rebates. Each record includes:
 
-- `amount` — value of the action (dividend payout, etc.)
+- `amount` — value of the fund change (positive = inflow, negative = outflow)
 - `currency` — USD, SGD, HKD, etc.
-- `desc` — description (e.g. "XDTE-DIVIDEND", "MSTY-DIVIDEND")
+- `desc` — description (e.g. "Buy-AVGO", "XDTE-DIVIDEND", "Funds Transfer In")
 - `businessDate` — Tiger-defined business date when the action was applied
 - `segType` — `SEC` (securities) or `FUT` (futures)
-- `type` — fund type label
+- `type` — fund type label (e.g. "Trade", "Dividend", "Dividend Tax", "Commission", "Platform Fee")
 
-**Correct parameter format** (based on Tiger's official Python/Java SDK docs):
+**Correct parameter format** (fund_type: 'ALL' for complete cash ledger):
 
 ```json
 {
-  "fund_type": "CORPORATE_ACTION",
+  "fund_type": "ALL",
   "seg_types": ["SEC"],
   "start_date": "2026-02-01",
   "end_date": "2026-05-01",
@@ -106,13 +107,22 @@ Tiger's standard OpenAPI provides account-level corporate action history via the
 }
 ```
 
-Key: `seg_types` is an **array of strings** using Tiger's enum values `SEC`/`FUT` (not `S`/`C`), and `fund_type` is the **string** `"CORPORATE_ACTION"` (not the integer `7`).
+Key: `seg_types` is an **array of strings** using Tiger's enum values `SEC`/`FUT` (not `S`/`C`), and `fund_type` is the **string** `"ALL"` for the complete cash ledger. Pagination is driven by the `pageCount` field in Tiger's response metadata. The first request (page 1) reveals the total number of pages; subsequent requests fetch pages 2 through `pageCount`. A 6100ms delay is applied between pages to respect the Low-tier rate limit (10 req/min). Records are deduplicated by `id` as a safety net in case the API returns overlapping data across pages.
 
-### What's NOT Available via Standard API
+### Type Classification
 
-The standard API provides fund-change records (dividend receipts, fee debits) but does **not** include structured metadata like ex-date, pay-date, or symbol-level corporate action details. This structured data is available through the **Enterprise API** (`GET /corp-actions`) but that endpoint requires OAuth2 token authentication — a separate authorization tier.
+The adapter maps Tiger `type` strings to normalized `FundDetailType` values:
 
-The Tiger provider maps `fund_details` records to normalized `BrokerageCorpAction` entries with best-effort type classification (dividend/split/rights/other) based on the description text. For detailed corporate action tracking, upgrading to the Enterprise API tier would be needed.
+| Tiger type | Classified As |
+|---|---|
+| Dividend | DIVIDEND |
+| Dividend Tax | DIVIDEND_TAX |
+| Trade | TRADE |
+| Commission, Platform Fee, GST, SEC Fee, etc. | FEE |
+| Funds Transfer In | TRANSFER_IN |
+| Campaign Subsidy | REBATE |
+
+Trade records are enriched with quantity/price data from `filled_orders` by matching symbol, date, and action. Unenriched trade records still appear in the unified view with the total amount only.
 
 ## Market/Account Segmentation
 
@@ -148,7 +158,7 @@ The script will:
 2. **Positions** — displays all current holdings with P&L breakdown
 3. **Account summary** — cash balance, net liquidation by currency segment
 4. **Recent orders** — last 30 days of filled orders
-5. **Corporate actions** — last 90 days of dividends/splits
+5. **Fund details** — last 90 days of fund detail records (dividends, fees, trades, transfers, rebates)
 
 ### What success looks like
 
@@ -177,8 +187,8 @@ Tiger OpenAPI — Connection Verification
 ✓ Fetched 3 filled order(s)
 ...
 
-─── 5. Corporate Actions ─────────────────────────────────────
-✓ Fetched 1 corporate action(s)
+─── 5. Fund Details ─────────────────────────────────────────
+✓ Fetched 12 fund detail record(s)
   2025-03-15  AAPL Dividend  $24.00
 
 ─── Result ───────────────────────────────────────────────────
@@ -192,7 +202,7 @@ Tiger OpenAPI — Connection Verification
 | `Authentication failed` | Key is PKCS1 — convert to PKCS8: `openssl pkcs8 -topk8 -inform PEM -outform PEM -in key.pem -out key_pkcs8.pem -nocrypt` |
 | `API error [-1]` | `tiger_id` or account number is wrong, or public key not uploaded in Developer Center |
 | `HTTP 403` | OpenAPI access not activated — visit `developer.tigerbrokers.com.sg` |
-| `Corporate actions unavailable` | `fund_details` endpoint requires specific account permissions |
+| `Fund details unavailable` | `fund_details` endpoint requires specific account permissions |
 
 ## Validation (Programmatic)
 

--- a/apps/web/src/lib/brokerage/tiger/tiger-adapter.test.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-adapter.test.ts
@@ -1,0 +1,299 @@
+import type { BrokerageTransaction } from '@lokfi/brokerage-core'
+import { describe, expect, it } from 'vitest'
+import {
+  adaptAsset,
+  adaptAssetSegment,
+  adaptCorpAction,
+  adaptOrder,
+  adaptOrderTransaction,
+  adaptPosition,
+} from './tiger-adapter'
+import type {
+  TigerAsset,
+  TigerAssetSegment,
+  TigerCorpAction,
+  TigerOrder,
+  TigerOrderTransaction,
+  TigerPosition,
+} from './tiger-types'
+
+describe('adaptPosition', () => {
+  it('maps TigerPosition to BrokeragePosition correctly', () => {
+    const tigerPos: TigerPosition = {
+      account: 'test-account',
+      symbol: 'AAPL',
+      secType: 'STK',
+      currency: 'USD',
+      position: 100,
+      averageCost: 150.5,
+      marketValue: 18000,
+      unrealizedPnl: 2950,
+    }
+
+    const result = adaptPosition(tigerPos)
+
+    expect(result.symbol).toBe('AAPL')
+    expect(result.quantity).toBe(100)
+    expect(result.marketValue).toBe(18000)
+    expect(result.unrealizedPnl).toBe(2950)
+    expect(result.avgCost).toBe(150.5)
+    expect(result.currency).toBe('USD')
+    expect(result.secType).toBe('STK')
+  })
+
+  it('generates correct id format with symbol_tiger', () => {
+    const tigerPos: TigerPosition = {
+      account: 'test-account',
+      symbol: 'MSFT',
+      secType: 'STK',
+      currency: 'USD',
+      position: 50,
+      averageCost: 300,
+    }
+
+    const result = adaptPosition(tigerPos)
+
+    expect(result.id).toBe('MSFT_tiger')
+  })
+})
+
+describe('adaptOrder', () => {
+  it('returns null when filledQuantity is 0', () => {
+    const order: TigerOrder = {
+      account: 'test-account',
+      id: 1,
+      orderId: 123,
+      action: 'BUY',
+      orderType: 'LMT',
+      totalQuantity: 100,
+      filledQuantity: 0,
+      symbol: 'AAPL',
+      secType: 'STK',
+      timeInForce: 'DAY',
+      outsideRth: false,
+      currency: 'USD',
+    }
+
+    const result = adaptOrder(order)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns transaction when order has fills', () => {
+    const order: TigerOrder = {
+      account: 'test-account',
+      id: 1,
+      orderId: 456,
+      action: 'BUY',
+      orderType: 'LMT',
+      totalQuantity: 100,
+      filledQuantity: 50,
+      avgFillPrice: 175,
+      symbol: 'AAPL',
+      secType: 'STK',
+      timeInForce: 'DAY',
+      outsideRth: false,
+      currency: 'USD',
+      latestTime: 1704067200000,
+    }
+
+    const result = adaptOrder(order)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageTransaction).symbol).toBe('AAPL')
+    expect((result as BrokerageTransaction).quantity).toBe(50)
+    expect((result as BrokerageTransaction).price).toBe(175)
+  })
+
+  it('normalizes BUY action', () => {
+    const order: TigerOrder = {
+      account: 'test-account',
+      orderId: 789,
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: 10,
+      filledQuantity: 10,
+      symbol: 'TSLA',
+      secType: 'STK',
+      timeInForce: 'DAY',
+      outsideRth: false,
+      currency: 'USD',
+    }
+
+    const result = adaptOrder(order)
+
+    expect((result as BrokerageTransaction).action).toBe('BUY')
+  })
+
+  it('normalizes SELL action', () => {
+    const order: TigerOrder = {
+      account: 'test-account',
+      orderId: 101,
+      action: 'SELL',
+      orderType: 'MKT',
+      totalQuantity: 25,
+      filledQuantity: 25,
+      symbol: 'GOOG',
+      secType: 'STK',
+      timeInForce: 'DAY',
+      outsideRth: false,
+      currency: 'USD',
+    }
+
+    const result = adaptOrder(order)
+
+    expect((result as BrokerageTransaction).action).toBe('SELL')
+  })
+})
+
+describe('adaptOrderTransaction', () => {
+  it('maps TigerOrderTransaction to BrokerageTransaction', () => {
+    const txn: TigerOrderTransaction = {
+      account: 'test-account',
+      id: 1,
+      orderId: 999,
+      symbol: 'AAPL',
+      action: 'BUY',
+      quantity: 25,
+      price: 180,
+      currency: 'USD',
+      tradeTime: 1704067200000,
+    }
+
+    const result = adaptOrderTransaction(txn)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageTransaction).symbol).toBe('AAPL')
+    expect((result as BrokerageTransaction).quantity).toBe(25)
+    expect((result as BrokerageTransaction).price).toBe(180)
+  })
+
+  it('returns null when orderId is missing', () => {
+    const txn: TigerOrderTransaction = {
+      account: 'test-account',
+      symbol: 'AAPL',
+      action: 'BUY',
+      quantity: 10,
+      price: 150,
+      currency: 'USD',
+    }
+
+    const result = adaptOrderTransaction(txn)
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('adaptAsset', () => {
+  it('maps asset to account with cashValue', () => {
+    const asset: TigerAsset = {
+      account: 'test-account',
+      currency: 'USD',
+      cashValue: 10000,
+      netLiquidation: 50000,
+    }
+
+    const result = adaptAsset(asset)
+
+    expect(result.source).toBe('tiger')
+    expect(result.currency).toBe('USD')
+    expect(result.cashBalance).toBe(10000)
+    expect(result.netLiquidation).toBe(50000)
+  })
+
+  it('generates correct id format from currency only', () => {
+    const asset: TigerAsset = {
+      account: 'test-account',
+      currency: 'HKD',
+      cashValue: 20000,
+    }
+
+    const result = adaptAsset(asset)
+
+    expect(result.id).toBe('tiger_HKD')
+  })
+})
+
+describe('adaptAssetSegment', () => {
+  it('maps segment category S to SEC', () => {
+    const seg: TigerAssetSegment = {
+      account: 'test-account',
+      category: 'S',
+      cashValue: 5000,
+      netLiquidation: 30000,
+    }
+
+    const result = adaptAssetSegment(seg, 'USD')
+
+    expect(result.segType).toBe('SEC')
+    expect(result.cashBalance).toBe(5000)
+  })
+
+  it('maps segment category C to FUT', () => {
+    const seg: TigerAssetSegment = {
+      account: 'test-account',
+      category: 'C',
+      cashValue: 2000,
+    }
+
+    const result = adaptAssetSegment(seg, 'USD')
+
+    expect(result.segType).toBe('FUT')
+  })
+
+  it('generates correct id format with segment', () => {
+    const seg: TigerAssetSegment = {
+      account: 'test-account',
+      category: 'S',
+    }
+
+    const result = adaptAssetSegment(seg, 'HKD')
+
+    expect(result.id).toBe('tiger_HKD_S')
+  })
+})
+
+describe('adaptCorpAction', () => {
+  it('classifies DIVIDEND from desc', () => {
+    const corpAction: TigerCorpAction = {
+      id: 1,
+      account: 'test-account',
+      currency: 'USD',
+      amount: 24,
+      desc: 'AAPL Dividend',
+      businessDate: '2025-02-13',
+    }
+
+    const result = adaptCorpAction(corpAction)
+
+    expect(result?.type).toBe('DIVIDEND')
+  })
+
+  it('classifies SPLIT from desc', () => {
+    const corpAction: TigerCorpAction = {
+      id: 2,
+      account: 'test-account',
+      amount: 4,
+      desc: 'TSLA Split 4-for-1',
+      businessDate: '2025-03-01',
+    }
+
+    const result = adaptCorpAction(corpAction)
+
+    expect(result?.type).toBe('SPLIT')
+  })
+
+  it('defaults to OTHER for unknown desc', () => {
+    const corpAction: TigerCorpAction = {
+      id: 3,
+      account: 'test-account',
+      amount: 10,
+      desc: 'Some random corporate action',
+      businessDate: '2025-04-01',
+    }
+
+    const result = adaptCorpAction(corpAction)
+
+    expect(result?.type).toBe('OTHER')
+  })
+})

--- a/apps/web/src/lib/brokerage/tiger/tiger-adapter.test.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-adapter.test.ts
@@ -1,17 +1,21 @@
-import type { BrokerageTransaction } from '@lokfi/brokerage-core'
+import type { BrokerageFundDetail, BrokerageTransaction } from '@lokfi/brokerage-core'
 import { describe, expect, it } from 'vitest'
 import {
   adaptAsset,
   adaptAssetSegment,
-  adaptCorpAction,
+  adaptFundDetail,
   adaptOrder,
   adaptOrderTransaction,
   adaptPosition,
+  classifyFundType,
+  enrichTradeFundDetail,
+  extractActionFromDesc,
+  extractSymbolFromDesc,
 } from './tiger-adapter'
 import type {
   TigerAsset,
   TigerAssetSegment,
-  TigerCorpAction,
+  TigerFundDetail,
   TigerOrder,
   TigerOrderTransaction,
   TigerPosition,
@@ -39,9 +43,13 @@ describe('adaptPosition', () => {
     expect(result.avgCost).toBe(150.5)
     expect(result.currency).toBe('USD')
     expect(result.secType).toBe('STK')
+    // Option fields should be undefined for stock positions
+    expect(result.identifier).toBeUndefined()
+    expect(result.multiplier).toBeUndefined()
+    expect(result.contractId).toBeUndefined()
   })
 
-  it('generates correct id format with symbol_tiger', () => {
+  it('generates id with symbol_secType_source format', () => {
     const tigerPos: TigerPosition = {
       account: 'test-account',
       symbol: 'MSFT',
@@ -53,7 +61,73 @@ describe('adaptPosition', () => {
 
     const result = adaptPosition(tigerPos)
 
-    expect(result.id).toBe('MSFT_tiger')
+    expect(result.id).toBe('MSFT_STK_tiger')
+  })
+
+  it('includes secType in id so stock and option positions do not collide', () => {
+    const stock: TigerPosition = {
+      account: 'test-account',
+      symbol: 'CRWV',
+      secType: 'STK',
+      currency: 'USD',
+      position: 50,
+      averageCost: 85.12,
+    }
+    const option: TigerPosition = {
+      account: 'test-account',
+      symbol: 'CRWV',
+      secType: 'OPT',
+      currency: 'USD',
+      position: -1,
+      averageCost: 5.29,
+      identifier: 'CRWV  260508P00106000',
+      multiplier: 100,
+      contractId: 421026041,
+    }
+
+    const stockResult = adaptPosition(stock)
+    const optionResult = adaptPosition(option)
+
+    expect(stockResult.id).toBe('CRWV_STK_tiger')
+    expect(optionResult.id).toBe('OPT_CRWV_260508P00106000_tiger')
+    expect(stockResult.id).not.toBe(optionResult.id)
+    // Option fields mapped correctly
+    expect(optionResult.identifier).toBe('CRWV  260508P00106000')
+    expect(optionResult.multiplier).toBe(100)
+    expect(optionResult.contractId).toBe(421026041)
+    expect(stockResult.identifier).toBeUndefined()
+  })
+
+  it('generates unique ids for multiple option contracts on same underlying', () => {
+    const opt1: TigerPosition = {
+      account: 'test-account',
+      symbol: 'GRAB',
+      secType: 'OPT',
+      currency: 'USD',
+      position: -13,
+      averageCost: 0.15,
+      identifier: 'GRAB  260508C00004000',
+      multiplier: 100,
+      contractId: 416667521,
+    }
+    const opt2: TigerPosition = {
+      account: 'test-account',
+      symbol: 'GRAB',
+      secType: 'OPT',
+      currency: 'USD',
+      position: -10,
+      averageCost: 0.15,
+      identifier: 'GRAB  260508C00004500',
+      multiplier: 100,
+      contractId: 416667513,
+    }
+
+    const r1 = adaptPosition(opt1)
+    const r2 = adaptPosition(opt2)
+
+    expect(r1.id).toBe('OPT_GRAB_260508C00004000_tiger')
+    expect(r2.id).toBe('OPT_GRAB_260508C00004500_tiger')
+    expect(r1.id).not.toBe(r2.id)
   })
 })
 
@@ -253,47 +327,441 @@ describe('adaptAssetSegment', () => {
   })
 })
 
-describe('adaptCorpAction', () => {
-  it('classifies DIVIDEND from desc', () => {
-    const corpAction: TigerCorpAction = {
+describe('classifyFundType', () => {
+  it('classifies "Dividend" → DIVIDEND', () => {
+    expect(classifyFundType('Dividend')).toBe('DIVIDEND')
+  })
+
+  it('classifies "Dividend Tax" → DIVIDEND_TAX', () => {
+    expect(classifyFundType('Dividend Tax')).toBe('DIVIDEND_TAX')
+  })
+
+  it('classifies "Trade" → TRADE', () => {
+    expect(classifyFundType('Trade')).toBe('TRADE')
+  })
+
+  it('classifies "Commission" → FEE', () => {
+    expect(classifyFundType('Commission')).toBe('FEE')
+  })
+
+  it('classifies "Platform Fee" → FEE', () => {
+    expect(classifyFundType('Platform Fee')).toBe('FEE')
+  })
+
+  it('classifies "Funds Transfer In" → TRANSFER_IN', () => {
+    expect(classifyFundType('Funds Transfer In')).toBe('TRANSFER_IN')
+  })
+
+  it('classifies "Campaign Subsidy" → REBATE', () => {
+    expect(classifyFundType('Campaign Subsidy')).toBe('REBATE')
+  })
+
+  it('classifies "Currency Exchange - Quotation Currency" → CURRENCY_EXCHANGE', () => {
+    expect(classifyFundType('Currency Exchange - Quotation Currency')).toBe('CURRENCY_EXCHANGE')
+  })
+
+  it('classifies "Currency Exchange - Base Currency" → CURRENCY_EXCHANGE', () => {
+    expect(classifyFundType('Currency Exchange - Base Currency')).toBe('CURRENCY_EXCHANGE')
+  })
+
+  it('classifies "Deposit" → DEPOSIT_WITHDRAWAL', () => {
+    expect(classifyFundType('Deposit')).toBe('DEPOSIT_WITHDRAWAL')
+  })
+
+  it('classifies "Funds Transfer Out" → TRANSFER_OUT', () => {
+    expect(classifyFundType('Funds Transfer Out')).toBe('TRANSFER_OUT')
+  })
+
+  it('classifies unknown type → UNKNOWN with warning', () => {
+    expect(classifyFundType('UnknownThing')).toBe('UNKNOWN')
+  })
+
+  it('handles undefined → UNKNOWN', () => {
+    expect(classifyFundType(undefined)).toBe('UNKNOWN')
+  })
+})
+
+describe('extractSymbolFromDesc', () => {
+  it('extracts "AVGO" from "Buy-AVGO"', () => {
+    expect(extractSymbolFromDesc('Buy-AVGO')).toBe('AVGO')
+  })
+
+  it('extracts "XDTE" from "XDTE-DIVIDEND"', () => {
+    expect(extractSymbolFromDesc('XDTE-DIVIDEND')).toBe('XDTE')
+  })
+
+  it('extracts "AAPL" from "Sell-AAPL"', () => {
+    expect(extractSymbolFromDesc('Sell-AAPL')).toBe('AAPL')
+  })
+
+  it('returns "" for undefined desc', () => {
+    expect(extractSymbolFromDesc(undefined)).toBe('')
+  })
+})
+
+describe('extractActionFromDesc', () => {
+  it('extracts "BUY" from "Buy-AVGO"', () => {
+    expect(extractActionFromDesc('Buy-AVGO')).toBe('BUY')
+  })
+
+  it('extracts "SELL" from "Sell-AAPL"', () => {
+    expect(extractActionFromDesc('Sell-AAPL')).toBe('SELL')
+  })
+
+  it('returns undefined for "XDTE-DIVIDEND"', () => {
+    expect(extractActionFromDesc('XDTE-DIVIDEND')).toBeUndefined()
+  })
+
+  it('returns undefined for undefined desc', () => {
+    expect(extractActionFromDesc(undefined)).toBeUndefined()
+  })
+})
+
+describe('adaptFundDetail', () => {
+  it('adapts Dividend record', () => {
+    const fundDetail: TigerFundDetail = {
       id: 1,
       account: 'test-account',
       currency: 'USD',
-      amount: 24,
-      desc: 'AAPL Dividend',
-      businessDate: '2025-02-13',
+      amount: 94.15,
+      desc: 'XDTE-DIVIDEND',
+      type: 'Dividend',
+      businessDate: '2025-04-15',
     }
 
-    const result = adaptCorpAction(corpAction)
+    const result = adaptFundDetail(fundDetail)
 
-    expect(result?.type).toBe('DIVIDEND')
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('DIVIDEND')
+    expect((result as BrokerageFundDetail).symbol).toBe('XDTE')
+    expect((result as BrokerageFundDetail).amount).toBe(94.15)
   })
 
-  it('classifies SPLIT from desc', () => {
-    const corpAction: TigerCorpAction = {
+  it('adapts Dividend Tax withheld (negative)', () => {
+    const fundDetail: TigerFundDetail = {
       id: 2,
       account: 'test-account',
-      amount: 4,
-      desc: 'TSLA Split 4-for-1',
-      businessDate: '2025-03-01',
+      currency: 'USD',
+      amount: -28.24,
+      desc: 'XDTE-DIVIDEND',
+      type: 'Dividend Tax',
+      businessDate: '2025-04-15',
     }
 
-    const result = adaptCorpAction(corpAction)
+    const result = adaptFundDetail(fundDetail)
 
-    expect(result?.type).toBe('SPLIT')
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('DIVIDEND_TAX')
+    expect((result as BrokerageFundDetail).amount).toBe(-28.24)
   })
 
-  it('defaults to OTHER for unknown desc', () => {
-    const corpAction: TigerCorpAction = {
+  it('adapts Dividend Tax refund (positive)', () => {
+    const fundDetail: TigerFundDetail = {
       id: 3,
       account: 'test-account',
-      amount: 10,
-      desc: 'Some random corporate action',
-      businessDate: '2025-04-01',
+      currency: 'USD',
+      amount: 5.0,
+      desc: 'XDTE-DIVIDEND',
+      type: 'Dividend Tax',
+      businessDate: '2025-04-15',
     }
 
-    const result = adaptCorpAction(corpAction)
+    const result = adaptFundDetail(fundDetail)
 
-    expect(result?.type).toBe('OTHER')
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('DIVIDEND_TAX')
+    expect((result as BrokerageFundDetail).amount).toBe(5.0)
+  })
+
+  it('adapts Commission', () => {
+    const fundDetail: TigerFundDetail = {
+      id: 4,
+      account: 'test-account',
+      currency: 'USD',
+      amount: -1.99,
+      desc: 'Buy-AVGO',
+      type: 'Commission',
+      businessDate: '2025-04-15',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('FEE')
+    expect((result as BrokerageFundDetail).rawType).toBe('Commission')
+    expect((result as BrokerageFundDetail).symbol).toBe('AVGO')
+  })
+
+  it('adapts Platform Fee', () => {
+    const fundDetail: TigerFundDetail = {
+      id: 5,
+      account: 'test-account',
+      currency: 'USD',
+      amount: -0.99,
+      type: 'Platform Fee',
+      businessDate: '2025-04-15',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('FEE')
+  })
+
+  it('adapts Trade', () => {
+    const fundDetail: TigerFundDetail = {
+      id: 6,
+      account: 'test-account',
+      currency: 'USD',
+      amount: -2008.8,
+      desc: 'Buy-AVGO',
+      type: 'Trade',
+      businessDate: '2025-04-15',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('TRADE')
+    expect((result as BrokerageFundDetail).action).toBe('BUY')
+  })
+
+  it('adapts GST', () => {
+    const fundDetail: TigerFundDetail = {
+      id: 7,
+      account: 'test-account',
+      currency: 'USD',
+      amount: -0.16,
+      type: 'GST',
+      businessDate: '2025-04-15',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('FEE')
+  })
+
+  it('adapts Transfer In', () => {
+    const fundDetail: TigerFundDetail = {
+      id: 8,
+      account: 'test-account',
+      currency: 'USD',
+      amount: 20.29,
+      type: 'Funds Transfer In',
+      businessDate: '2025-04-15',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('TRANSFER_IN')
+  })
+
+  it('adapts Campaign Subsidy', () => {
+    const fundDetail: TigerFundDetail = {
+      id: 9,
+      account: 'test-account',
+      currency: 'USD',
+      amount: 0.5,
+      type: 'Campaign Subsidy',
+      businessDate: '2025-04-15',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('REBATE')
+  })
+
+  it('adapts unknown type as UNKNOWN (not fee)', () => {
+    const fundDetail: TigerFundDetail = {
+      id: 10,
+      account: 'test-account',
+      currency: 'USD',
+      amount: -5.0,
+      type: 'UnknownThing',
+      businessDate: '2025-04-15',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).not.toBeNull()
+    expect((result as BrokerageFundDetail).classifiedType).toBe('UNKNOWN')
+  })
+
+  it('returns null when id is undefined', () => {
+    const fundDetail: TigerFundDetail = {
+      account: 'test-account',
+      currency: 'USD',
+      amount: 94.15,
+      desc: 'XDTE-DIVIDEND',
+      type: 'Dividend',
+      businessDate: '2025-04-15',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when businessDate is missing', () => {
+    const fundDetail: TigerFundDetail = {
+      id: 1,
+      account: 'test-account',
+      currency: 'USD',
+      amount: 94.15,
+      desc: 'XDTE-DIVIDEND',
+      type: 'Dividend',
+    }
+
+    const result = adaptFundDetail(fundDetail)
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('enrichTradeFundDetail', () => {
+  it('enriches TRADE fund detail with matching filled order', () => {
+    const filledOrder: BrokerageTransaction = {
+      id: 'tiger_123',
+      source: 'tiger',
+      orderId: '123',
+      symbol: 'AVGO',
+      action: 'BUY',
+      quantity: 10,
+      price: 200.88,
+      currency: 'USD',
+      commission: 0,
+      executedAt: '2025-04-15T10:00:00Z',
+    }
+
+    const fundDetail: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
+      source: 'tiger',
+      rawType: 'Trade',
+      classifiedType: 'TRADE',
+      symbol: 'AVGO',
+      amount: -2008.8,
+      currency: 'USD',
+      action: 'BUY',
+      businessDate: '2025-04-15',
+    }
+
+    const result = enrichTradeFundDetail(fundDetail, [filledOrder])
+
+    expect(result.quantity).toBe(10)
+    expect(result.price).toBe(200.88)
+  })
+
+  it('does not modify non-TRADE fund details', () => {
+    const fundDetail: BrokerageFundDetail = {
+      id: 'tiger_fund_2',
+      source: 'tiger',
+      rawType: 'Dividend',
+      classifiedType: 'DIVIDEND',
+      symbol: 'XDTE',
+      amount: 94.15,
+      currency: 'USD',
+      businessDate: '2025-04-15',
+    }
+
+    const filledOrder: BrokerageTransaction = {
+      id: 'tiger_123',
+      source: 'tiger',
+      orderId: '123',
+      symbol: 'AVGO',
+      action: 'BUY',
+      quantity: 10,
+      price: 200.88,
+      currency: 'USD',
+      commission: 0,
+      executedAt: '2025-04-15T10:00:00Z',
+    }
+
+    const result = enrichTradeFundDetail(fundDetail, [filledOrder])
+
+    expect(result.quantity).toBeUndefined()
+    expect(result.price).toBeUndefined()
+  })
+
+  it('returns unenriched when no matching filled order found', () => {
+    const fundDetail: BrokerageFundDetail = {
+      id: 'tiger_fund_3',
+      source: 'tiger',
+      rawType: 'Trade',
+      classifiedType: 'TRADE',
+      symbol: 'AVGO',
+      amount: -2008.8,
+      currency: 'USD',
+      action: 'BUY',
+      businessDate: '2025-04-15',
+    }
+
+    const filledOrder: BrokerageTransaction = {
+      id: 'tiger_456',
+      source: 'tiger',
+      orderId: '456',
+      symbol: 'AAPL', // different symbol
+      action: 'BUY',
+      quantity: 10,
+      price: 200.88,
+      currency: 'USD',
+      commission: 0,
+      executedAt: '2025-04-15T10:00:00Z',
+    }
+
+    const result = enrichTradeFundDetail(fundDetail, [filledOrder])
+
+    expect(result.quantity).toBeUndefined()
+    expect(result.price).toBeUndefined()
+  })
+
+  it('selects closest amount match for multiple matches', () => {
+    const fundDetail: BrokerageFundDetail = {
+      id: 'tiger_fund_4',
+      source: 'tiger',
+      rawType: 'Trade',
+      classifiedType: 'TRADE',
+      symbol: 'AVGO',
+      amount: -2008.8,
+      currency: 'USD',
+      action: 'BUY',
+      businessDate: '2025-04-15',
+    }
+
+    const closerOrder: BrokerageTransaction = {
+      id: 'tiger_789',
+      source: 'tiger',
+      orderId: '789',
+      symbol: 'AVGO',
+      action: 'BUY',
+      quantity: 10,
+      price: 200.88,
+      currency: 'USD',
+      commission: 0,
+      executedAt: '2025-04-15T10:00:00Z',
+    }
+
+    // This order has gross = 10 * 200.88 + 0 = 2008.8 (exact match)
+    const fartherOrder: BrokerageTransaction = {
+      id: 'tiger_101',
+      source: 'tiger',
+      orderId: '101',
+      symbol: 'AVGO',
+      action: 'BUY',
+      quantity: 12,
+      price: 180.0,
+      currency: 'USD',
+      commission: 0,
+      executedAt: '2025-04-15T10:00:00Z',
+    }
+
+    // Gross = 12 * 180 = 2160, diff from 2008.8 = 151.2
+
+    const result = enrichTradeFundDetail(fundDetail, [fartherOrder, closerOrder])
+
+    expect(result.quantity).toBe(10)
+    expect(result.price).toBe(200.88)
   })
 })

--- a/apps/web/src/lib/brokerage/tiger/tiger-adapter.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-adapter.ts
@@ -7,16 +7,16 @@
 
 import type {
   BrokerageAccount,
-  BrokerageCorpAction,
+  BrokerageFundDetail,
   BrokeragePosition,
   BrokerageTransaction,
-  CorpActionType,
+  FundDetailType,
   TradeAction,
 } from '@lokfi/brokerage-core'
 import type {
   TigerAsset,
   TigerAssetSegment,
-  TigerCorpAction,
+  TigerFundDetail,
   TigerOrder,
   TigerOrderTransaction,
   TigerPosition,
@@ -28,17 +28,27 @@ export const SOURCE = 'tiger'
 // ── Position ──────────────────────────────────────────────────────────────
 
 export function adaptPosition(raw: TigerPosition): BrokeragePosition {
+  const secType = (raw.secType || 'STK') as BrokeragePosition['secType']
+  // For derivatives, include the OCC identifier in the ID to disambiguate
+  // multiple contracts on the same underlying (e.g. GRAB OPT $4 vs $4.50).
+  const id = raw.identifier
+    ? `${raw.secType}_${raw.identifier.replace(/\s+/g, '_')}_${SOURCE}`
+    : `${raw.symbol}_${secType}_${SOURCE}`
   return {
-    id: `${raw.symbol}_${SOURCE}`,
+    id,
     source: SOURCE,
     symbol: raw.symbol,
     name: raw.name,
-    secType: (raw.secType || 'STK') as BrokeragePosition['secType'],
+    secType,
     currency: raw.currency || 'USD',
     quantity: raw.position,
     avgCost: raw.averageCost,
     marketValue: raw.marketValue,
     unrealizedPnl: raw.unrealizedPnl,
+    // Option/derivative fields (only present for OPT, FUT, etc.)
+    identifier: raw.identifier,
+    multiplier: raw.multiplier,
+    contractId: raw.contractId,
     updatedAt: new Date().toISOString(),
   }
 }
@@ -121,26 +131,183 @@ export function adaptAssetSegment(segment: TigerAssetSegment, currency: string):
   }
 }
 
-// ── Corporate Action ──────────────────────────────────────────────────────
+// ── Fund Detail → BrokerageFundDetail ─────────────────────────────────────
 
 /**
- * Adapt Tiger fund_detail records with fund_type=CORPORATE_ACTION
- * into normalized corp actions. Parses the description string to
- * determine action type (dividend, split, rights, or other).
+ * Static mapping of Tiger fund_detail `type` strings to `FundDetailType`.
+ * Exact-match map — entries here take priority over prefix/pattern matching.
  */
-export function adaptCorpAction(raw: TigerCorpAction): BrokerageCorpAction | null {
-  const date = raw.businessDate || new Date().toISOString().slice(0, 10)
+const FUND_TYPE_MAP: Record<string, FundDetailType> = {
+  Dividend: 'DIVIDEND',
+  'Dividend Tax': 'DIVIDEND_TAX',
+  Trade: 'TRADE',
+  Commission: 'FEE',
+  'Platform Fee': 'FEE',
+  'Settlement Fee': 'FEE',
+  GST: 'FEE',
+  'Trading Activity Fee': 'FEE',
+  'SEC Fee': 'FEE',
+  'Option Regulatory Fee': 'FEE',
+  'Clearing Fee': 'FEE',
+  'Funds Transfer In': 'TRANSFER_IN',
+  'Funds Transfer Out': 'TRANSFER_OUT',
+  'Campaign Subsidy': 'REBATE',
+  Deposit: 'DEPOSIT_WITHDRAWAL',
+}
+
+/** Track already-logged unknown types to avoid console spam on repeated syncs */
+const warnedTypes = new Set<string>()
+
+/**
+ * Classify a Tiger fund_detail `type` string into a FundDetailType.
+ *
+ * Matching order:
+ *   1. Exact match in FUND_TYPE_MAP (fast path)
+ *   2. Prefix / regex pattern match (handles variants)
+ *   3. Fallback to `UNKNOWN` with a one-time warning per type
+ */
+export function classifyFundType(rawType?: string): FundDetailType {
+  if (!rawType) return 'UNKNOWN'
+
+  // 1. Exact match
+  const mapped = FUND_TYPE_MAP[rawType]
+  if (mapped) return mapped
+
+  // 2. Prefix / pattern matches
+  if (rawType.startsWith('Currency Exchange')) return 'CURRENCY_EXCHANGE'
+  if (/^(Deposit|Withdrawal)/i.test(rawType)) return 'DEPOSIT_WITHDRAWAL'
+
+  // 3. Unknown — log once per type, classify as UNKNOWN
+  if (!warnedTypes.has(rawType)) {
+    warnedTypes.add(rawType)
+    console.warn(`[tiger-adapter] Unknown fund_detail type: "${rawType}" — classifying as UNKNOWN`)
+  }
+  return 'UNKNOWN'
+}
+
+/**
+ * Extract the stock symbol from a fund detail description.
+ * Descriptions follow the pattern "Action-SYMBOL" (e.g. "Buy-AVGO")
+ * or "SYMBOL-DIVIDEND" (e.g. "XDTE-DIVIDEND").
+ */
+export function extractSymbolFromDesc(desc?: string): string {
+  if (!desc) return ''
+  // Try "Buy-AVGO" pattern first (prefix-action)
+  const actionMatch = desc.trim().match(/^(?:Buy|Sell)-(\S+)/i)
+  if (actionMatch) return actionMatch[1].toUpperCase()
+  // Fall back to first segment split by '-' (e.g. "XDTE-DIVIDEND" → "XDTE")
+  const segments = desc.trim().split('-')
+  return segments[0] ? segments[0].toUpperCase() : ''
+}
+
+/**
+ * Extract trade action (Buy/Sell) from a fund detail description.
+ * Returns undefined if the description does not start with a recognised prefix.
+ */
+export function extractActionFromDesc(desc?: string): TradeAction | undefined {
+  if (!desc) return undefined
+  const match = desc.trim().match(/^(Buy|Sell)/i)
+  if (!match) return undefined
+  const upper = match[1].toUpperCase()
+  if (upper === 'SELL') return 'SELL'
+  return 'BUY'
+}
+
+/**
+ * Adapt a raw TigerFundDetail record into a normalized BrokerageFundDetail.
+ * Returns null if the record is unparseable (no id, no business date).
+ */
+export function adaptFundDetail(raw: TigerFundDetail): BrokerageFundDetail | null {
+  if (raw.id === undefined || raw.id === null) return null
+  if (!raw.businessDate) return null
+
+  const classifiedType = classifyFundType(raw.type)
+  const symbol = extractSymbolFromDesc(raw.desc)
+  const action = classifyFundType(raw.type) === 'TRADE' ? extractActionFromDesc(raw.desc) : undefined
 
   return {
-    id: `${SOURCE}_${date}_${raw.id ?? raw.desc ?? ''}`,
+    id: `${SOURCE}_fund_${raw.id}`,
     source: SOURCE,
-    symbol: '', // Not available in fund_detail — derived from desc
-    type: classifyCorpAction(raw.desc),
-    amount: raw.amount,
-    currency: raw.currency,
-    payDate: date,
-    appliedAt: raw.transactionTime ? new Date(raw.transactionTime * 1000).toISOString() : new Date().toISOString(),
+    rawType: raw.type ?? 'UNKNOWN',
+    classifiedType,
+    symbol: symbol || undefined,
+    contractName: raw.contractName,
+    amount: raw.amount ?? 0,
+    currency: raw.currency || 'USD',
+    action,
+    quantity: undefined,
+    price: undefined,
+    commission: undefined,
+    businessDate: raw.businessDate,
+    segType: raw.segType,
   }
+}
+
+// ── Trade Enrichment ──────────────────────────────────────────────────────
+
+/**
+ * Enrich a TRADE fund_detail record with quantity, price, and commission
+ * from matching filled orders.
+ *
+ * Matching strategy (most → least reliable):
+ * 1. Match by symbol + date + action (single match → use it)
+ * 2. Multiple matches → select closest amount match
+ * 3. No match → return unenriched
+ */
+export function enrichTradeFundDetail(
+  fd: BrokerageFundDetail,
+  filledOrders: BrokerageTransaction[]
+): BrokerageFundDetail {
+  if (fd.classifiedType !== 'TRADE') return fd
+  if (!fd.symbol || !fd.action) return fd
+
+  const fdDate = fd.businessDate.slice(0, 10)
+
+  // Find filled orders matching symbol + date + action
+  const matches = filledOrders.filter((o) => {
+    const oDate = o.executedAt.slice(0, 10)
+    return o.symbol === fd.symbol && oDate === fdDate && o.action === fd.action
+  })
+
+  if (matches.length === 0) {
+    console.debug(`[tiger-adapter] Unmatched trade fund detail: ${fd.symbol} ${fd.action} on ${fdDate}`)
+    return fd
+  }
+
+  // Single match — use it directly
+  if (matches.length === 1) {
+    const order = matches[0]
+    return {
+      ...fd,
+      quantity: order.quantity,
+      price: order.price,
+      commission: order.commission,
+    }
+  }
+
+  // Multiple matches — select closest amount match
+  const fdAbsAmount = Math.abs(fd.amount)
+  let bestMatch = matches[0]
+  let bestDiff = Math.abs(Math.abs(orderGrossAmount(matches[0])) - fdAbsAmount)
+
+  for (let i = 1; i < matches.length; i++) {
+    const diff = Math.abs(Math.abs(orderGrossAmount(matches[i])) - fdAbsAmount)
+    if (diff < bestDiff) {
+      bestDiff = diff
+      bestMatch = matches[i]
+    }
+  }
+
+  return {
+    ...fd,
+    quantity: bestMatch.quantity,
+    price: bestMatch.price,
+    commission: bestMatch.commission,
+  }
+}
+
+function orderGrossAmount(order: BrokerageTransaction): number {
+  return order.quantity * order.price + (order.commission ?? 0)
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -149,13 +316,4 @@ function normalizeAction(action: string): TradeAction {
   const upper = action.toUpperCase()
   if (upper === 'SELL' || upper === 'SHORT') return 'SELL'
   return 'BUY'
-}
-
-function classifyCorpAction(desc?: string): CorpActionType {
-  if (!desc) return 'OTHER'
-  const lower = desc.toLowerCase()
-  if (lower.includes('dividend') || lower.includes('div')) return 'DIVIDEND'
-  if (lower.includes('split')) return 'SPLIT'
-  if (lower.includes('right')) return 'RIGHTS'
-  return 'OTHER'
 }

--- a/apps/web/src/lib/brokerage/tiger/tiger-adapter.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-adapter.ts
@@ -1,0 +1,161 @@
+/**
+ * Tiger → normalized type adapters.
+ *
+ * Maps raw Tiger API responses into the @lokfi/brokerage-core normalized
+ * types that the sync orchestrator persists to Dexie.
+ */
+
+import type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokeragePosition,
+  BrokerageTransaction,
+  CorpActionType,
+  TradeAction,
+} from '@lokfi/brokerage-core'
+import type {
+  TigerAsset,
+  TigerAssetSegment,
+  TigerCorpAction,
+  TigerOrder,
+  TigerOrderTransaction,
+  TigerPosition,
+} from './tiger-types'
+
+/** Source discriminator for all Tiger records */
+export const SOURCE = 'tiger'
+
+// ── Position ──────────────────────────────────────────────────────────────
+
+export function adaptPosition(raw: TigerPosition): BrokeragePosition {
+  return {
+    id: `${raw.symbol}_${SOURCE}`,
+    source: SOURCE,
+    symbol: raw.symbol,
+    name: raw.name,
+    secType: (raw.secType || 'STK') as BrokeragePosition['secType'],
+    currency: raw.currency || 'USD',
+    quantity: raw.position,
+    avgCost: raw.averageCost,
+    marketValue: raw.marketValue,
+    unrealizedPnl: raw.unrealizedPnl,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+// ── Order → Transaction ───────────────────────────────────────────────────
+
+/**
+ * Convert a Tiger Order (which includes fills) to a BrokerageTransaction.
+ * Only orders with status 'Filled' or 'PartiallyFilled' produce transactions.
+ * Partially filled orders produce one transaction per fill quantity.
+ */
+export function adaptOrder(order: TigerOrder): BrokerageTransaction | null {
+  const orderId = String(order.orderId ?? order.id ?? '')
+  if (!orderId) return null
+
+  // Only emit transactions for executed order states
+  const filledQty = order.filledQuantity ?? 0
+  if (filledQty <= 0) return null
+
+  const action = normalizeAction(order.action)
+
+  return {
+    id: `${SOURCE}_${orderId}`,
+    source: SOURCE,
+    orderId,
+    symbol: order.symbol,
+    action,
+    quantity: filledQty,
+    price: order.avgFillPrice ?? 0,
+    currency: order.currency || 'USD',
+    commission: order.commission,
+    executedAt: order.latestTime ? new Date(order.latestTime).toISOString() : new Date().toISOString(),
+  }
+}
+
+// ── Order Transaction Detail → Transaction ────────────────────────────────
+
+export function adaptOrderTransaction(raw: TigerOrderTransaction): BrokerageTransaction | null {
+  const orderId = String(raw.orderId ?? raw.id ?? '')
+  if (!orderId) return null
+
+  return {
+    id: `${SOURCE}_txn_${orderId}`,
+    source: SOURCE,
+    orderId,
+    symbol: raw.symbol ?? '',
+    action: normalizeAction(raw.action ?? ''),
+    quantity: raw.quantity ?? 0,
+    price: raw.price ?? 0,
+    currency: raw.currency || 'USD',
+    commission: raw.commission,
+    executedAt: raw.tradeTime ? new Date(raw.tradeTime).toISOString() : new Date().toISOString(),
+  }
+}
+
+// ── Asset → Account ───────────────────────────────────────────────────────
+
+export function adaptAsset(raw: TigerAsset): BrokerageAccount {
+  return {
+    id: `${SOURCE}_${raw.currency}`,
+    source: SOURCE,
+    currency: raw.currency,
+    cashBalance: raw.cashValue ?? 0,
+    netLiquidation: raw.netLiquidation,
+    segType: undefined,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+/** Adapt a segment from the assets response into an account record */
+export function adaptAssetSegment(segment: TigerAssetSegment, currency: string): BrokerageAccount {
+  return {
+    id: `${SOURCE}_${currency}_${segment.category}`,
+    source: SOURCE,
+    currency,
+    cashBalance: segment.cashValue ?? 0,
+    netLiquidation: segment.netLiquidation,
+    segType: segment.category === 'S' ? 'SEC' : segment.category === 'C' ? 'FUT' : segment.category,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+// ── Corporate Action ──────────────────────────────────────────────────────
+
+/**
+ * Adapt Tiger fund_detail records with fund_type=CORPORATE_ACTION
+ * into normalized corp actions. Parses the description string to
+ * determine action type (dividend, split, rights, or other).
+ */
+export function adaptCorpAction(raw: TigerCorpAction): BrokerageCorpAction | null {
+  const date = raw.businessDate || new Date().toISOString().slice(0, 10)
+
+  return {
+    id: `${SOURCE}_${date}_${raw.id ?? raw.desc ?? ''}`,
+    source: SOURCE,
+    symbol: '', // Not available in fund_detail — derived from desc
+    type: classifyCorpAction(raw.desc),
+    amount: raw.amount,
+    currency: raw.currency,
+    payDate: date,
+    appliedAt: raw.transactionTime ? new Date(raw.transactionTime * 1000).toISOString() : new Date().toISOString(),
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function normalizeAction(action: string): TradeAction {
+  const upper = action.toUpperCase()
+  if (upper === 'SELL' || upper === 'SHORT') return 'SELL'
+  return 'BUY'
+}
+
+function classifyCorpAction(desc?: string): CorpActionType {
+  if (!desc) return 'OTHER'
+  const lower = desc.toLowerCase()
+  if (lower.includes('dividend') || lower.includes('div')) return 'DIVIDEND'
+  if (lower.includes('split')) return 'SPLIT'
+  if (lower.includes('right')) return 'RIGHTS'
+  return 'OTHER'
+}

--- a/apps/web/src/lib/brokerage/tiger/tiger-http-client.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-http-client.ts
@@ -1,0 +1,175 @@
+/**
+ * Tiger OpenAPI HTTP client — browser-compatible implementation using
+ * Web Crypto API for RSA signing.
+ *
+ * Replicates the auth flow from @tigeropenapi/tigeropen SDK but uses
+ * `crypto.subtle` instead of Node.js `crypto` module.
+ */
+
+import type { TigerApiRequest, TigerApiResponse, TigerClientConfig } from './tiger-types'
+
+const DEFAULT_SERVER_URL = 'https://openapi.tigerfintech.com'
+const API_VERSION = '2.0'
+
+/** Format a Date as 'yyyy-MM-dd HH:mm:ss' (Tiger API expected format) */
+function formatTimestamp(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
+export class TigerHttpError extends Error {
+  code: number
+  constructor(code: number, message: string) {
+    super(`Tiger API error ${code}: ${message}`)
+    this.code = code
+    this.name = 'TigerHttpError'
+  }
+}
+
+export class TigerAuthError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TigerAuthError'
+  }
+}
+
+/**
+ * Browser-compatible Tiger OpenAPI HTTP client using Web Crypto for RSA signing.
+ */
+/** Resolved CryptoKey instance type — works in both DOM and @types/node contexts */
+type _Key = Awaited<ReturnType<typeof crypto.subtle.importKey>>
+
+export class TigerHttpClient {
+  private config: TigerClientConfig
+  private privateKey: _Key | null = null
+
+  constructor(config: TigerClientConfig) {
+    this.config = {
+      language: 'en_US',
+      serverUrl: DEFAULT_SERVER_URL,
+      ...config,
+    }
+  }
+
+  /** Ensure the private key is imported into Web Crypto */
+  private async getPrivateKey(): Promise<_Key> {
+    if (this.privateKey) return this.privateKey
+
+    const pem = this.parsePem(this.config.privateKey)
+
+    try {
+      this.privateKey = await crypto.subtle.importKey(
+        'pkcs8',
+        pem,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-1' },
+        false,
+        ['sign']
+      )
+    } catch {
+      throw new TigerAuthError(
+        'Failed to import RSA private key. Ensure the key is in PKCS8 PEM format.\n' +
+          'If you have a PKCS1 key (-----BEGIN RSA PRIVATE KEY-----), convert it with:\n' +
+          '  openssl pkcs8 -topk8 -inform PEM -outform PEM -in key.pem -out key_pkcs8.pem -nocrypt'
+      )
+    }
+
+    return this.privateKey
+  }
+
+  /**
+   * Execute an API request. Signs the request with RSA, sends POST as JSON,
+   * verifies response signature, returns parsed data.
+   */
+  async execute<T>(request: TigerApiRequest): Promise<T> {
+    const url = `${this.config.serverUrl}/gateway`
+
+    const params = await this.buildSignedParams(request)
+    const body = JSON.stringify(params)
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      body,
+    })
+
+    if (!response.ok) {
+      throw new TigerHttpError(response.status, `HTTP ${response.status}: ${response.statusText}`)
+    }
+
+    const json = (await response.json()) as TigerApiResponse<T>
+
+    if (json.code !== 0) {
+      throw new TigerHttpError(json.code, json.message)
+    }
+
+    // The Tiger API returns `data` as a JSON-encoded string in some responses.
+    // Double-parse if needed.
+    let data = json.data
+    if (typeof data === 'string') {
+      try {
+        data = JSON.parse(data) as T
+      } catch {
+        // Not valid JSON — return as-is
+      }
+    }
+
+    return data
+  }
+
+  /** Build JSON params with RSA signature */
+  private async buildSignedParams(request: TigerApiRequest): Promise<Record<string, string>> {
+    const timestamp = formatTimestamp(new Date())
+    const params: Record<string, string> = {
+      method: request.method,
+      version: request.version || API_VERSION,
+      format: 'json',
+      charset: 'UTF-8',
+      sign_type: 'RSA',
+      timestamp,
+      biz_content: request.bizContent,
+      tiger_id: this.config.tigerId,
+      ...(this.config.language ? { language: this.config.language } : {}),
+    }
+
+    // Sort keys alphabetically and build sign string
+    const signContent = Object.keys(params)
+      .sort()
+      .map((k) => `${k}=${params[k]}`)
+      .join('&')
+
+    const key = await this.getPrivateKey()
+    const signature = await crypto.subtle.sign(
+      { name: 'RSASSA-PKCS1-v1_5' },
+      key,
+      new TextEncoder().encode(signContent)
+    )
+
+    params.sign = this.arrayBufferToBase64(signature)
+
+    return params
+  }
+
+  /** Parse a PEM string to ArrayBuffer (strips headers/footers) */
+  private parsePem(pem: string): ArrayBuffer {
+    const b64 = pem
+      .replace(/-----BEGIN .*?-----/g, '')
+      .replace(/-----END .*?-----/g, '')
+      .replace(/\s+/g, '')
+
+    const binary = atob(b64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes.buffer
+  }
+
+  private arrayBufferToBase64(buffer: ArrayBuffer): string {
+    const bytes = new Uint8Array(buffer)
+    let binary = ''
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]!)
+    }
+    return btoa(binary)
+  }
+}

--- a/apps/web/src/lib/brokerage/tiger/tiger-provider.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-provider.ts
@@ -7,14 +7,22 @@
 
 import type {
   BrokerageAccount,
-  BrokerageCorpAction,
+  BrokerageFundDetail,
   BrokeragePosition,
   BrokerageTransaction,
 } from '@lokfi/brokerage-core'
-import type { BrokerageProvider } from '@lokfi/brokerage-core'
-import { SOURCE, adaptAsset, adaptAssetSegment, adaptCorpAction, adaptOrder, adaptPosition } from './tiger-adapter'
-import { TigerHttpClient, TigerHttpError } from './tiger-http-client'
-import type { TigerAsset, TigerClientConfig, TigerCorpAction, TigerOrder, TigerPosition } from './tiger-types'
+import type { BrokerageProvider, ProviderProgress } from '@lokfi/brokerage-core'
+import {
+  SOURCE,
+  adaptAsset,
+  adaptAssetSegment,
+  adaptFundDetail,
+  adaptOrder,
+  adaptPosition,
+  enrichTradeFundDetail,
+} from './tiger-adapter'
+import { TigerHttpClient } from './tiger-http-client'
+import type { TigerAsset, TigerClientConfig, TigerFundDetail, TigerOrder, TigerPosition } from './tiger-types'
 
 export interface TigerProviderOptions {
   config: TigerClientConfig
@@ -22,11 +30,18 @@ export interface TigerProviderOptions {
   lookbackDays?: number
 }
 
+const FUND_DETAIL_PAGE_SIZE = 100
+const FUND_DETAIL_PAGE_DELAY_MS = 6100
+const TRANSACTIONS_CHUNK_DAYS = 90
+
 export class TigerProvider implements BrokerageProvider {
   readonly source = SOURCE
   readonly displayName = 'Tiger Brokers'
   private client: TigerHttpClient
   private account: string
+
+  /** Cache of last fetched filled orders for enrichment use */
+  private lastFilledOrders: BrokerageTransaction[] = []
 
   constructor(options: TigerProviderOptions) {
     this.client = new TigerHttpClient(options.config)
@@ -41,86 +56,197 @@ export class TigerProvider implements BrokerageProvider {
     })
   }
 
-  async fetchPositions(): Promise<BrokeragePosition[]> {
-    const raw = await this.client.execute<{ items?: TigerPosition[] }>({
+  async fetchPositions(_onProgress?: ProviderProgress): Promise<BrokeragePosition[]> {
+    const raw = await this.client.execute<unknown>({
       method: 'positions',
       bizContent: this.bizContent(),
     })
 
-    const positions = raw?.items ?? []
-    return positions.map(adaptPosition)
+    // Debug: log response shape
+    console.debug(
+      '[tiger-provider] Raw positions response type:',
+      typeof raw,
+      Array.isArray(raw)
+        ? 'array'
+        : typeof raw === 'object'
+          ? `object keys=${Object.keys(raw as object).join(',')}`
+          : typeof raw
+    )
+
+    // Handle both { items: [...] } and direct array responses
+    let tigerPositions: TigerPosition[]
+    if (Array.isArray(raw)) {
+      tigerPositions = raw
+    } else if (raw && typeof raw === 'object' && 'items' in (raw as Record<string, unknown>)) {
+      tigerPositions = ((raw as Record<string, unknown>).items as TigerPosition[]) ?? []
+    } else {
+      console.warn('[tiger-provider] Unexpected positions response shape — no positions returned')
+      tigerPositions = []
+    }
+
+    // Debug: log secType breakdown
+    const byType: Record<string, number> = {}
+    for (const p of tigerPositions) {
+      const t = p.secType || 'UNDEFINED'
+      byType[t] = (byType[t] ?? 0) + 1
+    }
+    console.debug('[tiger-provider] Positions by secType:', JSON.stringify(byType))
+    tigerPositions.forEach((p) => console.debug(`  secType=${p.secType} symbol=${p.symbol} qty=${p.position}`))
+
+    return tigerPositions.map(adaptPosition)
   }
 
-  async fetchTransactions(since: Date): Promise<BrokerageTransaction[]> {
+  async fetchTransactions(since: Date, _onProgress?: ProviderProgress): Promise<BrokerageTransaction[]> {
     // Strategy:
-    // 1. Get completed orders (status = Filled) wrapped in { items: [...] }
-    // 2. Filter by date range
+    // 1. Chunk the date range into ≤90-day windows (Tiger API limit)
+    // 2. Fetch completed orders (status = Filled) for each chunk
     // 3. Adapt each to normalized transaction
+    // 4. Deduplicate across chunks (safety net)
+    // 5. Cache filled orders for enrichment use in fetchFundDetails
 
-    const filledOrdersRaw = await this.client.execute<{ items?: TigerOrder[] }>({
-      method: 'filled_orders',
-      bizContent: this.bizContent({
-        start_date: since.toISOString().slice(0, 10),
-        end_date: new Date().toISOString().slice(0, 10),
-      }),
-    })
+    const endDate = new Date()
+    const chunks = this.getDateChunks(since, endDate, TRANSACTIONS_CHUNK_DAYS)
 
-    const filledOrders = filledOrdersRaw?.items ?? []
-    const transactions: BrokerageTransaction[] = []
+    const allTransactions: BrokerageTransaction[] = []
 
-    for (const order of filledOrders) {
-      const txn = adaptOrder(order)
-      if (txn && new Date(txn.executedAt) >= since) {
-        transactions.push(txn)
-      }
+    for (const { start, end } of chunks) {
+      const filledOrdersRaw = await this.client.execute<{ items?: TigerOrder[] }>({
+        method: 'filled_orders',
+        bizContent: this.bizContent({
+          start_date: start.toISOString().slice(0, 10),
+          end_date: end.toISOString().slice(0, 10),
+        }),
+      })
 
-      // Also fetch detailed transaction records per order
-      if (order.orderId) {
-        try {
-          const detail = await this.client.execute<{ items?: unknown[] }>({
-            method: 'order_transactions',
-            bizContent: this.bizContent({ id: order.orderId }),
-          })
-          const txnItems = detail?.items ?? []
-          if (txnItems.length > 0) {
-            // Per-fill transaction records — extends the order-level data
+      const filledOrders = filledOrdersRaw?.items ?? []
+
+      for (const order of filledOrders) {
+        const txn = adaptOrder(order)
+        if (txn && new Date(txn.executedAt) >= since) {
+          allTransactions.push(txn)
+        }
+
+        // Also fetch detailed transaction records per order
+        if (order.orderId) {
+          try {
+            const detail = await this.client.execute<{ items?: unknown[] }>({
+              method: 'order_transactions',
+              bizContent: this.bizContent({ id: order.orderId }),
+            })
+            const txnItems = detail?.items ?? []
+            if (txnItems.length > 0) {
+              // Per-fill transaction records — extends the order-level data
+            }
+          } catch {
+            // Non-critical — order-level data is sufficient
           }
-        } catch {
-          // Non-critical — order-level data is sufficient
         }
       }
     }
 
-    return transactions
+    // Deduplicate by id across chunks (safety net in case an order's
+    // execution date straddles a chunk boundary)
+    const seen = new Set<string>()
+    const deduped = allTransactions.filter((txn) => {
+      if (seen.has(txn.id)) return false
+      seen.add(txn.id)
+      return true
+    })
+
+    // Cache filled orders for enrichment
+    this.lastFilledOrders = deduped
+
+    return deduped
   }
 
-  async fetchCorpActions(since: Date): Promise<BrokerageCorpAction[]> {
-    // Tiger exposes corporate actions via fund_details with fund_type=7 (CORPORATE_ACTION)
-    // Response is wrapped in { items: [...] }
-    try {
-      const raw = await this.client.execute<{ items?: TigerCorpAction[] }>({
+  async fetchFundDetails(since: Date, onProgress?: ProviderProgress): Promise<BrokerageFundDetail[]> {
+    const endDate = new Date().toISOString().slice(0, 10)
+    const startDate = since.toISOString().slice(0, 10)
+
+    // Tiger fund_details response includes pagination metadata at the top level.
+    // The API expects offset-based pagination via `start` (not `page`).
+    // We parse pageCount from the first response to know how many pages to request.
+    type FundDetailResponse = {
+      items?: TigerFundDetail[]
+      page?: number
+      limit?: number
+      itemCount?: number
+      pageCount?: number
+    }
+
+    // Fetch first page (offset 0) to discover total page count
+    onProgress?.('Fetching page 1...')
+    const firstPage = await this.client.execute<FundDetailResponse>({
+      method: 'fund_details',
+      bizContent: this.bizContent({
+        fund_type: 'ALL',
+        seg_types: ['SEC'],
+        start_date: startDate,
+        end_date: endDate,
+        limit: FUND_DETAIL_PAGE_SIZE,
+        start: 0,
+      }),
+    })
+
+    const totalPageCount = firstPage?.pageCount ?? 1
+    const allRaw: TigerFundDetail[] = firstPage?.items ?? []
+
+    // Fetch remaining pages (2 through pageCount) using offset-based pagination
+    for (let page = 2; page <= totalPageCount; page++) {
+      onProgress?.(`Fetching page ${page}/${totalPageCount}...`)
+      const raw = await this.client.execute<FundDetailResponse>({
         method: 'fund_details',
         bizContent: this.bizContent({
-          fund_type: 'CORPORATE_ACTION',
+          fund_type: 'ALL',
           seg_types: ['SEC'],
-          start_date: since.toISOString().slice(0, 10),
-          end_date: new Date().toISOString().slice(0, 10),
+          start_date: startDate,
+          end_date: endDate,
+          limit: FUND_DETAIL_PAGE_SIZE,
+          start: (page - 1) * FUND_DETAIL_PAGE_SIZE,
         }),
       })
 
-      const actions = raw?.items ?? []
-      return actions.map(adaptCorpAction).filter((a): a is BrokerageCorpAction => a !== null)
-    } catch (err) {
-      // Corporate actions may not be available on all accounts.
-      // Log the error at the orchestrator level so it appears in sync_log.
-      if (err instanceof TigerHttpError) {
-        throw err
+      const pageItems = raw?.items ?? []
+      allRaw.push(...pageItems)
+
+      // Delay between pages to respect rate limits (after each page except the last)
+      if (page < totalPageCount) {
+        onProgress?.(`Pausing before page ${page + 1}/${totalPageCount}...`)
       }
-      throw err
+      if (page < totalPageCount) {
+        await new Promise((resolve) => setTimeout(resolve, FUND_DETAIL_PAGE_DELAY_MS))
+      }
     }
+
+    // Deduplicate by id — safety net in case the API returns overlapping data
+    // across pages (e.g. due to data changes during pagination).
+    const seen = new Set<string>()
+    const deduped = allRaw.filter((item) => {
+      const key = String(item.id ?? '')
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+    // Adapt each raw record
+    onProgress?.(`Adapting ${deduped.length} records...`)
+    const adapted = deduped.map(adaptFundDetail).filter((fd): fd is BrokerageFundDetail => fd !== null)
+
+    // Enrich TRADE records with filled order data
+    if (this.lastFilledOrders.length > 0) {
+      const enriched = adapted.map((fd) => {
+        if (fd.classifiedType === 'TRADE') {
+          return enrichTradeFundDetail(fd, this.lastFilledOrders)
+        }
+        return fd
+      })
+      return enriched
+    }
+
+    return adapted
   }
 
-  async fetchAccount(): Promise<BrokerageAccount[]> {
+  async fetchAccount(_onProgress?: ProviderProgress): Promise<BrokerageAccount[]> {
     // Assets response: { items: TigerAsset[] } where each item has segments[]
     type AssetResponse = { items?: TigerAsset[] }
     const accounts: BrokerageAccount[] = []
@@ -162,6 +288,33 @@ export class TigerProvider implements BrokerageProvider {
     }
 
     return accounts
+  }
+
+  /**
+   * Split a date range into chunks no larger than maxDays.
+   * Tiger's filled_orders API has a 90-day window limit, so this is used
+   * to fetch all-time transaction history in compliant segments.
+   */
+  private getDateChunks(start: Date, end: Date, maxDays: number): { start: Date; end: Date }[] {
+    if (start >= end) return []
+
+    const chunks: { start: Date; end: Date }[] = []
+    const current = new Date(start)
+
+    while (current < end) {
+      const chunkEnd = new Date(current)
+      chunkEnd.setDate(chunkEnd.getDate() + maxDays)
+
+      if (chunkEnd >= end) {
+        chunks.push({ start: new Date(current), end: new Date(end) })
+        break
+      }
+
+      chunks.push({ start: new Date(current), end: new Date(chunkEnd) })
+      current.setTime(chunkEnd.getTime())
+    }
+
+    return chunks
   }
 
   async validateConnection(): Promise<boolean> {

--- a/apps/web/src/lib/brokerage/tiger/tiger-provider.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-provider.ts
@@ -1,0 +1,179 @@
+/**
+ * Tiger brokerage provider — wraps the TigerHttpClient, fetches data
+ * from the Tiger OpenAPI, and maps responses to normalized types.
+ *
+ * Implements BrokerageProvider from @lokfi/brokerage-core.
+ */
+
+import type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokeragePosition,
+  BrokerageTransaction,
+} from '@lokfi/brokerage-core'
+import type { BrokerageProvider } from '@lokfi/brokerage-core'
+import { SOURCE, adaptAsset, adaptAssetSegment, adaptCorpAction, adaptOrder, adaptPosition } from './tiger-adapter'
+import { TigerHttpClient, TigerHttpError } from './tiger-http-client'
+import type { TigerAsset, TigerClientConfig, TigerCorpAction, TigerOrder, TigerPosition } from './tiger-types'
+
+export interface TigerProviderOptions {
+  config: TigerClientConfig
+  /** Lookback window for transaction/corp action history (days) */
+  lookbackDays?: number
+}
+
+export class TigerProvider implements BrokerageProvider {
+  readonly source = SOURCE
+  readonly displayName = 'Tiger Brokers'
+  private client: TigerHttpClient
+  private account: string
+
+  constructor(options: TigerProviderOptions) {
+    this.client = new TigerHttpClient(options.config)
+    this.account = options.config.account
+  }
+
+  /** Build bizContent JSON string with account injected */
+  private bizContent(extra?: Record<string, unknown>): string {
+    return JSON.stringify({
+      account: this.account,
+      ...extra,
+    })
+  }
+
+  async fetchPositions(): Promise<BrokeragePosition[]> {
+    const raw = await this.client.execute<{ items?: TigerPosition[] }>({
+      method: 'positions',
+      bizContent: this.bizContent(),
+    })
+
+    const positions = raw?.items ?? []
+    return positions.map(adaptPosition)
+  }
+
+  async fetchTransactions(since: Date): Promise<BrokerageTransaction[]> {
+    // Strategy:
+    // 1. Get completed orders (status = Filled) wrapped in { items: [...] }
+    // 2. Filter by date range
+    // 3. Adapt each to normalized transaction
+
+    const filledOrdersRaw = await this.client.execute<{ items?: TigerOrder[] }>({
+      method: 'filled_orders',
+      bizContent: this.bizContent({
+        start_date: since.toISOString().slice(0, 10),
+        end_date: new Date().toISOString().slice(0, 10),
+      }),
+    })
+
+    const filledOrders = filledOrdersRaw?.items ?? []
+    const transactions: BrokerageTransaction[] = []
+
+    for (const order of filledOrders) {
+      const txn = adaptOrder(order)
+      if (txn && new Date(txn.executedAt) >= since) {
+        transactions.push(txn)
+      }
+
+      // Also fetch detailed transaction records per order
+      if (order.orderId) {
+        try {
+          const detail = await this.client.execute<{ items?: unknown[] }>({
+            method: 'order_transactions',
+            bizContent: this.bizContent({ id: order.orderId }),
+          })
+          const txnItems = detail?.items ?? []
+          if (txnItems.length > 0) {
+            // Per-fill transaction records — extends the order-level data
+          }
+        } catch {
+          // Non-critical — order-level data is sufficient
+        }
+      }
+    }
+
+    return transactions
+  }
+
+  async fetchCorpActions(since: Date): Promise<BrokerageCorpAction[]> {
+    // Tiger exposes corporate actions via fund_details with fund_type=7 (CORPORATE_ACTION)
+    // Response is wrapped in { items: [...] }
+    try {
+      const raw = await this.client.execute<{ items?: TigerCorpAction[] }>({
+        method: 'fund_details',
+        bizContent: this.bizContent({
+          fund_type: 'CORPORATE_ACTION',
+          seg_types: ['SEC'],
+          start_date: since.toISOString().slice(0, 10),
+          end_date: new Date().toISOString().slice(0, 10),
+        }),
+      })
+
+      const actions = raw?.items ?? []
+      return actions.map(adaptCorpAction).filter((a): a is BrokerageCorpAction => a !== null)
+    } catch (err) {
+      // Corporate actions may not be available on all accounts.
+      // Log the error at the orchestrator level so it appears in sync_log.
+      if (err instanceof TigerHttpError) {
+        throw err
+      }
+      throw err
+    }
+  }
+
+  async fetchAccount(): Promise<BrokerageAccount[]> {
+    // Assets response: { items: TigerAsset[] } where each item has segments[]
+    type AssetResponse = { items?: TigerAsset[] }
+    const accounts: BrokerageAccount[] = []
+
+    // Fetch standard assets
+    const standard = await this.client.execute<AssetResponse>({
+      method: 'assets',
+      bizContent: this.bizContent(),
+    })
+
+    const items = standard?.items ?? []
+    for (const item of items) {
+      accounts.push(adaptAsset(item))
+      // Also add per-segment records
+      if (item.segments) {
+        for (const seg of item.segments) {
+          accounts.push(adaptAssetSegment(seg, item.currency))
+        }
+      }
+    }
+
+    // Prime assets may fail if account doesn't have futures permissions
+    try {
+      const prime = await this.client.execute<AssetResponse>({
+        method: 'prime_assets',
+        bizContent: this.bizContent(),
+      })
+      const primeItems = prime?.items ?? []
+      for (const item of primeItems) {
+        accounts.push(adaptAsset(item))
+        if (item.segments) {
+          for (const seg of item.segments) {
+            accounts.push(adaptAssetSegment(seg, item.currency))
+          }
+        }
+      }
+    } catch {
+      // Non-critical — prime assets unavailable
+    }
+
+    return accounts
+  }
+
+  async validateConnection(): Promise<boolean> {
+    try {
+      // Use assets as a lightweight connectivity check
+      await this.client.execute<{ items?: TigerAsset[] }>({
+        method: 'assets',
+        bizContent: this.bizContent(),
+      })
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/apps/web/src/lib/brokerage/tiger/tiger-types.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-types.ts
@@ -169,21 +169,29 @@ export interface TigerAssetSegment {
   buyingPower?: number
 }
 
-// ── Corporate Action (fund_detail with fund_type=CORPORATE_ACTION) ────────
+// TigerCorpAction removed — superseded by TigerFundDetail (see below)
 
-export interface TigerCorpAction {
+// ── Fund Detail (fund_detail with fund_type=ALL) ──────────────────────────
+
+export interface TigerFundDetail {
   /** Fund change record ID */
   id?: number
   account: string
   currency?: string
   amount?: number
-  /** Description (e.g. "AAPL Dividend") */
+  /** Description (e.g. "Buy-AVGO", "XDTE-DIVIDEND", "Funds Transfer In") */
   desc?: string
-  /** Business date of the action */
+  /** Fund type string (e.g. "Trade", "Commission", "Dividend", "Dividend Tax") */
+  type?: string
+  /** Contract/company display name */
+  contractName?: string
+  /** Segment type (e.g. 'SEC') */
+  segType?: string
+  /** Business date (ISO-8601 date string) */
   businessDate?: string
-  /** Fund type: 7 = CORPORATE_ACTION */
-  fundType?: string
-  /** Transaction time (ISO-8601 or timestamp) */
+  /** Last update timestamp (epoch seconds) */
+  updatedAt?: number
+  /** Transaction timestamp (epoch seconds) */
   transactionTime?: number
 }
 

--- a/apps/web/src/lib/brokerage/tiger/tiger-types.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-types.ts
@@ -1,0 +1,198 @@
+/**
+ * Tiger OpenAPI type definitions — mirrors the internal types from the
+ * @tigeropenapi/tigeropen SDK (src/model/*) since the SDK's compiled
+ * declarations don't export model types and it's Node.js-only anyway.
+ */
+
+// ── Enums ─────────────────────────────────────────────────────────────────
+
+export const TigerMarket = {
+  US: 'US',
+  HK: 'HK',
+  CN: 'CN',
+  SG: 'SG',
+} as const
+export type TigerMarket = (typeof TigerMarket)[keyof typeof TigerMarket]
+
+export const TigerSecType = {
+  STK: 'STK',
+  OPT: 'OPT',
+  FUT: 'FUT',
+  FOP: 'FOP',
+  CASH: 'CASH',
+  FUND: 'FUND',
+  WAR: 'WAR',
+  MLEG: 'MLEG',
+} as const
+export type TigerSecType = (typeof TigerSecType)[keyof typeof TigerSecType]
+
+export const TigerCurrency = {
+  USD: 'USD',
+  HKD: 'HKD',
+  CNH: 'CNH',
+  SGD: 'SGD',
+} as const
+export type TigerCurrency = (typeof TigerCurrency)[keyof typeof TigerCurrency]
+
+export const TigerOrderStatus = {
+  Submitted: 'Submitted',
+  PartiallyFilled: 'PartiallyFilled',
+  Filled: 'Filled',
+  Cancelled: 'Cancelled',
+  Inactive: 'Inactive',
+} as const
+export type TigerOrderStatus = (typeof TigerOrderStatus)[keyof typeof TigerOrderStatus]
+
+// ── API Request / Response ────────────────────────────────────────────────
+
+export interface TigerApiRequest {
+  method: string
+  bizContent: string
+  version?: string
+}
+
+export interface TigerApiResponse<T = unknown> {
+  code: number
+  message: string
+  data: T
+  timestamp: number
+  sign?: string
+}
+
+// ── Position ──────────────────────────────────────────────────────────────
+
+export interface TigerPosition {
+  account: string
+  symbol: string
+  secType: string
+  market?: string
+  currency?: string
+  /** Current position quantity */
+  position: number
+  positionScale?: number
+  positionQty?: number
+  salableQty?: number
+  averageCost: number
+  averageCostByAverage?: number
+  marketValue?: number
+  realizedPnl?: number
+  unrealizedPnl?: number
+  unrealizedPnlByAverage?: number
+  unrealizedPnlPercent?: number
+  contractId?: number
+  identifier?: string
+  name?: string
+  latestPrice?: number
+  multiplier?: number
+}
+
+// ── Order ─────────────────────────────────────────────────────────────────
+
+export interface TigerOrder {
+  account: string
+  id?: number
+  orderId?: number
+  action: string
+  orderType: string
+  totalQuantity: number
+  limitPrice?: number
+  status?: string
+  filledQuantity?: number
+  avgFillPrice?: number
+  timeInForce: string
+  outsideRth: boolean
+  symbol: string
+  secType: string
+  market?: string
+  currency?: string
+  identifier?: string
+  name?: string
+  commission?: number
+  realizedPnl?: number
+  openTime?: number
+  updateTime?: number
+  latestTime?: number
+  remark?: string
+}
+
+// ── Transaction (order fill detail) ───────────────────────────────────────
+
+export interface TigerOrderTransaction {
+  account: string
+  id?: number
+  orderId?: number
+  symbol?: string
+  secType?: string
+  action?: string
+  quantity?: number
+  price?: number
+  currency?: string
+  commission?: number
+  tradeTime?: number
+}
+
+// ── Asset ─────────────────────────────────────────────────────────────────
+
+/** Per-currency-segment account asset data */
+export interface TigerAsset {
+  account: string
+  currency: string
+  capability?: string
+  /** Cash value (securities segment) / available funds */
+  cashValue?: number
+  /** Net liquidation value */
+  netLiquidation?: number
+  /** Buying power */
+  buyingPower?: number
+  /** Realized P&L */
+  realizedPnL?: number
+  /** Unrealized P&L */
+  unrealizedPnL?: number
+  /** Segment details */
+  segments?: TigerAssetSegment[]
+}
+
+export interface TigerAssetSegment {
+  account: string
+  /** 'S' = securities, 'C' = commodities/futures */
+  category: string
+  title?: string
+  netLiquidation?: number
+  cashValue?: number
+  availableFunds?: number
+  equityWithLoan?: number
+  excessLiquidity?: number
+  accruedCash?: number
+  accruedDividend?: number
+  initMarginReq?: number
+  maintMarginReq?: number
+  buyingPower?: number
+}
+
+// ── Corporate Action (fund_detail with fund_type=CORPORATE_ACTION) ────────
+
+export interface TigerCorpAction {
+  /** Fund change record ID */
+  id?: number
+  account: string
+  currency?: string
+  amount?: number
+  /** Description (e.g. "AAPL Dividend") */
+  desc?: string
+  /** Business date of the action */
+  businessDate?: string
+  /** Fund type: 7 = CORPORATE_ACTION */
+  fundType?: string
+  /** Transaction time (ISO-8601 or timestamp) */
+  transactionTime?: number
+}
+
+// ── Client Config ─────────────────────────────────────────────────────────
+
+export interface TigerClientConfig {
+  tigerId: string
+  privateKey: string
+  account: string
+  language?: string
+  serverUrl?: string
+}

--- a/apps/web/src/lib/brokerage/unifiedTransactions.test.ts
+++ b/apps/web/src/lib/brokerage/unifiedTransactions.test.ts
@@ -1,7 +1,7 @@
-import type { BrokerageCorpAction, BrokerageTransaction } from '@lokfi/brokerage-core'
+import type { BrokerageFundDetail, BrokerageTransaction } from '@lokfi/brokerage-core'
 import { describe, expect, it } from 'vitest'
 import type { DbTransaction } from '../db/db'
-import { mapBankTransaction, mapBrokerageTransaction, mapCorpAction } from './unifiedTransactions'
+import { mapBankTransaction, mapBrokerageTransaction, mapFundDetail } from './unifiedTransactions'
 
 describe('mapBankTransaction', () => {
   it('maps a bank transaction correctly', () => {
@@ -78,38 +78,152 @@ describe('mapBrokerageTransaction', () => {
   })
 })
 
-describe('mapCorpAction', () => {
-  it('maps a DIVIDEND corp action', () => {
-    const a: BrokerageCorpAction = {
-      id: 'ca-1',
+describe('mapFundDetail', () => {
+  it('maps a DIVIDEND', () => {
+    const d: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
       source: 'tiger',
+      rawType: 'Dividend',
+      classifiedType: 'DIVIDEND',
       symbol: 'AAPL',
-      type: 'DIVIDEND',
       amount: 12.5,
       currency: 'USD',
-      payDate: '2024-03-20',
-      appliedAt: '2024-03-20T12:00:00Z',
+      businessDate: '2024-03-20',
     }
-    const rows = mapCorpAction(a)
+    const rows = mapFundDetail(d)
     expect(rows).toHaveLength(1)
     expect(rows[0]!.type).toBe('DIVIDEND')
     expect(rows[0]!.amount).toBe(12.5)
-    expect(rows[0]!.description).toBe('AAPL Dividend — $12.50')
+    expect(rows[0]!.description).toContain('AAPL Dividend')
   })
 
-  it('maps a SPLIT corp action', () => {
-    const a: BrokerageCorpAction = {
-      id: 'ca-2',
+  it('maps a DIVIDEND_TAX withheld (negative amount)', () => {
+    const d: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
       source: 'tiger',
-      symbol: 'AAPL',
-      type: 'SPLIT',
-      appliedAt: '2024-03-21T08:00:00Z',
+      rawType: 'Dividend Tax',
+      classifiedType: 'DIVIDEND_TAX',
+      symbol: 'XDTE',
+      amount: -28.24,
+      currency: 'USD',
+      businessDate: '2024-03-20',
     }
-    const rows = mapCorpAction(a)
+    const rows = mapFundDetail(d)
     expect(rows).toHaveLength(1)
-    expect(rows[0]!.type).toBe('SPLIT')
-    expect(rows[0]!.amount).toBe(0)
-    expect(rows[0]!.description).toBe('AAPL SPLIT')
+    expect(rows[0]!.type).toBe('DIVIDEND_TAX')
+    expect(rows[0]!.amount).toBe(-28.24)
+    expect(rows[0]!.description).toContain('Dividend Tax withheld')
+  })
+
+  it('maps a DIVIDEND_TAX refund (positive amount)', () => {
+    const d: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
+      source: 'tiger',
+      rawType: 'Dividend Tax',
+      classifiedType: 'DIVIDEND_TAX',
+      symbol: 'XDTE',
+      amount: 5.0,
+      currency: 'USD',
+      businessDate: '2024-03-20',
+    }
+    const rows = mapFundDetail(d)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('DIVIDEND_TAX')
+    expect(rows[0]!.amount).toBe(5.0)
+    expect(rows[0]!.description).toContain('refund (return of capital)')
+  })
+
+  it('maps a TRADE enriched', () => {
+    const d: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
+      source: 'tiger',
+      rawType: 'Trade',
+      classifiedType: 'TRADE',
+      symbol: 'AVGO',
+      action: 'BUY',
+      quantity: 10,
+      price: 200.88,
+      commission: 1.99,
+      amount: -2008.8,
+      currency: 'USD',
+      businessDate: '2024-03-20',
+    }
+    const rows = mapFundDetail(d)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('BUY')
+    expect(rows[0]!.symbol).toBe('AVGO')
+    expect(rows[0]!.quantity).toBe(10)
+    expect(rows[0]!.price).toBe(200.88)
+  })
+
+  it('maps a TRADE unenriched', () => {
+    const d: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
+      source: 'tiger',
+      rawType: 'Trade',
+      classifiedType: 'TRADE',
+      symbol: 'AVGO',
+      amount: -2008.8,
+      currency: 'USD',
+      businessDate: '2024-03-20',
+    }
+    const rows = mapFundDetail(d)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('BUY')
+    expect(rows[0]!.amount).toBe(-2008.8)
+    expect(rows[0]!.description).toContain('Trade AVGO')
+  })
+
+  it('maps a FEE', () => {
+    const d: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
+      source: 'tiger',
+      rawType: 'Platform Fee',
+      classifiedType: 'FEE',
+      symbol: 'AVGO',
+      amount: -1.99,
+      currency: 'USD',
+      businessDate: '2024-03-20',
+    }
+    const rows = mapFundDetail(d)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('FEE')
+    expect(rows[0]!.amount).toBe(-1.99)
+    expect(rows[0]!.description).toContain('Platform Fee')
+  })
+
+  it('maps a TRANSFER_IN', () => {
+    const d: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
+      source: 'tiger',
+      rawType: 'Transfer',
+      classifiedType: 'TRANSFER_IN',
+      amount: 20.29,
+      currency: 'USD',
+      businessDate: '2024-03-20',
+    }
+    const rows = mapFundDetail(d)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('TRANSFER_IN')
+    expect(rows[0]!.amount).toBe(20.29)
+    expect(rows[0]!.description).toContain('Funds Transfer In')
+  })
+
+  it('maps a REBATE', () => {
+    const d: BrokerageFundDetail = {
+      id: 'tiger_fund_1',
+      source: 'tiger',
+      rawType: 'Campaign Subsidy',
+      classifiedType: 'REBATE',
+      amount: 0.5,
+      currency: 'USD',
+      businessDate: '2024-03-20',
+    }
+    const rows = mapFundDetail(d)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('REBATE')
+    expect(rows[0]!.amount).toBe(0.5)
+    expect(rows[0]!.description).toContain('Rebate')
   })
 })
 
@@ -136,16 +250,18 @@ describe('date sorting', () => {
       currency: 'USD',
       executedAt: '2024-03-15T12:00:00Z',
     }
-    const dividend: BrokerageCorpAction = {
+    const dividend: BrokerageFundDetail = {
       id: 'd1',
       source: 'tiger',
+      rawType: 'Dividend',
+      classifiedType: 'DIVIDEND',
       symbol: 'X',
-      type: 'DIVIDEND',
       amount: 5,
-      appliedAt: '2024-03-12T00:00:00Z',
+      currency: 'USD',
+      businessDate: '2024-03-12',
     }
 
-    const rows = [mapBankTransaction(bank), ...mapBrokerageTransaction(brokerage), ...mapCorpAction(dividend)]
+    const rows = [mapBankTransaction(bank), ...mapBrokerageTransaction(brokerage), ...mapFundDetail(dividend)]
     rows.sort((a, b) => b.date.localeCompare(a.date))
 
     expect(rows[0]!.date).toBe('2024-03-15T12:00:00Z')

--- a/apps/web/src/lib/brokerage/unifiedTransactions.test.ts
+++ b/apps/web/src/lib/brokerage/unifiedTransactions.test.ts
@@ -1,0 +1,155 @@
+import type { BrokerageCorpAction, BrokerageTransaction } from '@lokfi/brokerage-core'
+import { describe, expect, it } from 'vitest'
+import type { DbTransaction } from '../db/db'
+import { mapBankTransaction, mapBrokerageTransaction, mapCorpAction } from './unifiedTransactions'
+
+describe('mapBankTransaction', () => {
+  it('maps a bank transaction correctly', () => {
+    const t: DbTransaction = {
+      id: 'txn-1',
+      hash: 'txn-1',
+      source: 'dbs',
+      accountNo: '123-4-56789-0',
+      date: '2024-03-15',
+      description: 'Grocery Store',
+      transactionValue: -45.67,
+      importedAt: '2024-03-15T10:00:00Z',
+    }
+    const row = mapBankTransaction(t)
+    expect(row.id).toBe('txn-1')
+    expect(row.source).toBe('dbs')
+    expect(row.date).toBe('2024-03-15T00:00:00Z')
+    expect(row.description).toBe('Grocery Store')
+    expect(row.amount).toBe(-45.67)
+    expect(row.currency).toBe('SGD')
+    expect(row.type).toBe('BANK')
+    expect(row.isBank).toBe(true)
+    expect(row.originalBank).toBe(t)
+  })
+})
+
+describe('mapBrokerageTransaction', () => {
+  it('maps a BUY transaction with commission', () => {
+    const t: BrokerageTransaction = {
+      id: 'order-1',
+      source: 'tiger',
+      orderId: 'order-1',
+      symbol: 'AAPL',
+      action: 'BUY',
+      quantity: 10,
+      price: 185,
+      currency: 'USD',
+      commission: 1.5,
+      executedAt: '2024-03-15T14:30:00Z',
+    }
+    const rows = mapBrokerageTransaction(t)
+    expect(rows).toHaveLength(2)
+
+    const main = rows[0]!
+    expect(main.type).toBe('BUY')
+    expect(main.symbol).toBe('AAPL')
+    expect(main.amount).toBe(-(10 * 185 + 1.5))
+    expect(main.currency).toBe('USD')
+    expect(main.description).toBe('BUY AAPL — 10 shares @ $185.00')
+
+    const fee = rows[1]!
+    expect(fee.type).toBe('FEE')
+    expect(fee.amount).toBe(-1.5)
+    expect(fee.description).toBe('Commission Fee — $1.50')
+  })
+
+  it('maps a SELL transaction without commission', () => {
+    const t: BrokerageTransaction = {
+      id: 'order-2',
+      source: 'tiger',
+      orderId: 'order-2',
+      symbol: 'NVDA',
+      action: 'SELL',
+      quantity: 5,
+      price: 245,
+      currency: 'USD',
+      executedAt: '2024-03-16T10:00:00Z',
+    }
+    const rows = mapBrokerageTransaction(t)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('SELL')
+    expect(rows[0]!.amount).toBe(5 * 245)
+    expect(rows[0]!.description).toBe('SELL NVDA — 5 shares @ $245.00')
+  })
+})
+
+describe('mapCorpAction', () => {
+  it('maps a DIVIDEND corp action', () => {
+    const a: BrokerageCorpAction = {
+      id: 'ca-1',
+      source: 'tiger',
+      symbol: 'AAPL',
+      type: 'DIVIDEND',
+      amount: 12.5,
+      currency: 'USD',
+      payDate: '2024-03-20',
+      appliedAt: '2024-03-20T12:00:00Z',
+    }
+    const rows = mapCorpAction(a)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('DIVIDEND')
+    expect(rows[0]!.amount).toBe(12.5)
+    expect(rows[0]!.description).toBe('AAPL Dividend — $12.50')
+  })
+
+  it('maps a SPLIT corp action', () => {
+    const a: BrokerageCorpAction = {
+      id: 'ca-2',
+      source: 'tiger',
+      symbol: 'AAPL',
+      type: 'SPLIT',
+      appliedAt: '2024-03-21T08:00:00Z',
+    }
+    const rows = mapCorpAction(a)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.type).toBe('SPLIT')
+    expect(rows[0]!.amount).toBe(0)
+    expect(rows[0]!.description).toBe('AAPL SPLIT')
+  })
+})
+
+describe('date sorting', () => {
+  it('sorts bank and brokerage rows by date descending', () => {
+    const bank: DbTransaction = {
+      id: 'b1',
+      hash: 'b1',
+      source: 'dbs',
+      accountNo: '1',
+      date: '2024-03-10',
+      description: 'Old',
+      transactionValue: -10,
+      importedAt: '2024-03-10T00:00:00Z',
+    }
+    const brokerage: BrokerageTransaction = {
+      id: 't1',
+      source: 'tiger',
+      orderId: 't1',
+      symbol: 'X',
+      action: 'BUY',
+      quantity: 1,
+      price: 1,
+      currency: 'USD',
+      executedAt: '2024-03-15T12:00:00Z',
+    }
+    const dividend: BrokerageCorpAction = {
+      id: 'd1',
+      source: 'tiger',
+      symbol: 'X',
+      type: 'DIVIDEND',
+      amount: 5,
+      appliedAt: '2024-03-12T00:00:00Z',
+    }
+
+    const rows = [mapBankTransaction(bank), ...mapBrokerageTransaction(brokerage), ...mapCorpAction(dividend)]
+    rows.sort((a, b) => b.date.localeCompare(a.date))
+
+    expect(rows[0]!.date).toBe('2024-03-15T12:00:00Z')
+    expect(rows[1]!.date).toBe('2024-03-12T00:00:00Z')
+    expect(rows[2]!.date).toBe('2024-03-10T00:00:00Z')
+  })
+})

--- a/apps/web/src/lib/brokerage/unifiedTransactions.ts
+++ b/apps/web/src/lib/brokerage/unifiedTransactions.ts
@@ -1,0 +1,264 @@
+import type { BrokerageCorpAction, BrokerageTransaction } from '@lokfi/brokerage-core'
+import { useLiveQuery } from 'dexie-react-hooks'
+import type { Filters } from '../../pages/transactions/filterTypes'
+import { type DbTransaction, db } from '../db/db'
+
+/** Brokerage-specific row types displayed in the unified view */
+export type BrokerageRowType = 'BUY' | 'SELL' | 'DIVIDEND' | 'FEE' | 'SPLIT' | 'RIGHTS' | 'OTHER' | 'CORP ACTION'
+
+/** Common row shape for both bank and brokerage transactions in the UI */
+export interface UnifiedTransactionRow {
+  id: string
+  source: string
+  /** ISO-8601 timestamp used for sorting */
+  date: string
+  description: string
+  amount: number
+  currency: string
+  type: 'BANK' | BrokerageRowType
+  symbol?: string
+  quantity?: number
+  price?: number
+  isBank: boolean
+  /** Original bank record — present only when `isBank` is true */
+  originalBank?: DbTransaction
+  /** Original brokerage record — present only when `isBank` is false */
+  originalBrokerage?: BrokerageTransaction | BrokerageCorpAction
+}
+
+// ── Formatting helpers ──────────────────────────────────────────────────────
+
+function fmtCurrency(amount: number, currency: string): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(amount)
+}
+
+/** Normalise a date string for reliable lexicographic sorting */
+function toComparableDate(dateStr: string): string {
+  if (dateStr.length === 10) return `${dateStr}T00:00:00Z`
+  return dateStr
+}
+
+// ── Mappers ─────────────────────────────────────────────────────────────────
+
+/** Map a bank DbTransaction to a UnifiedTransactionRow */
+export function mapBankTransaction(t: DbTransaction): UnifiedTransactionRow {
+  return {
+    id: t.id,
+    source: t.source,
+    date: `${t.date}T00:00:00Z`,
+    description: t.description,
+    amount: t.transactionValue,
+    currency: 'SGD',
+    type: 'BANK',
+    isBank: true,
+    originalBank: t,
+  }
+}
+
+/** Map a BrokerageTransaction to one or more UnifiedTransactionRows */
+export function mapBrokerageTransaction(t: BrokerageTransaction): UnifiedTransactionRow[] {
+  const rows: UnifiedTransactionRow[] = []
+  const date = t.executedAt
+
+  const gross = t.quantity * t.price
+  const commission = t.commission ?? 0
+  const total = t.action === 'BUY' ? -(gross + commission) : gross - commission
+
+  rows.push({
+    id: `bt-${t.id}`,
+    source: t.source,
+    date,
+    description: `${t.action} ${t.symbol} — ${t.quantity} shares @ ${fmtCurrency(t.price, t.currency)}`,
+    amount: total,
+    currency: t.currency,
+    type: t.action,
+    symbol: t.symbol,
+    quantity: t.quantity,
+    price: t.price,
+    isBank: false,
+    originalBrokerage: t,
+  })
+
+  if (commission > 0) {
+    rows.push({
+      id: `bt-${t.id}-fee`,
+      source: t.source,
+      date,
+      description: `Commission Fee — ${fmtCurrency(commission, t.currency)}`,
+      amount: -commission,
+      currency: t.currency,
+      type: 'FEE',
+      symbol: t.symbol,
+      isBank: false,
+      originalBrokerage: t,
+    })
+  }
+
+  return rows
+}
+
+/** Map a BrokerageCorpAction to one or more UnifiedTransactionRows */
+export function mapCorpAction(a: BrokerageCorpAction): UnifiedTransactionRow[] {
+  const rows: UnifiedTransactionRow[] = []
+  const date = a.appliedAt || a.payDate || a.exDate || '1970-01-01T00:00:00Z'
+
+  if (a.type === 'DIVIDEND' && a.amount !== undefined) {
+    rows.push({
+      id: `ca-${a.id}`,
+      source: a.source,
+      date,
+      description: `${a.symbol} Dividend — ${fmtCurrency(a.amount, a.currency ?? 'USD')}`,
+      amount: a.amount,
+      currency: a.currency ?? 'USD',
+      type: 'DIVIDEND',
+      symbol: a.symbol,
+      isBank: false,
+      originalBrokerage: a,
+    })
+  } else {
+    rows.push({
+      id: `ca-${a.id}`,
+      source: a.source,
+      date,
+      description: `${a.symbol} ${a.type}${a.amount ? ` — ${fmtCurrency(a.amount, a.currency ?? 'USD')}` : ''}`,
+      amount: a.amount ?? 0,
+      currency: a.currency ?? 'USD',
+      type: a.type === 'OTHER' ? 'CORP ACTION' : a.type,
+      symbol: a.symbol,
+      isBank: false,
+      originalBrokerage: a,
+    })
+  }
+
+  return rows
+}
+
+// ── Filtering ───────────────────────────────────────────────────────────────
+
+function filterBankRow(row: UnifiedTransactionRow, filters: Filters): boolean {
+  if (!row.isBank || !row.originalBank) return false
+  const t = row.originalBank
+
+  if (filters.dateFrom && t.date < filters.dateFrom) return false
+  if (filters.dateTo && t.date > filters.dateTo) return false
+  if (filters.sources.length > 0 && !filters.sources.includes(t.source)) return false
+  if (filters.accounts.length > 0 && !filters.accounts.includes(t.accountNo)) return false
+  if (filters.type && row.type !== filters.type) return false
+  if (filters.categoryId) {
+    const resolved = t.manualCategory ?? t.category
+    if (filters.categoryId === '__uncategorised__') {
+      if (resolved) return false
+    } else if (resolved !== filters.categoryId) {
+      return false
+    }
+  }
+  return true
+}
+
+function filterBrokerageRow(row: UnifiedTransactionRow, filters: Filters): boolean {
+  if (row.isBank) return false
+  const dateOnly = row.date.slice(0, 10)
+  if (filters.dateFrom && dateOnly < filters.dateFrom) return false
+  if (filters.dateTo && dateOnly > filters.dateTo) return false
+  if (filters.sources.length > 0 && !filters.sources.includes(row.source)) return false
+  if (filters.type && row.type !== filters.type) return false
+  return true
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetch and merge bank + brokerage rows according to the current filters.
+ *
+ * Lazily queries brokerage tables only when `sourceType` is `"all"` or `"brokerage"`.
+ * Results are sorted by date descending.
+ *
+ * @param filters - Current filter state including sourceType, date range, etc.
+ * @returns All matching rows and the total count
+ */
+export async function fetchUnifiedRows(filters: Filters): Promise<{ rows: UnifiedTransactionRow[]; total: number }> {
+  const bankRows: UnifiedTransactionRow[] = []
+  const brokerageRows: UnifiedTransactionRow[] = []
+
+  // Bank
+  if (filters.sourceType === 'all' || filters.sourceType === 'bank') {
+    let query = filters.dateFrom
+      ? db.transactions.where('date').aboveOrEqual(filters.dateFrom)
+      : db.transactions.orderBy('date').reverse()
+
+    if (filters.dateTo) {
+      query = query.and((t) => t.date <= filters.dateTo)
+    }
+    if (filters.sources.length > 0) {
+      query = query.and((t) => filters.sources.includes(t.source))
+    }
+    if (filters.accounts.length > 0) {
+      query = query.and((t) => filters.accounts.includes(t.accountNo))
+    }
+
+    const allBank = await query.toArray()
+    for (const t of allBank) {
+      const row = mapBankTransaction(t)
+      if (filterBankRow(row, filters)) {
+        bankRows.push(row)
+      }
+    }
+  }
+
+  // Brokerage
+  if (filters.sourceType === 'all' || filters.sourceType === 'brokerage') {
+    const txns = await db.brokerageTransactions.toArray()
+    for (const t of txns) {
+      for (const row of mapBrokerageTransaction(t)) {
+        if (filterBrokerageRow(row, filters)) {
+          brokerageRows.push(row)
+        }
+      }
+    }
+
+    const actions = await db.brokerageCorpActions.toArray()
+    for (const a of actions) {
+      for (const row of mapCorpAction(a)) {
+        if (filterBrokerageRow(row, filters)) {
+          brokerageRows.push(row)
+        }
+      }
+    }
+  }
+
+  const allRows = [...bankRows, ...brokerageRows]
+  allRows.sort((a, b) => toComparableDate(b.date).localeCompare(toComparableDate(a.date)))
+
+  return { rows: allRows, total: allRows.length }
+}
+
+/**
+ * React hook that returns a reactive, paginated slice of unified transactions.
+ *
+ * Queries `db.transactions` (bank) and `db.brokerageTransactions` +
+ * `db.brokerageCorpActions` (brokerage), merges them into a common row shape,
+ * sorts by date descending, and slices for pagination.
+ *
+ * Brokerage tables are queried lazily — only when `sourceType` is `"all"` or
+ * `"brokerage"`.
+ *
+ * @param filters - Current filter state (including `sourceType`)
+ * @param pageOffset - Zero-based offset for pagination
+ * @param pageSize - Number of rows per page
+ * @returns Object with `rows`, `total`, `hasMore`, and `isLoading`
+ */
+export function useUnifiedTransactions(filters: Filters, pageOffset: number, pageSize: number) {
+  return useLiveQuery(
+    async () => {
+      const { rows, total } = await fetchUnifiedRows(filters)
+      const paginated = rows.slice(pageOffset, pageOffset + pageSize)
+      const hasMore = pageOffset + paginated.length < total
+      return { rows: paginated, total, hasMore, isLoading: false }
+    },
+    [filters, pageOffset, pageSize],
+    { rows: [] as UnifiedTransactionRow[], total: 0, hasMore: false, isLoading: true }
+  )
+}

--- a/apps/web/src/lib/brokerage/unifiedTransactions.ts
+++ b/apps/web/src/lib/brokerage/unifiedTransactions.ts
@@ -1,10 +1,25 @@
-import type { BrokerageCorpAction, BrokerageTransaction } from '@lokfi/brokerage-core'
+import type { BrokerageFundDetail, BrokerageTransaction } from '@lokfi/brokerage-core'
 import { useLiveQuery } from 'dexie-react-hooks'
 import type { Filters } from '../../pages/transactions/filterTypes'
 import { type DbTransaction, db } from '../db/db'
 
 /** Brokerage-specific row types displayed in the unified view */
-export type BrokerageRowType = 'BUY' | 'SELL' | 'DIVIDEND' | 'FEE' | 'SPLIT' | 'RIGHTS' | 'OTHER' | 'CORP ACTION'
+export type BrokerageRowType =
+  | 'BUY'
+  | 'SELL'
+  | 'DIVIDEND'
+  | 'FEE'
+  | 'SPLIT'
+  | 'RIGHTS'
+  | 'OTHER'
+  | 'DIVIDEND_TAX'
+  | 'TRANSFER_IN'
+  | 'TRANSFER_OUT'
+  | 'DEPOSIT'
+  | 'WITHDRAWAL'
+  | 'CURRENCY_EXCHANGE'
+  | 'UNKNOWN'
+  | 'REBATE'
 
 /** Common row shape for both bank and brokerage transactions in the UI */
 export interface UnifiedTransactionRow {
@@ -23,7 +38,7 @@ export interface UnifiedTransactionRow {
   /** Original bank record — present only when `isBank` is true */
   originalBank?: DbTransaction
   /** Original brokerage record — present only when `isBank` is false */
-  originalBrokerage?: BrokerageTransaction | BrokerageCorpAction
+  originalBrokerage?: BrokerageTransaction | BrokerageFundDetail
 }
 
 // ── Formatting helpers ──────────────────────────────────────────────────────
@@ -100,37 +115,218 @@ export function mapBrokerageTransaction(t: BrokerageTransaction): UnifiedTransac
   return rows
 }
 
-/** Map a BrokerageCorpAction to one or more UnifiedTransactionRows */
-export function mapCorpAction(a: BrokerageCorpAction): UnifiedTransactionRow[] {
+/** Map a BrokerageFundDetail to one or more UnifiedTransactionRows */
+export function mapFundDetail(d: BrokerageFundDetail): UnifiedTransactionRow[] {
   const rows: UnifiedTransactionRow[] = []
-  const date = a.appliedAt || a.payDate || a.exDate || '1970-01-01T00:00:00Z'
+  const date = d.businessDate.length === 10 ? `${d.businessDate}T00:00:00Z` : d.businessDate
 
-  if (a.type === 'DIVIDEND' && a.amount !== undefined) {
-    rows.push({
-      id: `ca-${a.id}`,
-      source: a.source,
-      date,
-      description: `${a.symbol} Dividend — ${fmtCurrency(a.amount, a.currency ?? 'USD')}`,
-      amount: a.amount,
-      currency: a.currency ?? 'USD',
-      type: 'DIVIDEND',
-      symbol: a.symbol,
-      isBank: false,
-      originalBrokerage: a,
-    })
-  } else {
-    rows.push({
-      id: `ca-${a.id}`,
-      source: a.source,
-      date,
-      description: `${a.symbol} ${a.type}${a.amount ? ` — ${fmtCurrency(a.amount, a.currency ?? 'USD')}` : ''}`,
-      amount: a.amount ?? 0,
-      currency: a.currency ?? 'USD',
-      type: a.type === 'OTHER' ? 'CORP ACTION' : a.type,
-      symbol: a.symbol,
-      isBank: false,
-      originalBrokerage: a,
-    })
+  switch (d.classifiedType) {
+    case 'DIVIDEND': {
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: `${d.symbol || ''} Dividend — ${fmtCurrency(d.amount, d.currency)}`,
+        amount: d.amount,
+        currency: d.currency,
+        type: 'DIVIDEND',
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    case 'DIVIDEND_TAX': {
+      const isRefund = d.amount > 0
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: isRefund
+          ? `${d.symbol || ''} Dividend Tax refund (return of capital) — ${fmtCurrency(Math.abs(d.amount), d.currency)}`
+          : `${d.symbol || ''} Dividend Tax withheld — ${fmtCurrency(Math.abs(d.amount), d.currency)}`,
+        amount: d.amount,
+        currency: d.currency,
+        type: 'DIVIDEND_TAX',
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    case 'TRADE': {
+      if (d.quantity !== undefined && d.price !== undefined && d.action) {
+        // Enriched trade — show as BUY/SELL row with per-share detail
+        const gross = d.quantity * d.price
+        const comm = d.commission ?? 0
+        const total = d.action === 'BUY' ? -(gross + comm) : gross - comm
+        rows.push({
+          id: `fd-${d.id}`,
+          source: d.source,
+          date,
+          description: `${d.action} ${d.symbol || ''} — ${d.quantity} shares @ ${fmtCurrency(d.price, d.currency)}`,
+          amount: total,
+          currency: d.currency,
+          type: d.action,
+          symbol: d.symbol,
+          quantity: d.quantity,
+          price: d.price,
+          isBank: false,
+          originalBrokerage: d,
+        })
+      } else {
+        // Unenriched trade — show as TRADE row with total only
+        rows.push({
+          id: `fd-${d.id}`,
+          source: d.source,
+          date,
+          description: `Trade ${d.symbol || ''} — ${fmtCurrency(Math.abs(d.amount), d.currency)}`,
+          amount: d.amount,
+          currency: d.currency,
+          type: d.action ?? 'BUY',
+          symbol: d.symbol,
+          isBank: false,
+          originalBrokerage: d,
+        })
+      }
+      break
+    }
+
+    case 'FEE': {
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: `${d.rawType}${d.symbol ? ` (${d.symbol})` : ''} — ${fmtCurrency(Math.abs(d.amount), d.currency)}`,
+        amount: -Math.abs(d.amount), // Fees are always outflows
+        currency: d.currency,
+        type: 'FEE',
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    case 'TRANSFER_IN': {
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: `Funds Transfer In — ${fmtCurrency(d.amount, d.currency)}`,
+        amount: d.amount,
+        currency: d.currency,
+        type: 'TRANSFER_IN',
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    case 'TRANSFER_OUT': {
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: `Funds Transfer Out — ${fmtCurrency(Math.abs(d.amount), d.currency)}`,
+        amount: d.amount, // Already negative from broker
+        currency: d.currency,
+        type: 'TRANSFER_OUT',
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    case 'DEPOSIT_WITHDRAWAL': {
+      const isDeposit = d.amount > 0
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: isDeposit
+          ? `Deposit — ${fmtCurrency(d.amount, d.currency)}`
+          : `Withdrawal — ${fmtCurrency(Math.abs(d.amount), d.currency)}`,
+        amount: d.amount,
+        currency: d.currency,
+        type: isDeposit ? 'DEPOSIT' : 'WITHDRAWAL',
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    case 'CURRENCY_EXCHANGE': {
+      const fxDesc = d.rawType.includes('Base Currency')
+        ? `Currency Conversion (→ Base) — ${fmtCurrency(Math.abs(d.amount), d.currency)}`
+        : `Currency Conversion (→ Quotation) — ${fmtCurrency(Math.abs(d.amount), d.currency)}`
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: fxDesc,
+        amount: d.amount,
+        currency: d.currency,
+        type: 'CURRENCY_EXCHANGE',
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    case 'UNKNOWN': {
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: `Unclassified (${d.rawType}) — ${fmtCurrency(Math.abs(d.amount), d.currency)}`,
+        amount: d.amount,
+        currency: d.currency,
+        type: 'UNKNOWN',
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    case 'REBATE': {
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: `Rebate (${d.rawType}) — ${fmtCurrency(d.amount, d.currency)}`,
+        amount: d.amount,
+        currency: d.currency,
+        type: 'REBATE',
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
+
+    default: {
+      // CORP_ACTION or any future unhandled type — generic row
+      rows.push({
+        id: `fd-${d.id}`,
+        source: d.source,
+        date,
+        description: `${d.classifiedType}${d.symbol ? ` (${d.symbol})` : ''} — ${fmtCurrency(Math.abs(d.amount), d.currency)}`,
+        amount: d.amount,
+        currency: d.currency,
+        type: d.classifiedType,
+        symbol: d.symbol,
+        isBank: false,
+        originalBrokerage: d,
+      })
+      break
+    }
   }
 
   return rows
@@ -165,6 +361,8 @@ function filterBrokerageRow(row: UnifiedTransactionRow, filters: Filters): boole
   if (filters.dateTo && dateOnly > filters.dateTo) return false
   if (filters.sources.length > 0 && !filters.sources.includes(row.source)) return false
   if (filters.type && row.type !== filters.type) return false
+  // Bank-specific filters (accounts, categoryId) don't apply to brokerage rows
+  // DIVIDEND_TAX, TRANSFER_IN, REBATE, FEE don't have symbol-specific filtering
   return true
 }
 
@@ -210,6 +408,7 @@ export async function fetchUnifiedRows(filters: Filters): Promise<{ rows: Unifie
 
   // Brokerage
   if (filters.sourceType === 'all' || filters.sourceType === 'brokerage') {
+    // Filled orders that produce standalone BUY/SELL rows
     const txns = await db.brokerageTransactions.toArray()
     for (const t of txns) {
       for (const row of mapBrokerageTransaction(t)) {
@@ -219,9 +418,10 @@ export async function fetchUnifiedRows(filters: Filters): Promise<{ rows: Unifie
       }
     }
 
-    const actions = await db.brokerageCorpActions.toArray()
-    for (const a of actions) {
-      for (const row of mapCorpAction(a)) {
+    // Fund details
+    const fundDetails = await db.brokerageFundDetails.toArray()
+    for (const fd of fundDetails) {
+      for (const row of mapFundDetail(fd)) {
         if (filterBrokerageRow(row, filters)) {
           brokerageRows.push(row)
         }
@@ -239,7 +439,7 @@ export async function fetchUnifiedRows(filters: Filters): Promise<{ rows: Unifie
  * React hook that returns a reactive, paginated slice of unified transactions.
  *
  * Queries `db.transactions` (bank) and `db.brokerageTransactions` +
- * `db.brokerageCorpActions` (brokerage), merges them into a common row shape,
+ * `db.brokerageFundDetails` (brokerage), merges them into a common row shape,
  * sorts by date descending, and slices for pagination.
  *
  * Brokerage tables are queried lazily — only when `sourceType` is `"all"` or

--- a/apps/web/src/lib/db/README.md
+++ b/apps/web/src/lib/db/README.md
@@ -1,0 +1,21 @@
+# Database
+
+## Code snippet to query indexedDB
+
+In browser console, example to query unique rawTypes in `brokerageFundDetails` table
+
+```javascript
+const req = indexedDB.open('lokfi')
+req.onsuccess = () => {
+  const db = req.result
+  const tx = db.transaction('brokerageFundDetails', 'readonly')
+  const store = tx.objectStore('brokerageFundDetails')
+  const all = store.getAll()
+  all.onsuccess = () => {
+    const rawTypes = [...new Set(all.result.map(fd => fd.rawType).filter(Boolean))]
+    console.table(rawTypes.map(t => ({ rawType: t })))
+    console.log(`Total records: ${all.result.length}, unique rawTypes: ${rawTypes.length}`)
+  }
+}
+req.onerror = () => console.error('Failed to open IndexedDB')
+```

--- a/apps/web/src/lib/db/db.ts
+++ b/apps/web/src/lib/db/db.ts
@@ -1,7 +1,7 @@
 import type {
   BrokerageAccount,
-  BrokerageCorpAction,
   BrokerageCredentials,
+  BrokerageFundDetail,
   BrokeragePosition,
   BrokeragePositionExtension,
   BrokerageSyncLog,
@@ -47,6 +47,12 @@ export interface DbSetting {
 
 export type DbCustomParserProfile = CustomParserProfile
 
+export interface FxRateRecord {
+  date: string // 'YYYY-MM-DD'
+  base: string
+  rates: Record<string, number>
+}
+
 export interface DbBudget {
   id: string
   categoryId: string
@@ -67,10 +73,11 @@ export class LokfiDatabase extends Dexie {
   brokeragePositions!: Table<BrokeragePosition>
   brokeragePositionExtensions!: Table<BrokeragePositionExtension>
   brokerageTransactions!: Table<BrokerageTransaction>
-  brokerageCorpActions!: Table<BrokerageCorpAction>
+  brokerageFundDetails!: Table<BrokerageFundDetail>
   brokerageAccounts!: Table<BrokerageAccount>
   brokerageSyncLog!: Table<BrokerageSyncLog>
   brokerageCredentials!: Table<BrokerageCredentials>
+  fxRates!: Table<FxRateRecord>
 
   constructor() {
     super('lokfi')
@@ -103,10 +110,19 @@ export class LokfiDatabase extends Dexie {
       brokeragePositions: 'id',
       brokeragePositionExtensions: '[positionId+key], positionId',
       brokerageTransactions: 'id, orderId, source, symbol, executedAt',
-      brokerageCorpActions: 'id, source, symbol, type',
       brokerageAccounts: 'id, source, currency',
       brokerageSyncLog: '++id, source, category, lastSyncAt, status',
       brokerageCredentials: 'id',
+    })
+
+    // v6 schema (adds fxRates table for currency conversion)
+    this.version(6).stores({
+      fxRates: '[date+base]',
+    })
+
+    // v7 schema (adds brokerageFundDetails table for unified fund details)
+    this.version(7).stores({
+      brokerageFundDetails: 'id, source, classifiedType, symbol, businessDate',
     })
 
     // Seed default categories on initial DB creation

--- a/apps/web/src/lib/db/db.ts
+++ b/apps/web/src/lib/db/db.ts
@@ -1,3 +1,12 @@
+import type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokerageCredentials,
+  BrokeragePosition,
+  BrokeragePositionExtension,
+  BrokerageSyncLog,
+  BrokerageTransaction,
+} from '@lokfi/brokerage-core'
 import type { CustomParserProfile, StatementSource } from '@lokfi/parser-core'
 import Dexie, { type Table } from 'dexie'
 import { type DbCategory, defaultCategories } from './seedCategories'
@@ -46,12 +55,22 @@ export interface DbBudget {
 }
 
 export class LokfiDatabase extends Dexie {
+  // Bank statement tables
   transactions!: Table<DbTransaction>
   rules!: Table<DbRule>
   categories!: Table<DbCategory>
   settings!: Table<DbSetting>
   customParsers!: Table<DbCustomParserProfile>
   budgets!: Table<DbBudget>
+
+  // Brokerage tables (v5)
+  brokeragePositions!: Table<BrokeragePosition>
+  brokeragePositionExtensions!: Table<BrokeragePositionExtension>
+  brokerageTransactions!: Table<BrokerageTransaction>
+  brokerageCorpActions!: Table<BrokerageCorpAction>
+  brokerageAccounts!: Table<BrokerageAccount>
+  brokerageSyncLog!: Table<BrokerageSyncLog>
+  brokerageCredentials!: Table<BrokerageCredentials>
 
   constructor() {
     super('lokfi')
@@ -77,6 +96,17 @@ export class LokfiDatabase extends Dexie {
     // v4 schema (adds budgets table for category spending limits)
     this.version(4).stores({
       budgets: 'id, categoryId',
+    })
+
+    // v5 schema (adds brokerage pipeline tables)
+    this.version(5).stores({
+      brokeragePositions: 'id',
+      brokeragePositionExtensions: '[positionId+key], positionId',
+      brokerageTransactions: 'id, orderId, source, symbol, executedAt',
+      brokerageCorpActions: 'id, source, symbol, type',
+      brokerageAccounts: 'id, source, currency',
+      brokerageSyncLog: '++id, source, category, lastSyncAt, status',
+      brokerageCredentials: 'id',
     })
 
     // Seed default categories on initial DB creation

--- a/apps/web/src/lib/fx/cache.test.ts
+++ b/apps/web/src/lib/fx/cache.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { isStale } from './cache'
+
+describe('isStale', () => {
+  it('returns false for today', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    expect(isStale(today)).toBe(false)
+  })
+
+  it('returns true for yesterday', () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10)
+    expect(isStale(yesterday)).toBe(true)
+  })
+})

--- a/apps/web/src/lib/fx/cache.ts
+++ b/apps/web/src/lib/fx/cache.ts
@@ -1,0 +1,30 @@
+import { db } from '../db/db'
+import type { FxRateRecord } from '../db/db'
+
+/**
+ * Retrieve cached FX rates for a given date and base currency.
+ * @param date - Date string in 'YYYY-MM-DD' format
+ * @param base - Base currency code (e.g., 'USD')
+ * @returns FxRateRecord if found, undefined otherwise
+ */
+export async function getRates(date: string, base: string): Promise<FxRateRecord | undefined> {
+  return db.fxRates.get([date, base])
+}
+
+/**
+ * Store FX rates in the database cache.
+ * @param record - FxRateRecord to store
+ */
+export async function storeRates(record: FxRateRecord): Promise<void> {
+  await db.fxRates.put(record)
+}
+
+/**
+ * Check if a date string is stale (not today).
+ * @param date - Date string in 'YYYY-MM-DD' format
+ * @returns true if date is not today's date, false otherwise
+ */
+export function isStale(date: string): boolean {
+  const today = new Date().toISOString().slice(0, 10)
+  return date !== today
+}

--- a/apps/web/src/lib/fx/convert.test.ts
+++ b/apps/web/src/lib/fx/convert.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { convertAmount } from './convert'
+
+describe('convertAmount', () => {
+  const rates = { SGD: 1.35, HKD: 7.82, USD: 1 }
+
+  it('converts USD to SGD', () => {
+    expect(convertAmount(100, 'USD', 'SGD', rates)).toBeCloseTo(135, 2)
+  })
+
+  it('converts SGD to HKD via USD base', () => {
+    expect(convertAmount(100, 'SGD', 'HKD', rates)).toBeCloseTo((100 / 1.35) * 7.82, 2)
+  })
+
+  it('returns same amount when converting to same currency', () => {
+    expect(convertAmount(100, 'USD', 'USD', rates)).toBe(100)
+  })
+
+  it('returns original amount when rate is missing', () => {
+    expect(convertAmount(100, 'USD', 'XYZ', rates)).toBe(100)
+  })
+})

--- a/apps/web/src/lib/fx/convert.ts
+++ b/apps/web/src/lib/fx/convert.ts
@@ -1,0 +1,21 @@
+/**
+ * Convert an amount from one currency to another using cached rates.
+ * Rates object should contain exchange rates relative to a base currency.
+ * Example: rates = { SGD: 1.35, HKD: 7.82 } for USD base.
+ *
+ * @param amount - Original amount in source currency
+ * @param from - Source currency code
+ * @param to - Target currency code
+ * @param rates - Exchange rates map where values are rates relative to base currency
+ * @returns Converted amount, or original amount if rates are missing
+ */
+export function convertAmount(amount: number, from: string, to: string, rates: Record<string, number>): number {
+  if (from === to) return amount
+  // Rates are relative to a base currency (e.g. USD). The base currency
+  // is NOT in the rates map — its implicit rate is 1.
+  // amount_in_BASE = amount / rates[from]
+  // amount_in_TO = amount_in_BASE * rates[to]
+  const fromRate = from in rates ? rates[from] : 1 // base currency → rate of 1
+  const toRate = to in rates ? rates[to] : 1 // base currency → rate of 1
+  return (amount / fromRate) * toRate
+}

--- a/apps/web/src/lib/fx/fallback-client.ts
+++ b/apps/web/src/lib/fx/fallback-client.ts
@@ -1,0 +1,18 @@
+import type { FxRateResponse } from './frankfurter-client'
+
+/**
+ * Fetch fallback FX rates from open.er-api.com when Frankfurter is unavailable.
+ * @param base - Base currency code (default: USD)
+ * @returns FX rate response with date, base, and rates map
+ * @throws Error if API request fails
+ */
+export async function fetchFallbackRates(base = 'USD'): Promise<FxRateResponse> {
+  const res = await fetch(`https://open.er-api.com/v6/latest/${base}`)
+  if (!res.ok) throw new Error(`Fallback API error: ${res.status}`)
+  const data = await res.json()
+  return {
+    date: data.time_last_update_utc ? data.time_last_update_utc.slice(0, 10) : new Date().toISOString().slice(0, 10),
+    base: data.base_code,
+    rates: data.rates,
+  }
+}

--- a/apps/web/src/lib/fx/frankfurter-client.ts
+++ b/apps/web/src/lib/fx/frankfurter-client.ts
@@ -1,0 +1,17 @@
+export interface FxRateResponse {
+  date: string
+  base: string
+  rates: Record<string, number>
+}
+
+/**
+ * Fetch latest FX rates from Frankfurter API.
+ * @param base - Base currency code (default: USD)
+ * @returns FX rate response with date, base, and rates map
+ * @throws Error if API request fails
+ */
+export async function fetchFrankfurterRates(base = 'USD'): Promise<FxRateResponse> {
+  const res = await fetch(`https://api.frankfurter.dev/v1/latest?from=${base}`)
+  if (!res.ok) throw new Error(`Frankfurter API error: ${res.status}`)
+  return res.json()
+}

--- a/apps/web/src/lib/fx/useFxRates.ts
+++ b/apps/web/src/lib/fx/useFxRates.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { db } from '../db/db'
+import { getRates, isStale, storeRates } from './cache'
+import { fetchFallbackRates } from './fallback-client'
+import { fetchFrankfurterRates } from './frankfurter-client'
+
+export interface UseFxRatesResult {
+  rates: Record<string, number> | null
+  lastUpdated: string | null
+  loading: boolean
+  error: string | null
+}
+
+/**
+ * Hook to fetch and cache FX rates for a given base currency.
+ * Uses Frankfurter API as primary source with fallback to open.er-api.com.
+ * Caches results in IndexedDB to minimize API calls.
+ *
+ * @param base - Base currency code (default: USD)
+ * @returns Object containing rates, lastUpdated timestamp, loading state, and error message
+ */
+export function useFxRates(base = 'USD'): UseFxRatesResult {
+  const [state, setState] = useState<UseFxRatesResult>({
+    rates: null,
+    lastUpdated: null,
+    loading: true,
+    error: null,
+  })
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      const today = new Date().toISOString().slice(0, 10)
+      const cached = await getRates(today, base)
+
+      if (cached && !isStale(cached.date)) {
+        if (!cancelled) setState({ rates: cached.rates, lastUpdated: cached.date, loading: false, error: null })
+        return
+      }
+
+      try {
+        const data = await fetchFrankfurterRates(base)
+        await storeRates(data)
+        if (!cancelled) setState({ rates: data.rates, lastUpdated: data.date, loading: false, error: null })
+      } catch (err) {
+        try {
+          const fallback = await fetchFallbackRates(base)
+          await storeRates(fallback)
+          if (!cancelled) setState({ rates: fallback.rates, lastUpdated: fallback.date, loading: false, error: null })
+        } catch (fallbackErr) {
+          // Use most recent cached rates regardless of date
+          const allCached = await db.fxRates.where('base').equals(base).reverse().sortBy('date')
+          const mostRecent = allCached[0]
+          if (mostRecent) {
+            if (!cancelled)
+              setState({
+                rates: mostRecent.rates,
+                lastUpdated: mostRecent.date,
+                loading: false,
+                error: `Using cached rates from ${mostRecent.date}`,
+              })
+          } else {
+            if (!cancelled)
+              setState({
+                rates: null,
+                lastUpdated: null,
+                loading: false,
+                error: 'FX rates unavailable. Showing original currencies.',
+              })
+          }
+        }
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [base])
+
+  return state
+}

--- a/apps/web/src/lib/rules/applyRulesToImport.ts
+++ b/apps/web/src/lib/rules/applyRulesToImport.ts
@@ -18,9 +18,6 @@ export async function applyRulesToImport(transactionIds: string[]): Promise<void
   // check many of them across the batch of transactions.
   const rules = await db.rules.orderBy('priority').toArray()
 
-  // Optimization: If no rules exist, there's nothing to evaluate.
-  if (rules.length === 0) return
-
   // Run updates in a single Dexie database transaction for performance and atomicity
   await db.transaction('rw', db.transactions, async () => {
     // We can fetch transactions in chunks if the array is large,
@@ -35,11 +32,17 @@ export async function applyRulesToImport(transactionIds: string[]): Promise<void
       // Tier 1 precedence: Manual category always wins, so skip rule eval
       if (txn.manualCategory) continue
 
-      // Tier 2 precedence: Evaluate general rules
-      const matchedCategory = evaluateRules(txn, rules)
+      // Tier 2 precedence: Evaluate general rules (if any exist)
+      let matchedCategory: string | null = null
+      if (rules.length > 0) {
+        matchedCategory = evaluateRules(txn, rules)
+      }
 
       if (matchedCategory) {
         updates.push({ id: txn.id, category: matchedCategory })
+      } else if (txn.transactionValue > 0) {
+        // Tier 3: Auto-assign Income category to positive-value (inflow) transactions
+        updates.push({ id: txn.id, category: 'cat_income' })
       }
     }
 

--- a/apps/web/src/pages/dashboard/DashboardContext.tsx
+++ b/apps/web/src/pages/dashboard/DashboardContext.tsx
@@ -17,6 +17,9 @@ export const defaultDashboardFilters: DashboardFilters = {
   accounts: [],
 }
 
+/** Sentinel value for uncategorised transactions in the category filter */
+const UNCATEGORIZED = '__uncategorized__'
+
 // Persisted subset — only category/account selections are saved (dates are temporal)
 interface SavedFilterPrefs {
   categoryIds: string[]
@@ -117,8 +120,9 @@ export function DashboardFilterProvider({ children }: { children: ReactNode }) {
       if (filters.dateTo && t.date > filters.dateTo) return false
       if (!allAccountsSelected && !filters.accounts.includes(t.accountNo)) return false
       if (!allCategoriesSelected) {
-        const catId = t.manualCategory ?? t.category ?? ''
-        if (!filters.categoryIds.includes(catId)) return false
+        const catId = t.manualCategory ?? t.category
+        const effectiveCatId = catId || UNCATEGORIZED
+        if (!filters.categoryIds.includes(effectiveCatId)) return false
       }
       return true
     })

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { DashboardFilterProvider, useDashboard } from './DashboardContext'
 import { DashboardFilters } from './DashboardFilters'
+import { AverageIncome } from './widgets/AverageIncome'
 import { AverageSpending } from './widgets/AverageSpending'
 import { CategoryBreakdown } from './widgets/CategoryBreakdown'
 import { CategoryBudgetBars } from './widgets/CategoryBudgetBars'
@@ -38,6 +39,7 @@ function DashboardContent() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <SavingsRateGauge />
         <AverageSpending />
+        <AverageIncome />
       </div>
       <MonthlyTrendChart />
       <SpendingHeatmap />

--- a/apps/web/src/pages/dashboard/widgets/AverageIncome.tsx
+++ b/apps/web/src/pages/dashboard/widgets/AverageIncome.tsx
@@ -4,15 +4,15 @@ import { useDashboard } from '../DashboardContext'
 
 type Period = 'daily' | 'weekly' | 'monthly'
 
-export function AverageSpending() {
+export function AverageIncome() {
   const { transactions } = useDashboard()
   const [period, setPeriod] = useState<Period>('monthly')
 
   const { avg, periodCount } = useMemo(() => {
-    const expenses = transactions.filter((t) => t.transactionValue < 0)
-    if (expenses.length === 0) return { avg: 0, periodCount: 0 }
+    const incomes = transactions.filter((t) => t.transactionValue > 0)
+    if (incomes.length === 0) return { avg: 0, periodCount: 0 }
 
-    const total = expenses.reduce((s, t) => s + Math.abs(t.transactionValue), 0)
+    const total = incomes.reduce((s, t) => s + t.transactionValue, 0)
 
     // Full calendar span from all filtered transactions
     let minDate = transactions[0]!.date
@@ -42,9 +42,45 @@ export function AverageSpending() {
 
   return (
     <section className="space-y-3">
-      <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">
-        Average Spending
-      </h2>
+      <div className="flex items-center gap-2">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">
+          Average Income
+        </h2>
+        {/* Info tooltip */}
+        <div className="relative group">
+          <svg
+            className="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 cursor-help"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z"
+              clipRule="evenodd"
+            />
+          </svg>
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block z-10">
+            <div
+              className="text-xs rounded-lg px-3 py-2 shadow-lg whitespace-nowrap"
+              style={{
+                backgroundColor: 'var(--bg-sidebar)',
+                color: 'var(--text-secondary, #6b7280)',
+                border: '1px solid var(--border)',
+              }}
+            >
+              All transactions with a positive value are classified as income.
+              <div
+                className="absolute top-full left-1/2 -translate-x-1/2 w-2 h-2 rotate-45"
+                style={{
+                  backgroundColor: 'var(--bg-sidebar)',
+                  borderRight: '1px solid var(--border)',
+                  borderBottom: '1px solid var(--border)',
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
       <div
         className="rounded-xl border p-5"
         style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
@@ -71,7 +107,7 @@ export function AverageSpending() {
           ))}
         </div>
 
-        <div className="font-mono text-3xl font-medium text-gray-900 dark:text-white">{fmt.format(avg)}</div>
+        <div className="font-mono text-3xl font-medium text-green-600 dark:text-green-400">{fmt.format(avg)}</div>
         <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
           avg per {period === 'daily' ? 'day' : period === 'weekly' ? 'week' : 'month'}
           {' · '}

--- a/apps/web/src/pages/dashboard/widgets/KpiRow.tsx
+++ b/apps/web/src/pages/dashboard/widgets/KpiRow.tsx
@@ -47,8 +47,8 @@ export function KpiRow() {
     const months = new Set(expenses.map((t) => t.date.slice(0, 7)))
     const avgMonthly = months.size > 0 ? totalSpend / months.size : 0
 
-    // Savings rate
-    const savingsRate = totalIncome > 0 ? ((totalIncome - totalSpend) / totalIncome) * 100 : 0
+    // Savings rate: null means no income data (vs 0% = income equals spend)
+    const savingsRate = totalIncome > 0 ? ((totalIncome - totalSpend) / totalIncome) * 100 : null
 
     // Top category
     const catMap = new Map<string, number>()
@@ -99,7 +99,7 @@ export function KpiRow() {
         />
         <KpiCard
           label="Savings rate"
-          value={stats.savingsRate > 0 ? `${stats.savingsRate.toFixed(1)}%` : 'N/A'}
+          value={stats.savingsRate !== null ? `${stats.savingsRate.toFixed(1)}%` : 'N/A'}
           sub="income minus expenses"
         />
         <KpiCard label="Monthly average" value={fmt.format(stats.avgMonthly)} sub="expenses only" />

--- a/apps/web/src/pages/dashboard/widgets/SavingsRateGauge.tsx
+++ b/apps/web/src/pages/dashboard/widgets/SavingsRateGauge.tsx
@@ -44,10 +44,10 @@ export function SavingsRateGauge() {
   const filled = rate >= 0 ? (rate / 100) * arcLength : 0
 
   return (
-    <section className="space-y-3">
+    <section className="flex flex-col gap-3 h-full md:row-span-2">
       <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">Savings Rate</h2>
       <div
-        className="rounded-xl border p-5 flex flex-col items-center"
+        className="rounded-xl border p-5 flex flex-col items-center justify-center flex-1"
         style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
       >
         <svg width="240" height="140" viewBox="0 0 240 140">

--- a/apps/web/src/pages/portfolio/CurrencySelector.tsx
+++ b/apps/web/src/pages/portfolio/CurrencySelector.tsx
@@ -1,0 +1,66 @@
+import { ChevronDown } from 'lucide-react'
+import { useState } from 'react'
+import { CURRENCIES, type CurrencyOption } from './currencyPreference'
+
+interface CurrencySelectorProps {
+  value: CurrencyOption
+  onChange: (c: CurrencyOption) => void
+}
+
+/**
+ * Dropdown component for selecting the portfolio display currency.
+ * Uses native select element styled with Tailwind for simplicity and accessibility.
+ */
+export function CurrencySelector({ value, onChange }: CurrencySelectorProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border text-sm font-medium transition-colors"
+        style={{
+          backgroundColor: 'var(--bg-sidebar)',
+          borderColor: 'var(--border)',
+          color: 'var(--text-primary)',
+        }}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        {value}
+        <ChevronDown size={14} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div
+            className="absolute right-0 mt-1 z-20 min-w-[100px] rounded-xl border overflow-hidden"
+            style={{
+              backgroundColor: 'var(--bg-sidebar)',
+              borderColor: 'var(--border)',
+            }}
+          >
+            {CURRENCIES.map((currency) => (
+              <div
+                key={currency}
+                onClick={() => {
+                  onChange(currency)
+                  setOpen(false)
+                }}
+                className="px-3 py-2 text-sm cursor-pointer transition-colors"
+                style={{
+                  color: currency === value ? 'var(--accent)' : 'var(--text-primary)',
+                  backgroundColor: currency === value ? 'var(--bg)' : 'transparent',
+                }}
+              >
+                {currency}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/portfolio/DividendsTab.tsx
+++ b/apps/web/src/pages/portfolio/DividendsTab.tsx
@@ -1,0 +1,362 @@
+import { useLiveQuery } from 'dexie-react-hooks'
+import { useMemo, useState } from 'react'
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { CATEGORY_PALETTE } from '../../lib/charts/chartPalette'
+import { LEGEND_STYLE, TOOLTIP_STYLE } from '../../lib/charts/chartTheme'
+import { db } from '../../lib/db/db'
+import { convertAmount } from '../../lib/fx/convert'
+import type { CurrencyOption } from './currencyPreference'
+
+interface DividendsTabProps {
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+  fxLastUpdated: string | null
+  fxError: string | null
+}
+
+type FilterMode = 'all' | 'paid' | 'estimated'
+
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+function formatCurrency(amount: number, currency: string): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount)
+}
+
+function formatDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return '—'
+  try {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  } catch {
+    return '—'
+  }
+}
+
+function getYearOptions(): number[] {
+  const currentYear = new Date().getFullYear()
+  return Array.from({ length: 5 }, (_, i) => currentYear - i)
+}
+
+export function DividendsTab({ preferredCurrency, fxRates, fxLastUpdated }: DividendsTabProps) {
+  const [selectedYear, setSelectedYear] = useState(() => new Date().getFullYear())
+  const [filterMode, setFilterMode] = useState<FilterMode>('all')
+
+  const dividends =
+    useLiveQuery(
+      () => db.brokerageFundDetails.where('classifiedType').anyOf(['DIVIDEND', 'DIVIDEND_TAX']).toArray(),
+      []
+    ) ?? []
+
+  const positions = useLiveQuery(() => db.brokeragePositions.toArray(), []) ?? []
+
+  // Filtered dividends for selected year and filter mode
+  const filteredDividends = useMemo(() => {
+    return dividends.filter((div) => {
+      // Determine the effective year based on payDate or appliedAt
+      const dateStr = div.businessDate
+      if (!dateStr) return false
+      const date = new Date(dateStr)
+      const year = date.getFullYear()
+      if (year !== selectedYear) return false
+
+      // Apply filter mode
+      if (filterMode === 'paid') {
+        return div.businessDate !== null && div.businessDate !== undefined && new Date(div.businessDate) <= new Date()
+      }
+      if (filterMode === 'estimated') {
+        return !div.businessDate || new Date(div.businessDate) > new Date()
+      }
+      return true
+    })
+  }, [dividends, selectedYear, filterMode])
+
+  // YTD Total — each dividend converted individually when a specific currency is selected
+  const ytdTotal = useMemo(() => {
+    if (preferredCurrency === 'Original' || !fxRates) {
+      return filteredDividends.reduce((sum, div) => sum + (div.amount ?? 0), 0)
+    }
+    return filteredDividends.reduce((sum, div) => {
+      return sum + convertAmount(div.amount ?? 0, div.currency || 'USD', preferredCurrency, fxRates)
+    }, 0)
+  }, [filteredDividends, preferredCurrency, fxRates])
+
+  // Months with at least one dividend in selected year
+  const monthsWithDividends = useMemo(() => {
+    const months = new Set<number>()
+    filteredDividends.forEach((div) => {
+      const dateStr = div.businessDate
+      if (dateStr) {
+        const date = new Date(dateStr)
+        months.add(date.getMonth())
+      }
+    })
+    return months.size
+  }, [filteredDividends])
+
+  // Monthly average
+  const monthlyAverage = monthsWithDividends > 0 ? ytdTotal / monthsWithDividends : 0
+
+  // Cost basis: sum of avgCost * quantity for positions that have dividends — each converted individually
+  const totalCostBasis = useMemo(() => {
+    const dividendSymbols = new Set(filteredDividends.map((d) => d.symbol))
+    if (preferredCurrency === 'Original' || !fxRates) {
+      return positions
+        .filter((p) => dividendSymbols.has(p.symbol))
+        .reduce((sum, p) => sum + (p.avgCost ?? 0) * (p.quantity ?? 0), 0)
+    }
+    return positions
+      .filter((p) => dividendSymbols.has(p.symbol))
+      .reduce((sum, p) => {
+        const cost = (p.avgCost ?? 0) * (p.quantity ?? 0)
+        return sum + convertAmount(cost, p.currency || 'USD', preferredCurrency, fxRates)
+      }, 0)
+  }, [positions, filteredDividends, preferredCurrency, fxRates])
+
+  // Yield on Cost: annualized dividends / cost basis
+  const yieldOnCost = useMemo(() => {
+    if (totalCostBasis === 0) return null
+    const currentMonth = new Date().getMonth() + 1
+    const annualized = ytdTotal * (12 / currentMonth)
+    return annualized / totalCostBasis
+  }, [ytdTotal, totalCostBasis])
+
+  // Monthly chart data grouped by currency
+  const chartData = useMemo(() => {
+    const buckets: Array<Record<string, number | string>> = []
+    for (let i = 0; i < 12; i++) {
+      buckets[i] = { month: MONTH_NAMES[i] }
+    }
+
+    filteredDividends.forEach((div) => {
+      const dateStr = div.businessDate
+      if (!dateStr) return
+      const date = new Date(dateStr)
+      const monthIdx = date.getMonth()
+      const currency = div.currency ?? 'USD'
+      const current = (buckets[monthIdx][currency] as number | undefined) ?? 0
+      buckets[monthIdx][currency] = current + (div.amount ?? 0)
+    })
+
+    return Object.values(buckets)
+  }, [filteredDividends])
+
+  // Unique currencies in chart data for legend
+  const chartCurrencies = useMemo(() => {
+    const set = new Set<string>()
+    filteredDividends.forEach((d) => {
+      if (d.currency) set.add(d.currency)
+    })
+    return Array.from(set)
+  }, [filteredDividends])
+
+  // Sorted dividends for table
+  const sortedDividends = useMemo(() => {
+    return [...filteredDividends].sort((a, b) => {
+      const dateA = a.businessDate ?? ''
+      const dateB = b.businessDate ?? ''
+      return dateB.localeCompare(dateA)
+    })
+  }, [filteredDividends])
+
+  const yearOptions = useMemo(() => getYearOptions(), [])
+
+  const displayCurrency =
+    preferredCurrency === 'Original' ? (filteredDividends[0]?.currency ?? 'USD') : preferredCurrency
+
+  const kpiCardClass = 'rounded-xl border p-5'
+  const monoClass = 'font-mono tabular-nums'
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Year selector */}
+      <div className="flex items-center justify-between">
+        <select
+          value={selectedYear}
+          onChange={(e) => setSelectedYear(Number(e.target.value))}
+          className="text-sm border rounded-xl px-3 py-2"
+          style={{
+            borderColor: 'var(--border)',
+            backgroundColor: 'var(--bg-sidebar)',
+            color: 'var(--text-primary)',
+          }}
+        >
+          {yearOptions.map((y) => (
+            <option key={y} value={y}>
+              {y}
+            </option>
+          ))}
+        </select>
+        {fxLastUpdated && <span className="text-xs text-gray-400">FX rates: {fxLastUpdated}</span>}
+      </div>
+
+      {/* Summary KPIs */}
+      <div className="grid grid-cols-3 gap-4">
+        {/* YTD Total */}
+        <div className={kpiCardClass} style={{ backgroundColor: 'var(--bg-sidebar)', borderColor: 'var(--border)' }}>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">YTD Total</p>
+          <p className={`text-xl font-semibold ${monoClass}`} style={{ color: 'var(--text-primary)' }}>
+            {formatCurrency(ytdTotal, displayCurrency)}
+          </p>
+        </div>
+
+        {/* Monthly Average */}
+        <div className={kpiCardClass} style={{ backgroundColor: 'var(--bg-sidebar)', borderColor: 'var(--border)' }}>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">Monthly Avg</p>
+          <p className={`text-xl font-semibold ${monoClass}`} style={{ color: 'var(--text-primary)' }}>
+            {formatCurrency(monthlyAverage, displayCurrency)}
+          </p>
+        </div>
+
+        {/* Yield on Cost */}
+        <div className={kpiCardClass} style={{ backgroundColor: 'var(--bg-sidebar)', borderColor: 'var(--border)' }}>
+          <div className="flex items-center gap-1.5 mb-1">
+            <p className="text-sm text-gray-500 dark:text-gray-400">Yield on Cost</p>
+            {/* Info tooltip */}
+            <div className="relative group">
+              <svg
+                className="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 cursor-help"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block z-10">
+                <div
+                  className="text-xs rounded-lg px-3 py-2 shadow-lg whitespace-nowrap"
+                  style={{
+                    backgroundColor: 'var(--bg-sidebar)',
+                    color: 'var(--text-secondary, #6b7280)',
+                    border: '1px solid var(--border)',
+                  }}
+                >
+                  Annualized dividends ÷ total cost basis
+                  <br />
+                  (YTD × 12 ÷ month ÷ cost basis)
+                  <div
+                    className="absolute top-full left-1/2 -translate-x-1/2 w-2 h-2 rotate-45"
+                    style={{
+                      backgroundColor: 'var(--bg-sidebar)',
+                      borderRight: '1px solid var(--border)',
+                      borderBottom: '1px solid var(--border)',
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <p className={`text-xl font-semibold ${monoClass}`} style={{ color: 'var(--text-primary)' }}>
+            {yieldOnCost !== null ? `${(yieldOnCost * 100).toFixed(2)}%` : 'N/A'}
+          </p>
+        </div>
+      </div>
+
+      {/* Bar chart */}
+      {chartCurrencies.length > 0 ? (
+        <div
+          className="rounded-xl border p-4"
+          style={{ backgroundColor: 'var(--bg-sidebar)', borderColor: 'var(--border)' }}
+        >
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={chartData} barCategoryGap="20%">
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+              <XAxis
+                dataKey="month"
+                tick={{ fontSize: 11, fontFamily: 'DM Mono', fill: '#9ca3af' }}
+                axisLine={{ stroke: 'var(--border)' }}
+                tickLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 11, fontFamily: 'DM Mono', fill: '#9ca3af' }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <Tooltip
+                contentStyle={TOOLTIP_STYLE}
+                formatter={(value: number, name: string) => [formatCurrency(value, name), name]}
+              />
+              <Legend wrapperStyle={{ ...LEGEND_STYLE, paddingTop: '12px' }} iconType="square" />
+              {chartCurrencies.map((curr, idx) => (
+                <Bar key={curr} dataKey={curr} fill={CATEGORY_PALETTE[idx % CATEGORY_PALETTE.length]} stackId="stack" />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : null}
+
+      {/* Filter toggle */}
+      <div className="flex items-center gap-2">
+        {(['all', 'paid', 'estimated'] as FilterMode[]).map((mode) => (
+          <button
+            key={mode}
+            onClick={() => setFilterMode(mode)}
+            className="text-sm px-3 py-1.5 rounded-full border transition-colors capitalize"
+            style={{
+              backgroundColor: filterMode === mode ? 'var(--accent)' : 'transparent',
+              borderColor: 'var(--border)',
+              color: filterMode === mode ? 'white' : 'var(--text-primary)',
+            }}
+          >
+            {mode}
+          </button>
+        ))}
+      </div>
+
+      {/* Table */}
+      {sortedDividends.length > 0 ? (
+        <div className="rounded-xl border overflow-hidden" style={{ borderColor: 'var(--border)' }}>
+          <table className="w-full text-sm">
+            <thead>
+              <tr style={{ backgroundColor: 'var(--bg-sidebar)' }}>
+                {['Symbol', 'Date', 'Amount', 'Currency', 'Type'].map((col) => (
+                  <th
+                    key={col}
+                    className="text-left px-4 py-3 font-medium text-gray-500 dark:text-gray-400 border-b"
+                    style={{ borderColor: 'var(--border)' }}
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sortedDividends.map((div) => (
+                <tr key={div.id} className="border-b last:border-0" style={{ borderColor: 'var(--border)' }}>
+                  <td className="px-4 py-3 font-medium" style={{ color: 'var(--text-primary)' }}>
+                    {div.symbol}
+                  </td>
+                  <td className="px-4 py-3 text-gray-600 dark:text-gray-400">{formatDate(div.businessDate)}</td>
+                  <td className={`px-4 py-3 ${monoClass}`} style={{ color: 'var(--text-primary)' }}>
+                    {formatCurrency(div.amount, div.currency)}
+                  </td>
+                  <td className="px-4 py-3 text-gray-600 dark:text-gray-400">{div.currency}</td>
+                  <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+                    {div.classifiedType === 'DIVIDEND_TAX' ? 'Dividend Tax' : 'Dividend'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div
+          className="text-center py-12 rounded-xl border"
+          style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+        >
+          <p className="text-gray-500 dark:text-gray-400">No dividends recorded yet.</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/portfolio/HoldingsTab.tsx
+++ b/apps/web/src/pages/portfolio/HoldingsTab.tsx
@@ -1,0 +1,608 @@
+import type { BrokeragePosition } from '@lokfi/brokerage-core'
+import { Link } from '@tanstack/react-router'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { ChevronDown, ChevronRight, Info } from 'lucide-react'
+import { useState } from 'react'
+import { db } from '../../lib/db/db'
+import { convertAmount } from '../../lib/fx/convert'
+import type { CurrencyOption } from './currencyPreference'
+
+interface HoldingsTabProps {
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+  fxLastUpdated: string | null
+  fxError: string | null
+}
+
+interface PositionRow {
+  position: BrokeragePosition
+  mktPrice: number
+  mktValue: number
+  pnl: number
+  isEstimated: boolean
+}
+
+interface HoldingDetailRowProps {
+  row: PositionRow
+}
+
+const fmtCache = new Map<string, Intl.NumberFormat>()
+function getFormatter(currency: string): Intl.NumberFormat {
+  if (!fmtCache.has(currency)) {
+    fmtCache.set(
+      currency,
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })
+    )
+  }
+  return fmtCache.get(currency)!
+}
+
+function formatCurrency(amount: number, currency: string): string {
+  return getFormatter(currency).format(amount)
+}
+
+function HoldingDetailRow({ row }: HoldingDetailRowProps) {
+  const { position } = row
+  const isDerivative = position.secType != null && DERIVATIVE_TYPES.has(position.secType)
+  const costBasis = position.quantity * position.avgCost
+  const extData = useLiveQuery(
+    () => db.brokeragePositionExtensions.where('positionId').equals(position.id).toArray(),
+    [position.id]
+  )
+
+  function getExt(key: string): string | null {
+    const rec = extData?.find((e) => e.key === key)
+    if (!rec) return null
+    try {
+      return JSON.parse(rec.value)
+    } catch {
+      return rec.value
+    }
+  }
+
+  const dayLow = getExt('dayLow')
+  const dayHigh = getExt('dayHigh')
+  const week52Low = getExt('week52Low')
+  const week52High = getExt('week52High')
+
+  return (
+    <tr className="border-b" style={{ borderColor: 'var(--border)' }}>
+      <td colSpan={7} className="px-4 py-3">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          {/* Left column */}
+          <div className="space-y-2">
+            <div className="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider font-semibold mb-1">
+              Details
+            </div>
+            {position.name && (
+              <div className="flex gap-2">
+                <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Full Name</span>
+                <span className="text-gray-900 dark:text-white">{position.name}</span>
+              </div>
+            )}
+            {isDerivative ? (
+              <div className="flex gap-2">
+                <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Total Premium</span>
+                <span className="text-gray-900 dark:text-white font-mono tabular-nums">
+                  {formatCurrency(costBasis, position.currency)}
+                </span>
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Raw Cost Basis</span>
+                <span className="text-gray-900 dark:text-white font-mono tabular-nums">
+                  {formatCurrency(costBasis, position.currency)}
+                </span>
+              </div>
+            )}
+            <div className="flex gap-2">
+              <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Adjusted Cost</span>
+              <span className="text-gray-900 dark:text-white">
+                Adjusted cost basis (including options) is coming in a future update.
+              </span>
+            </div>
+          </div>
+
+          {/* Right column — price context only for stocks */}
+          <div className="space-y-2">
+            <div className="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider font-semibold mb-1">
+              {isDerivative ? 'Info' : 'Price Context'}
+            </div>
+            {!isDerivative && (
+              <>
+                <div className="flex gap-2">
+                  <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Day Range</span>
+                  <span className="text-gray-900 dark:text-white font-mono tabular-nums">
+                    {dayLow && dayHigh
+                      ? `${formatCurrency(Number.parseFloat(dayLow), position.currency)} – ${formatCurrency(Number.parseFloat(dayHigh), position.currency)}`
+                      : '—'}
+                  </span>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">52W Range</span>
+                  <span className="text-gray-900 dark:text-white font-mono tabular-nums">
+                    {week52Low && week52High
+                      ? `${formatCurrency(Number.parseFloat(week52Low), position.currency)} – ${formatCurrency(Number.parseFloat(week52High), position.currency)}`
+                      : '—'}
+                  </span>
+                </div>
+              </>
+            )}
+
+            {/* Action buttons */}
+            <div className="flex items-center gap-2 pt-2">
+              <Link
+                to="/transactions"
+                search={{ sourceType: 'brokerage', type: position.symbol }}
+                className="text-xs font-medium px-3 py-1 rounded border transition-colors hover:border-amber-500 hover:text-amber-600"
+                style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+              >
+                View Transactions
+              </Link>
+              <Link
+                to="/transactions"
+                search={{ sourceType: 'brokerage' }}
+                className="text-xs font-medium px-3 py-1 rounded border transition-colors hover:border-amber-500 hover:text-amber-600"
+                style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+              >
+                View Corp Actions
+              </Link>
+            </div>
+          </div>
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+function HoldingsTable({
+  positions,
+  preferredCurrency,
+  fxRates,
+  variant = 'stock',
+}: {
+  positions: PositionRow[]
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+  variant?: 'stock' | 'derivative'
+}) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+
+  function toggleExpand(id: string) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const showConverted = preferredCurrency !== 'Original' && fxRates != null
+  const prefCurrency = preferredCurrency === 'Original' ? (positions[0]?.position.currency ?? 'USD') : preferredCurrency
+
+  function pnClass(pnl: number) {
+    if (pnl > 0) return 'text-emerald-600 dark:text-emerald-400'
+    if (pnl < 0) return 'text-red-600 dark:text-red-400'
+    return 'text-gray-500 dark:text-gray-400'
+  }
+
+  const isDerivative = variant === 'derivative'
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b" style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}>
+            <th className="w-8 px-3 py-2.5" />
+            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              {isDerivative ? 'Underlying' : 'Symbol'}
+            </th>
+            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              {isDerivative ? 'Contracts' : 'Qty'}
+            </th>
+            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              {isDerivative ? 'Avg Price' : 'Avg Cost'}
+            </th>
+            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              {isDerivative ? 'Last Price' : 'Mkt Price'}
+            </th>
+            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Mkt Value
+            </th>
+            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              P&L
+            </th>
+          </tr>
+        </thead>
+        {positions.map((row, i) => {
+          const { position } = row
+          const isEven = i % 2 === 0
+          const isExpanded = expandedIds.has(position.id)
+          const isShort = position.quantity < 0
+
+          return (
+            <tbody key={position.id} className="border-b" style={{ borderColor: 'var(--border)' }}>
+              <tr
+                className="cursor-pointer transition-colors"
+                style={{
+                  backgroundColor: isEven ? 'var(--bg)' : 'var(--bg-sidebar)',
+                }}
+                onClick={() => toggleExpand(position.id)}
+              >
+                <td className="px-3 py-2.5 text-gray-400">
+                  {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                </td>
+                <td className="px-3 py-2.5 font-medium text-gray-900 dark:text-white">
+                  <span className="flex items-center gap-1.5">
+                    {position.symbol}
+                    {isDerivative && (
+                      <span
+                        className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
+                          isShort
+                            ? 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20'
+                            : 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20'
+                        }`}
+                      >
+                        {isShort ? 'Short' : 'Long'}
+                      </span>
+                    )}
+                    {row.isEstimated && (
+                      <span title="Estimated using avg cost" className="ml-1 text-amber-500">
+                        *
+                      </span>
+                    )}
+                  </span>
+                  {isDerivative &&
+                    (() => {
+                      const info = parseOptionIdentifier(position.identifier)
+                      if (!info) return null
+                      const expiryDate = new Date(
+                        Number(`20${info.expiry.slice(6)}`),
+                        Number(info.expiry.slice(0, 2)) - 1,
+                        Number(info.expiry.slice(3, 5))
+                      )
+                      const label = expiryDate.toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: '2-digit',
+                      })
+                      return (
+                        <div className="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5">
+                          {label} {info.type} ${info.strike.toFixed(info.strike % 1 === 0 ? 0 : 1)}
+                        </div>
+                      )
+                    })()}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                  {isDerivative ? Math.abs(position.quantity) : position.quantity}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                  {formatCurrency(position.avgCost, position.currency)}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                  {formatCurrency(row.mktPrice, position.currency)}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                  <div>
+                    {showConverted
+                      ? formatCurrency(
+                          convertAmount(row.mktValue, position.currency, prefCurrency, fxRates!),
+                          prefCurrency
+                        )
+                      : formatCurrency(row.mktValue, position.currency)}
+                    {showConverted && (
+                      <div className="text-xs text-gray-400 font-normal">
+                        {formatCurrency(row.mktValue, position.currency)}
+                      </div>
+                    )}
+                  </div>
+                </td>
+                <td className={`px-3 py-2.5 text-right font-mono tabular-nums font-medium ${pnClass(row.pnl)}`}>
+                  <div>
+                    {showConverted
+                      ? formatCurrency(convertAmount(row.pnl, position.currency, prefCurrency, fxRates!), prefCurrency)
+                      : formatCurrency(row.pnl, position.currency)}
+                    {showConverted && (
+                      <div className="text-xs font-normal">{formatCurrency(row.pnl, position.currency)}</div>
+                    )}
+                  </div>
+                </td>
+              </tr>
+              {isExpanded && <HoldingDetailRow row={row} />}
+            </tbody>
+          )
+        })}
+      </table>
+    </div>
+  )
+}
+
+/** Parse OCC option identifier into human-readable contract info */
+function parseOptionIdentifier(
+  identifier: string | undefined
+): { expiry: string; type: string; strike: number } | null {
+  if (!identifier) return null
+  // OCC format: <symbol><2 spaces><YYMMDD><C|P><strike_padded_zero*1000>
+  const match = identifier.match(/\s{2,}(\d{2})(\d{2})(\d{2})([CP])(\d{5,8})$/)
+  if (!match) return null
+  const [, yy, mm, dd, type, strikeStr] = match
+  const strike = Number.parseInt(strikeStr, 10) / 1000
+  const expiry = `${mm}/${dd}/${yy}`
+  return { expiry, type, strike }
+}
+
+/** Stock-like security types shown in the main holdings section */
+const STOCK_LIKE_TYPES = new Set(['STK', 'CASH', 'FUND', 'MLEG'])
+/** Derivative types shown in the derivatives section */
+const DERIVATIVE_TYPES = new Set(['OPT', 'FUT', 'FOP', 'WAR'])
+
+function isStockLike(p: BrokeragePosition): boolean {
+  if (p.secType == null) return true // default / legacy
+  return STOCK_LIKE_TYPES.has(p.secType)
+}
+
+function isDerivative(p: BrokeragePosition): boolean {
+  if (p.secType == null) return false
+  return DERIVATIVE_TYPES.has(p.secType)
+}
+
+function toRow(position: BrokeragePosition): PositionRow {
+  const mktValue = position.marketValue ?? position.quantity * position.avgCost
+  // For derivatives, divide by multiplier so Last Price is per-share (consistent
+  // with avgCost). Tiger reports marketValue as total contract value, so for
+  // options with multiplier=100, mktValue/qty = $165/contract = $1.65/share.
+  const mult = isDerivative(position) && position.multiplier ? position.multiplier : 1
+  const mktPrice = position.marketValue ? position.marketValue / position.quantity / mult : position.avgCost
+  // Use authoritative unrealizedPnl from the API when available.
+  const pnl = position.unrealizedPnl ?? (mktPrice - position.avgCost) * position.quantity * mult
+  const isEstimated = !position.marketValue
+  return { position, mktPrice, mktValue, pnl, isEstimated }
+}
+
+function CollapsibleCurrencyGroup({
+  currency,
+  label,
+  rows,
+  preferredCurrency,
+  fxRates,
+  defaultExpanded,
+  variant = 'stock',
+}: {
+  currency: string
+  label: string
+  rows: PositionRow[]
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+  defaultExpanded: boolean
+  variant?: 'stock' | 'derivative'
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+
+  return (
+    <div>
+      <button
+        onClick={() => setExpanded((p) => !p)}
+        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm font-bold text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        style={{
+          backgroundColor: 'var(--bg)',
+          borderBottom: '2px solid var(--border)',
+          borderTop: '1px solid var(--border)',
+        }}
+      >
+        <span
+          className="inline-flex items-center justify-center w-7 h-7 rounded-md text-xs font-bold text-white"
+          style={{ backgroundColor: 'var(--accent)' }}
+        >
+          {currency}
+        </span>
+        {label}
+        <span className="ml-auto text-xs font-normal text-gray-400">
+          {rows.length} {rows.length === 1 ? 'position' : 'positions'}
+        </span>
+      </button>
+      {expanded && (
+        <HoldingsTable positions={rows} preferredCurrency={preferredCurrency} fxRates={fxRates} variant={variant} />
+      )}
+    </div>
+  )
+}
+
+/** Render a list of currency-grouped sections for a set of position rows */
+function PositionSection({
+  title,
+  rows,
+  preferredCurrency,
+  fxRates,
+  defaultExpanded,
+  variant = 'stock',
+}: {
+  title: string
+  rows: PositionRow[]
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+  defaultExpanded: boolean
+  variant?: 'stock' | 'derivative'
+  emptyMessage?: string
+}) {
+  if (rows.length === 0) return null
+
+  // Group by currency
+  const grouped = rows.reduce<Record<string, PositionRow[]>>((acc, row) => {
+    const cur = row.position.currency
+    if (!acc[cur]) acc[cur] = []
+    acc[cur].push(row)
+    return acc
+  }, {})
+
+  const sortedCurrencies = Object.keys(grouped).sort()
+
+  return (
+    <div className="rounded-xl border overflow-hidden" style={{ borderColor: 'var(--border)' }}>
+      {sortedCurrencies.map((cur) => (
+        <CollapsibleCurrencyGroup
+          key={cur}
+          currency={cur}
+          label={title}
+          rows={grouped[cur]}
+          preferredCurrency={preferredCurrency}
+          fxRates={fxRates}
+          defaultExpanded={defaultExpanded}
+          variant={variant}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError }: HoldingsTabProps) {
+  const [search, setSearch] = useState('')
+
+  const allPositions = useLiveQuery(() => db.brokeragePositions.toArray(), [])
+
+  // Split into stock-like and derivatives
+  const stockRows: PositionRow[] = []
+  const derivativeRows: PositionRow[] = []
+
+  for (const p of allPositions ?? []) {
+    const row = toRow(p)
+    if (isStockLike(p)) {
+      stockRows.push(row)
+    } else if (isDerivative(p)) {
+      derivativeRows.push(row)
+    }
+    // Unknown secType falls through (shouldn't happen with current Tiger data)
+  }
+
+  // Apply search filter to BOTH sections
+  function matchesSearch(row: PositionRow): boolean {
+    if (!search.trim()) return true
+    const q = search.toLowerCase()
+    return row.position.symbol.toLowerCase().includes(q) || (row.position.name ?? '').toLowerCase().includes(q)
+  }
+
+  const filteredStock = stockRows.filter(matchesSearch)
+  const filteredDerivatives = derivativeRows.filter(matchesSearch)
+
+  const showConverted = preferredCurrency !== 'Original' && fxRates != null
+
+  // ── Empty / loading states ─────────────────────────────────────────────
+
+  if (!allPositions) {
+    return <div className="flex items-center justify-center py-12 text-gray-400">Loading...</div>
+  }
+
+  if (allPositions.length === 0) {
+    return (
+      <div
+        className="text-center p-8 rounded-xl border"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+      >
+        <p className="text-gray-600 dark:text-gray-400 mb-4">No holdings yet. Sync your account.</p>
+        <Link
+          to="/settings/brokerage"
+          className="inline-flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-full text-white transition-colors"
+          style={{ backgroundColor: 'var(--accent)' }}
+        >
+          <Info size={14} />
+          Brokerage Settings
+        </Link>
+      </div>
+    )
+  }
+
+  if (stockRows.length === 0 && derivativeRows.length === 0) {
+    // All positions have an unexpected secType (shouldn't happen)
+    return (
+      <div
+        className="text-center p-8 rounded-xl border"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+      >
+        <p className="text-gray-600 dark:text-gray-400 mb-2">No recognizable holdings found.</p>
+        <p className="text-sm text-gray-400 dark:text-gray-500 mb-4">
+          Your account has positions with unknown security types. Try syncing again.
+        </p>
+        <Link
+          to="/settings/brokerage"
+          className="inline-flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-full text-white transition-colors"
+          style={{ backgroundColor: 'var(--accent)' }}
+        >
+          <Info size={14} />
+          Brokerage Settings
+        </Link>
+      </div>
+    )
+  }
+
+  // ── Main render ────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-4">
+      {/* FX status bar */}
+      {showConverted && fxLastUpdated && (
+        <div className="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500 px-1">
+          <span>
+            FX rates as of {new Date(fxLastUpdated).toLocaleString()} · displaying in{' '}
+            <span className="font-medium text-gray-600 dark:text-gray-300">{preferredCurrency}</span>
+          </span>
+          {fxError && <span className="text-amber-600 dark:text-amber-400">· FX error: {fxError}</span>}
+        </div>
+      )}
+      {showConverted && fxError && (
+        <div className="text-xs text-amber-600 dark:text-amber-400 px-1">
+          FX rates unavailable · showing original currency values · {fxError}
+        </div>
+      )}
+
+      {/* Search */}
+      <div className="relative">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by symbol or name..."
+          className="w-full text-sm border rounded-lg px-4 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          style={{ borderColor: 'var(--border)' }}
+        />
+        {search && (
+          <button
+            onClick={() => setSearch('')}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      {/* No search results */}
+      {search.trim() && filteredStock.length === 0 && filteredDerivatives.length === 0 && (
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400 text-sm">
+          No results for &quot;{search}&quot;
+        </div>
+      )}
+
+      {/* Stocks section */}
+      <PositionSection
+        title="Holdings"
+        rows={filteredStock}
+        preferredCurrency={preferredCurrency}
+        fxRates={fxRates}
+        defaultExpanded={true}
+      />
+
+      {/* Derivatives section (options, futures, etc.) */}
+      <PositionSection
+        title="Derivatives"
+        rows={filteredDerivatives}
+        preferredCurrency={preferredCurrency}
+        fxRates={fxRates}
+        defaultExpanded={false}
+        variant="derivative"
+      />
+    </div>
+  )
+}

--- a/apps/web/src/pages/portfolio/OverviewTab.tsx
+++ b/apps/web/src/pages/portfolio/OverviewTab.tsx
@@ -1,0 +1,441 @@
+import { useLiveQuery } from 'dexie-react-hooks'
+import { AlertCircle, Minus, TrendingDown, TrendingUp } from 'lucide-react'
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
+import { CATEGORY_PALETTE } from '../../lib/charts/chartPalette'
+import { TOOLTIP_STYLE } from '../../lib/charts/chartTheme'
+import { db } from '../../lib/db/db'
+import { convertAmount } from '../../lib/fx/convert'
+import type { CurrencyOption } from './currencyPreference'
+
+export interface OverviewTabProps {
+  /** User's preferred display currency */
+  preferredCurrency: CurrencyOption
+  /** Cached FX rates map (base currency rates) */
+  fxRates: Record<string, number> | null
+  /** ISO timestamp of when FX rates were last fetched */
+  fxLastUpdated: string | null
+  /** Error message if FX rates failed to load */
+  fxError: string | null
+}
+
+interface KpiCardProps {
+  title: string
+  value: string
+  secondary?: string
+  warning?: string
+  trend?: 'positive' | 'negative' | 'neutral'
+  loading?: boolean
+}
+
+function KpiCard({ title, value, secondary, warning, trend, loading }: KpiCardProps) {
+  if (loading) {
+    return (
+      <div
+        className="animate-pulse rounded-xl border p-5"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+      >
+        <div className="mb-3 h-3 w-20 rounded bg-gray-200 dark:bg-gray-700" />
+        <div className="h-8 w-32 rounded bg-gray-200 dark:bg-gray-700" />
+      </div>
+    )
+  }
+
+  const valueColor =
+    trend === 'positive'
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : trend === 'negative'
+        ? 'text-red-600 dark:text-red-400'
+        : 'text-gray-900 dark:text-white'
+
+  const TrendIcon = trend === 'positive' ? TrendingUp : trend === 'negative' ? TrendingDown : Minus
+
+  return (
+    <div
+      className="rounded-xl border p-5"
+      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+    >
+      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{title}</div>
+      <div className="flex items-center gap-2">
+        {trend && <TrendIcon size={18} className={valueColor} />}
+        <span className={`font-mono text-2xl font-semibold tabular-nums ${valueColor}`}>{value}</span>
+      </div>
+      {secondary && <div className="mt-1 text-xs text-gray-400">{secondary}</div>}
+      {warning && (
+        <div className="mt-1 flex items-center gap-1 text-xs text-amber-500">
+          <AlertCircle size={12} />
+          <span>{warning}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AllocationChart({
+  positions,
+  totalValue,
+  preferredCurrency,
+  fxRates,
+  loading,
+}: {
+  positions: import('@lokfi/brokerage-core').BrokeragePosition[]
+  totalValue: number
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+  loading?: boolean
+}) {
+  if (loading) {
+    return (
+      <div
+        className="animate-pulse rounded-xl border p-5"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+      >
+        <div className="mb-4 h-4 w-32 rounded bg-gray-200 dark:bg-gray-700" />
+        <div className="flex justify-center">
+          <div className="h-48 w-48 rounded-full bg-gray-200 dark:bg-gray-700" />
+        </div>
+      </div>
+    )
+  }
+
+  if (positions.length === 0) {
+    return null
+  }
+
+  // Group by secType
+  const grouped: Record<string, number> = {}
+  for (const p of positions) {
+    const secType = p.secType ?? 'OTHER'
+    const value = p.marketValue ?? p.quantity * p.avgCost
+    const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+    const convertedValue = shouldConvert ? convertAmount(value, p.currency, preferredCurrency, fxRates) : value
+    grouped[secType] = (grouped[secType] ?? 0) + convertedValue
+  }
+
+  const data = Object.entries(grouped)
+    .filter(([, v]) => v > 0)
+    .map(([name, value]) => ({
+      name,
+      value,
+      pct: totalValue > 0 ? (value / totalValue) * 100 : 0,
+    }))
+
+  if (data.length === 0) return null
+
+  const renderLabel = ({ name, percent }: { name: string; percent: number }) => `${name} ${(percent * 100).toFixed(1)}%`
+
+  return (
+    <div
+      className="rounded-xl border p-5"
+      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+    >
+      <h3 className="mb-4 font-serif text-sm font-medium text-gray-900 dark:text-white">Asset Allocation</h3>
+      <ResponsiveContainer width="100%" height={260}>
+        <PieChart>
+          <Pie
+            data={data}
+            cx="50%"
+            cy="50%"
+            innerRadius={55}
+            outerRadius={75}
+            dataKey="value"
+            labelLine={false}
+            label={renderLabel}
+          >
+            {data.map((_, index) => (
+              <Cell key={`cell-${index}`} fill={CATEGORY_PALETTE[index % CATEGORY_PALETTE.length]} />
+            ))}
+          </Pie>
+          <Tooltip
+            contentStyle={TOOLTIP_STYLE}
+            formatter={(value: number) => [
+              value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+              'Value',
+            ]}
+          />
+          <Legend formatter={(value: string) => value} />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+function CurrencyBreakdown({
+  positions,
+  accounts,
+  totalValue,
+  preferredCurrency,
+  fxRates,
+  loading,
+}: {
+  positions: import('@lokfi/brokerage-core').BrokeragePosition[]
+  accounts: import('@lokfi/brokerage-core').BrokerageAccount[]
+  totalValue: number
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+  loading?: boolean
+}) {
+  if (loading) {
+    return (
+      <div
+        className="animate-pulse rounded-xl border p-5"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+      >
+        <div className="mb-4 h-4 w-32 rounded bg-gray-200 dark:bg-gray-700" />
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="mb-3 flex items-center gap-3">
+            <div className="h-4 w-12 rounded bg-gray-200 dark:bg-gray-700" />
+            <div className="h-2 flex-1 rounded bg-gray-200 dark:bg-gray-700" />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (positions.length === 0 && accounts.length === 0) {
+    return null
+  }
+
+  // Aggregate by currency
+  const currencyTotals: Record<string, { converted: number; original: number }> = {}
+  const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+
+  for (const p of positions) {
+    const value = p.marketValue ?? p.quantity * p.avgCost
+    const convertedValue = shouldConvert ? convertAmount(value, p.currency, preferredCurrency, fxRates) : value
+    if (!currencyTotals[p.currency]) currencyTotals[p.currency] = { converted: 0, original: 0 }
+    currencyTotals[p.currency].converted += convertedValue
+    currencyTotals[p.currency].original += value
+  }
+
+  for (const acc of accounts) {
+    const convertedValue = shouldConvert
+      ? convertAmount(acc.cashBalance, acc.currency, preferredCurrency, fxRates)
+      : acc.cashBalance
+    if (!currencyTotals[acc.currency]) currencyTotals[acc.currency] = { converted: 0, original: 0 }
+    currencyTotals[acc.currency].converted += convertedValue
+    currencyTotals[acc.currency].original += acc.cashBalance
+  }
+
+  const entries = Object.entries(currencyTotals).filter(([, c]) => c.converted > 0 || c.original > 0)
+
+  if (entries.length === 0) return null
+
+  return (
+    <div
+      className="rounded-xl border p-5"
+      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+    >
+      <h3 className="mb-4 font-serif text-sm font-medium text-gray-900 dark:text-white">Currency Breakdown</h3>
+      <div className="space-y-3">
+        {entries.map(([currency, c]) => {
+          const pct = totalValue > 0 ? (c.converted / totalValue) * 100 : 0
+          const needsWarning = shouldConvert && currency !== preferredCurrency && !fxRates?.[currency]
+          return (
+            <div key={currency}>
+              <div className="mb-1 flex items-center justify-between text-xs">
+                <span className="font-medium text-gray-700 dark:text-gray-300">{currency}</span>
+                <span className="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+                  {c.converted.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
+                  {needsWarning && <AlertCircle size={10} className="text-amber-500" />}
+                  <span className="text-gray-400">({pct.toFixed(1)}%)</span>
+                </span>
+              </div>
+              <div className="h-1.5 w-full rounded-full bg-gray-100 dark:bg-gray-800">
+                <div
+                  className="h-1.5 rounded-full transition-all"
+                  style={{
+                    width: `${Math.min(pct, 100)}%`,
+                    backgroundColor:
+                      CATEGORY_PALETTE[entries.findIndex(([k]) => k === currency) % CATEGORY_PALETTE.length],
+                  }}
+                />
+              </div>
+              {shouldConvert && currency !== preferredCurrency && (
+                <div className="mt-0.5 text-xs text-gray-400">
+                  Original:{' '}
+                  {c.original.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}{' '}
+                  {currency}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function PerformanceSparkline() {
+  // TODO: Implement historical snapshots — store portfolio value snapshots in
+  // brokerageAccounts history or a dedicated snapshot table, then compute
+  // value over time for the sparkline. Currently no historical data is stored.
+  return (
+    <div
+      className="rounded-xl border p-5"
+      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-serif text-sm font-medium text-gray-900 dark:text-white">Performance</h3>
+        <div className="flex gap-1">
+          {['1M', '3M', '6M', '1Y', 'YTD', 'All'].map((range) => (
+            <button
+              key={range}
+              className="rounded px-2 py-0.5 text-xs text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+            >
+              {range}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex h-40 items-center justify-center text-sm text-gray-400">
+        Not enough data — sync again to build history
+      </div>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div
+      className="col-span-full rounded-xl border p-8 text-center"
+      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+    >
+      <p className="mb-4 text-gray-500 dark:text-gray-400">No portfolio data yet. Sync your brokerage account.</p>
+      <a
+        href="/settings/brokerage"
+        className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-white transition-colors"
+        style={{ backgroundColor: 'var(--accent)' }}
+      >
+        Brokerage Settings
+      </a>
+    </div>
+  )
+}
+
+export function OverviewTab({
+  preferredCurrency = 'SGD',
+  fxRates = null,
+  fxLastUpdated = null,
+  fxError = null,
+}: Partial<OverviewTabProps> & { preferredCurrency: CurrencyOption }) {
+  const positions = useLiveQuery(() => db.brokeragePositions.toArray(), [])
+  const accounts = useLiveQuery(() => db.brokerageAccounts.toArray(), [])
+  const fundDetails = useLiveQuery(() => db.brokerageFundDetails.toArray(), [])
+
+  const isLoading = positions === undefined || accounts === undefined || fundDetails === undefined
+
+  // ── Derived values ─────────────────────────────────────────────────────────
+
+  const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+
+  // Total portfolio value: sum of positions (marketValue or qty*avgCost) + cash balances
+  const totalValue = (() => {
+    if (!positions || !accounts) return 0
+    let sum = 0
+    for (const p of positions) {
+      const v = p.marketValue ?? p.quantity * p.avgCost
+      sum += shouldConvert ? convertAmount(v, p.currency, preferredCurrency, fxRates) : v
+    }
+    for (const a of accounts) {
+      sum += shouldConvert ? convertAmount(a.cashBalance, a.currency, preferredCurrency, fxRates) : a.cashBalance
+    }
+    return sum
+  })()
+
+  // Day change: sum of unrealizedPnl as proxy (historical snapshots not available)
+  const dayChange = (() => {
+    if (!positions) return null
+    let sum = 0
+    for (const p of positions) {
+      if (p.unrealizedPnl != null) {
+        const v = shouldConvert
+          ? convertAmount(p.unrealizedPnl, p.currency, preferredCurrency, fxRates)
+          : p.unrealizedPnl
+        sum += v
+      }
+    }
+    return sum
+  })()
+
+  // Dividends YTD
+  const dividendsYtd = (() => {
+    if (!fundDetails) return null
+    const year = new Date().getFullYear()
+    let sum = 0
+    for (const fd of fundDetails) {
+      if (fd.classifiedType !== 'DIVIDEND' && fd.classifiedType !== 'DIVIDEND_TAX') continue
+      if (!fd.businessDate) continue
+      const yearMatch = fd.businessDate.startsWith(String(year))
+      if (!yearMatch) continue
+      const amt = fd.amount
+      const v = shouldConvert ? convertAmount(amt, fd.currency, preferredCurrency, fxRates) : amt
+      sum += v
+    }
+    return sum
+  })()
+
+  // FX warning
+  const fxWarning = fxError ?? (shouldConvert && !fxRates ? 'FX rate unavailable' : null)
+
+  // Determine if we have any data
+  const hasData = !isLoading && (positions?.length ?? 0) > 0
+
+  // Format helpers
+  const fmt = (v: number) => v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+
+  const fmtWithSymbol = (v: number) => `${preferredCurrency === 'Original' ? '' : preferredCurrency} ${fmt(v)}`
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {/* KPI Row */}
+      <KpiCard title="Total Portfolio Value" value={fmtWithSymbol(totalValue)} loading={isLoading} />
+      <KpiCard
+        title="Day Change"
+        value={dayChange !== null ? fmtWithSymbol(dayChange) : '—'}
+        trend={dayChange !== null ? (dayChange > 0 ? 'positive' : dayChange < 0 ? 'negative' : 'neutral') : undefined}
+        loading={isLoading}
+      />
+      <KpiCard
+        title="Dividends YTD"
+        value={dividendsYtd !== null ? fmtWithSymbol(dividendsYtd) : '—'}
+        secondary={fxLastUpdated ? `Rates updated ${new Date(fxLastUpdated).toLocaleDateString()}` : undefined}
+        warning={fxWarning ?? undefined}
+        loading={isLoading}
+      />
+
+      {/* Empty state */}
+      {!isLoading && !hasData && <EmptyState />}
+
+      {/* Allocation chart */}
+      {!isLoading && hasData && (
+        <AllocationChart
+          positions={positions!}
+          totalValue={totalValue}
+          preferredCurrency={preferredCurrency}
+          fxRates={fxRates}
+        />
+      )}
+
+      {/* Currency breakdown */}
+      {!isLoading && hasData && (
+        <CurrencyBreakdown
+          positions={positions!}
+          accounts={accounts!}
+          totalValue={totalValue}
+          preferredCurrency={preferredCurrency}
+          fxRates={fxRates}
+        />
+      )}
+
+      {/* Performance sparkline */}
+      {!isLoading && hasData && (
+        <div className="md:col-span-2 lg:col-span-3">
+          <PerformanceSparkline />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/portfolio/PortfolioPage.tsx
+++ b/apps/web/src/pages/portfolio/PortfolioPage.tsx
@@ -1,0 +1,274 @@
+import { Link, useLocation, useNavigate } from '@tanstack/react-router'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { RefreshCw, Settings } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  CredentialManager,
+  DexieCredentialStore,
+  DexieSyncAdapter,
+  SyncOrchestrator,
+  TigerProvider,
+} from '../../lib/brokerage'
+import type { TigerClientConfig } from '../../lib/brokerage'
+import { SyncProgressBar } from '../../lib/brokerage/SyncProgressBar'
+import type { SyncProgress } from '../../lib/brokerage/sync-orchestrator'
+import { db } from '../../lib/db/db'
+import { useFxRates } from '../../lib/fx/useFxRates'
+import { CurrencySelector } from './CurrencySelector'
+import { DividendsTab } from './DividendsTab'
+import { HoldingsTab } from './HoldingsTab'
+import { OverviewTab } from './OverviewTab'
+import { PortfolioTabs } from './PortfolioTabs'
+import { PortfolioTransactionsTab } from './PortfolioTransactionsTab'
+import { type CurrencyOption, getPreferredCurrency, setPreferredCurrency } from './currencyPreference'
+
+const SOURCE = 'tiger'
+
+export function PortfolioPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const searchParams = new URLSearchParams(location.search)
+  const tab = searchParams.get('tab') || 'overview'
+  const validTabs = ['overview', 'holdings', 'transactions', 'dividends']
+  const activeTab = validTabs.includes(tab) ? tab : 'overview'
+
+  const [preferredCurrency, setPreferredCurrencyState] = useState<CurrencyOption>('SGD')
+  const [passphrase, setPassphrase] = useState('')
+  const [syncing, setSyncing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [showSyncForm, setShowSyncForm] = useState(false)
+  const [syncProgress, setSyncProgress] = useState<SyncProgress[]>([])
+
+  const credManager = useMemo(() => new CredentialManager(new DexieCredentialStore(db)), [])
+  const { rates: fxRates, lastUpdated: fxLastUpdated, error: fxError } = useFxRates('USD')
+
+  const hasCredentials = useLiveQuery(() => db.brokerageCredentials.count(), []) ?? 0
+
+  const lastSyncLog = useLiveQuery(async () => {
+    const logs = await db.brokerageSyncLog.orderBy('lastSyncAt').reverse().limit(1).toArray()
+    return logs[0] ?? null
+  }, [])
+
+  const lookbackDays = useLiveQuery(async () => {
+    const s = await db.settings.get(`brokerage:${SOURCE}:lookbackDays`)
+    return s ? Number.parseInt(s.value, 10) : 90
+  }, [])
+
+  useEffect(() => {
+    getPreferredCurrency().then(setPreferredCurrencyState)
+  }, [])
+
+  function setTab(newTab: string) {
+    navigate({ to: '/portfolio', search: { tab: newTab } })
+  }
+
+  async function handleCurrencyChange(currency: CurrencyOption) {
+    setPreferredCurrencyState(currency)
+    await setPreferredCurrency(currency)
+  }
+
+  useEffect(() => {
+    if (error) {
+      const t = setTimeout(() => setError(null), 5000)
+      return () => clearTimeout(t)
+    }
+  }, [error])
+
+  useEffect(() => {
+    if (success) {
+      const t = setTimeout(() => setSuccess(null), 5000)
+      return () => clearTimeout(t)
+    }
+  }, [success])
+
+  async function handleSync() {
+    if (!passphrase) {
+      setError('Enter your passphrase to sync')
+      return
+    }
+    if (lookbackDays === undefined) {
+      setError('Lookback days not loaded')
+      return
+    }
+    setSyncing(true)
+    setError(null)
+    setSuccess(null)
+    setSyncProgress([])
+    try {
+      const stored = await credManager.retrieve(SOURCE, passphrase)
+      if (!stored) {
+        setError('No credentials found')
+        return
+      }
+      const config: TigerClientConfig = {
+        tigerId: stored.tigerId,
+        privateKey: stored.privateKey,
+        account: stored.account,
+      }
+      const provider = new TigerProvider({ config })
+      const adapter = new DexieSyncAdapter(db)
+      const orchestrator = new SyncOrchestrator({
+        provider,
+        database: adapter,
+        lookbackDays,
+        onProgress: (p) => setSyncProgress((prev) => [...prev, p]),
+      })
+      await orchestrator.sync()
+      setSuccess('Sync completed')
+      setPassphrase('')
+      setShowSyncForm(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sync failed')
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-5 py-8">
+      {/* Page header */}
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="font-serif text-xl text-gray-900 dark:text-white">Portfolio</h1>
+        <div className="flex items-center gap-3">
+          {fxRates && preferredCurrency !== 'Original' && fxRates[preferredCurrency] && (
+            <span className="text-xs text-gray-400 dark:text-gray-500" title={`Updated ${fxLastUpdated ?? 'unknown'}`}>
+              1 USD = {fxRates[preferredCurrency].toFixed(4)} {preferredCurrency}
+            </span>
+          )}
+          {fxLastUpdated && <span className="text-xs text-gray-400 dark:text-gray-500">{fxLastUpdated}</span>}
+          <CurrencySelector value={preferredCurrency} onChange={handleCurrencyChange} />
+          <Link
+            to="/settings/brokerage"
+            className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+            title="Brokerage Settings"
+          >
+            <Settings size={18} />
+          </Link>
+        </div>
+      </div>
+
+      {/* Sync status bar */}
+      <div
+        className="flex items-center justify-between px-4 py-3 rounded-xl border mb-6"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+      >
+        <div className="flex items-center gap-3">
+          {lastSyncLog ? (
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              Last sync: {new Date(lastSyncLog.lastSyncAt).toLocaleString()}
+            </span>
+          ) : (
+            <span className="text-sm text-gray-500 dark:text-gray-400">Never synced</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {showSyncForm ? (
+            <div className="flex items-center gap-2">
+              <input
+                type="password"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                placeholder="Passphrase"
+                className="text-sm border rounded-lg px-3 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500"
+                style={{ borderColor: 'var(--border)' }}
+              />
+              <button
+                onClick={handleSync}
+                disabled={syncing}
+                className="text-sm font-medium px-3 py-1.5 rounded-full text-white transition-colors disabled:opacity-50"
+                style={{ backgroundColor: 'var(--accent)' }}
+              >
+                {syncing ? 'Syncing...' : 'Confirm'}
+              </button>
+              <button
+                onClick={() => {
+                  setShowSyncForm(false)
+                  setPassphrase('')
+                }}
+                className="text-sm px-3 py-1.5 rounded-full border transition-colors"
+                style={{ borderColor: 'var(--border)' }}
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowSyncForm(true)}
+              className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 rounded-full border transition-colors"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              <RefreshCw size={14} />
+              Sync Now
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Alerts */}
+      {error && (
+        <div className="mb-4 flex items-center gap-2 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-4 py-3 rounded-lg border border-red-200 dark:border-red-800">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="mb-4 flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 px-4 py-3 rounded-lg border border-emerald-200 dark:border-emerald-800">
+          {success}
+        </div>
+      )}
+
+      {/* Sync progress */}
+      <SyncProgressBar progress={syncProgress} syncing={syncing} />
+
+      {/* No data CTA */}
+      {hasCredentials === 0 && (
+        <div
+          className="text-center p-8 rounded-xl border mb-6"
+          style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+        >
+          <p className="text-gray-600 dark:text-gray-400 mb-4">No portfolio data yet. Sync your brokerage account.</p>
+          <Link
+            to="/settings/brokerage"
+            className="inline-flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-full text-white transition-colors"
+            style={{ backgroundColor: 'var(--accent)' }}
+          >
+            <Settings size={14} />
+            Brokerage Settings
+          </Link>
+        </div>
+      )}
+
+      {/* Tabs */}
+      <PortfolioTabs activeTab={activeTab} onTabChange={setTab} />
+
+      {/* Tab content */}
+      <div className="mt-6">
+        {activeTab === 'overview' && (
+          <OverviewTab
+            preferredCurrency={preferredCurrency}
+            fxRates={fxRates}
+            fxLastUpdated={fxLastUpdated}
+            fxError={fxError}
+          />
+        )}
+        {activeTab === 'holdings' && (
+          <HoldingsTab
+            preferredCurrency={preferredCurrency}
+            fxRates={fxRates}
+            fxLastUpdated={fxLastUpdated}
+            fxError={fxError}
+          />
+        )}
+        {activeTab === 'transactions' && <PortfolioTransactionsTab />}
+        {activeTab === 'dividends' && (
+          <DividendsTab
+            preferredCurrency={preferredCurrency}
+            fxRates={fxRates}
+            fxLastUpdated={fxLastUpdated}
+            fxError={fxError}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/portfolio/PortfolioTabs.tsx
+++ b/apps/web/src/pages/portfolio/PortfolioTabs.tsx
@@ -1,0 +1,44 @@
+const TABS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'holdings', label: 'Holdings' },
+  { id: 'transactions', label: 'Transactions' },
+  { id: 'dividends', label: 'Dividends' },
+] as const
+
+interface PortfolioTabsProps {
+  activeTab: string
+  onTabChange: (tab: string) => void
+}
+
+export function PortfolioTabs({ activeTab, onTabChange }: PortfolioTabsProps) {
+  return (
+    <div className="border-b overflow-x-auto" style={{ borderColor: 'var(--border)' }}>
+      <div className="flex gap-1 min-w-max">
+        {TABS.map((t) => {
+          const isActive = t.id === activeTab
+          return (
+            <button
+              key={t.id}
+              onClick={() => onTabChange(t.id)}
+              className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                isActive
+                  ? 'text-gray-900 dark:text-white'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+              }`}
+              style={
+                isActive
+                  ? {
+                      borderColor: 'var(--accent)',
+                      backgroundColor: 'var(--accent-subtle)',
+                    }
+                  : { borderColor: 'transparent' }
+              }
+            >
+              {t.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/portfolio/PortfolioTransactionsTab.tsx
+++ b/apps/web/src/pages/portfolio/PortfolioTransactionsTab.tsx
@@ -1,0 +1,279 @@
+import { useNavigate } from '@tanstack/react-router'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { Link as LinkIcon } from 'lucide-react'
+import { useMemo } from 'react'
+import { type UnifiedTransactionRow, fetchUnifiedRows } from '../../lib/brokerage/unifiedTransactions'
+import { db } from '../../lib/db/db'
+import { defaultFilters } from '../transactions/filterTypes'
+
+// ── Formatting helpers ──────────────────────────────────────────────────────
+
+const fmtCache = new Map<string, Intl.NumberFormat>()
+function getFormatter(currency: string): Intl.NumberFormat {
+  if (!fmtCache.has(currency)) {
+    fmtCache.set(currency, new Intl.NumberFormat('en-US', { style: 'currency', currency }))
+  }
+  return fmtCache.get(currency)!
+}
+
+function formatAmount(row: UnifiedTransactionRow): string {
+  const fmt = getFormatter(row.currency)
+  const abs = Math.abs(row.amount)
+  const sign = row.amount < 0 ? '−' : '+'
+  return `${sign}${fmt.format(abs)}`
+}
+
+function formatPrice(row: UnifiedTransactionRow): string {
+  if (row.price === undefined) return '—'
+  const fmt = getFormatter(row.currency)
+  return fmt.format(row.price)
+}
+
+function amountColorClass(row: UnifiedTransactionRow): string {
+  if (row.isBank) {
+    return row.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'
+  }
+  switch (row.type) {
+    case 'DIVIDEND':
+      return 'text-emerald-600 dark:text-emerald-400'
+    case 'FEE':
+      return 'text-red-600 dark:text-red-400'
+    default:
+      return 'text-gray-500 dark:text-gray-400'
+  }
+}
+
+function formatSource(row: UnifiedTransactionRow): string {
+  const icon = row.isBank ? '🏦' : '📈'
+  return `${icon} ${row.source}`
+}
+
+// ── Type badge ──────────────────────────────────────────────────────────────
+
+const typeBadgeClasses: Record<string, string> = {
+  BUY: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  SELL: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  DIVIDEND: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  FEE: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400',
+  SPLIT: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  RIGHTS: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  'CORP ACTION': 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  OTHER: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400',
+}
+
+function TypeBadge({ type }: { type: string }) {
+  if (type === 'BANK') return <span className="text-gray-400">—</span>
+  const cls = typeBadgeClasses[type] ?? 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400'
+  return <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${cls}`}>{type}</span>
+}
+
+// ── Category display ────────────────────────────────────────────────────────
+
+function CategoryCell({ row }: { row: UnifiedTransactionRow }) {
+  if (!row.isBank || !row.originalBank) {
+    return <span className="text-gray-400 text-xs">—</span>
+  }
+  const cat = row.originalBank.manualCategory ?? row.originalBank.category
+  return <span className="text-xs text-gray-600 dark:text-gray-400">{cat ?? '—'}</span>
+}
+
+// ── Dividend bank linking ────────────────────────────────────────────────────
+
+function useDividendBankLinks(dividendRows: UnifiedTransactionRow[]): Map<string, string> {
+  const result = useLiveQuery(async () => {
+    const linkMap = new Map<string, string>()
+    if (dividendRows.length === 0) return linkMap
+
+    const dividendInfos = await Promise.all(
+      dividendRows
+        .filter((r) => r.type === 'DIVIDEND')
+        .map(async (divRow) => {
+          // Only match dividends in SGD (bank transactions are always SGD)
+          if (divRow.currency !== 'SGD') return { divRowId: divRow.id, bankId: undefined }
+
+          const divDate = new Date(divRow.date)
+          const dateFrom = new Date(divDate)
+          dateFrom.setDate(dateFrom.getDate() - 3)
+          const dateTo = new Date(divDate)
+          dateTo.setDate(dateTo.getDate() + 3)
+
+          const candidates = await db.transactions
+            .where('date')
+            .between(dateFrom.toISOString().slice(0, 10), dateTo.toISOString().slice(0, 10))
+            .toArray()
+
+          const match = candidates.find((t) => {
+            return t.transactionValue > 0 && Math.abs(t.transactionValue - divRow.amount) < 0.01 && t.id !== divRow.id
+          })
+
+          return { divRowId: divRow.id, bankId: match?.id }
+        })
+    )
+
+    for (const { divRowId, bankId } of dividendInfos) {
+      if (bankId) linkMap.set(divRowId, bankId)
+    }
+
+    return linkMap
+  }, [dividendRows])
+
+  return result ?? new Map()
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+export function PortfolioTransactionsTab() {
+  const navigate = useNavigate()
+
+  const { rows, total } = useLiveQuery(
+    async () => {
+      const filters = { ...defaultFilters, sourceType: 'brokerage' as const }
+      const result = await fetchUnifiedRows(filters)
+      return { rows: result.rows, total: result.total }
+    },
+    [],
+    { rows: [] as UnifiedTransactionRow[], total: 0 }
+  )
+
+  const dividendRows = useMemo(() => rows.filter((r) => r.type === 'DIVIDEND'), [rows])
+  const dividendBankLinks = useDividendBankLinks(dividendRows)
+
+  if (rows.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500 dark:text-gray-400 mb-4">No transactions yet.</p>
+        <a
+          href="/settings/brokerage"
+          className="text-sm font-medium text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
+        >
+          Configure brokerage account →
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto relative">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b" style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}>
+            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Date
+            </th>
+            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Description
+            </th>
+            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Type
+            </th>
+            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Symbol
+            </th>
+            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Quantity
+            </th>
+            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Price
+            </th>
+            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Amount
+            </th>
+            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Source
+            </th>
+            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Category
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((t, i) => {
+            const isEven = i % 2 === 0
+            const linkedBankId = dividendBankLinks.get(t.id)
+
+            return (
+              <tr
+                key={t.id}
+                className="border-b transition-colors"
+                style={{
+                  borderColor: 'var(--border)',
+                  backgroundColor: isEven ? 'var(--bg)' : 'var(--bg-sidebar)',
+                }}
+              >
+                {/* Date */}
+                <td className="px-3 py-2.5 text-gray-500 dark:text-gray-400 whitespace-nowrap font-mono text-xs">
+                  {t.date.slice(0, 10)}
+                </td>
+
+                {/* Description */}
+                <td className="px-3 py-2.5 text-gray-900 dark:text-white max-w-xs">
+                  <div className="flex items-center gap-1">
+                    <span className="truncate">{t.description}</span>
+                    {linkedBankId && (
+                      <button
+                        onClick={() => navigate({ to: '/transactions' })}
+                        className="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-amber-600 dark:text-amber-400"
+                        title="Linked bank deposit"
+                      >
+                        <LinkIcon className="w-3.5 h-3.5" />
+                      </button>
+                    )}
+                  </div>
+                </td>
+
+                {/* Type badge */}
+                <td className="px-3 py-2.5">
+                  <TypeBadge type={t.type} />
+                </td>
+
+                {/* Symbol */}
+                <td className="px-3 py-2.5 text-xs font-mono text-gray-600 dark:text-gray-400">
+                  {!t.isBank && t.symbol ? t.symbol : '—'}
+                </td>
+
+                {/* Quantity */}
+                <td className="px-3 py-2.5 text-right font-mono text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+                  {!t.isBank && (t.type === 'BUY' || t.type === 'SELL') && t.quantity !== undefined
+                    ? t.quantity.toString()
+                    : '—'}
+                </td>
+
+                {/* Price */}
+                <td className="px-3 py-2.5 text-right font-mono text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+                  {!t.isBank && (t.type === 'BUY' || t.type === 'SELL') ? formatPrice(t) : '—'}
+                </td>
+
+                {/* Amount */}
+                <td
+                  className={`px-3 py-2.5 text-right font-mono whitespace-nowrap text-xs font-medium tabular-nums ${amountColorClass(t)}`}
+                >
+                  {formatAmount(t)}
+                </td>
+
+                {/* Source */}
+                <td className="px-3 py-2.5 text-gray-400 dark:text-gray-500 text-xs uppercase tracking-wide">
+                  {formatSource(t)}
+                </td>
+
+                {/* Category */}
+                <td className="px-3 py-2.5">
+                  <CategoryCell row={t} />
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      {/* Footer */}
+      <div
+        className="flex items-center justify-between px-4 py-2.5 border-t text-xs text-gray-400 dark:text-gray-500"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+      >
+        <span>
+          Showing {rows.length} of {total} transactions
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/portfolio/currencyPreference.ts
+++ b/apps/web/src/pages/portfolio/currencyPreference.ts
@@ -1,0 +1,25 @@
+import { db } from '../../lib/db/db'
+
+const CURRENCIES = ['SGD', 'USD', 'HKD', 'Original'] as const
+export type CurrencyOption = (typeof CURRENCIES)[number]
+
+/**
+ * Retrieve the user's preferred display currency from settings.
+ * Defaults to 'SGD' if not set or invalid.
+ * @returns Preferred currency option
+ */
+export async function getPreferredCurrency(): Promise<CurrencyOption> {
+  const s = await db.settings.get('portfolio:preferredCurrency')
+  const val = s?.value as CurrencyOption
+  return CURRENCIES.includes(val) ? val : 'SGD'
+}
+
+/**
+ * Save the user's preferred display currency to settings.
+ * @param currency - Currency option to save
+ */
+export async function setPreferredCurrency(currency: CurrencyOption): Promise<void> {
+  await db.settings.put({ key: 'portfolio:preferredCurrency', value: currency })
+}
+
+export { CURRENCIES }

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -15,21 +15,48 @@ export function ProfilePage() {
   const customParsers = useLiveQuery(() => db.customParsers.orderBy('createdAt').toArray(), []) ?? []
 
   async function handleExport() {
-    const [transactions, rules, categories, customParsers, budgets] = await Promise.all([
+    const [
+      transactions,
+      rules,
+      categories,
+      customParsers,
+      budgets,
+      brokeragePositions,
+      brokeragePositionExtensions,
+      brokerageTransactions,
+      brokerageCorpActions,
+      brokerageAccounts,
+      brokerageSyncLog,
+      brokerageCredentials,
+    ] = await Promise.all([
       db.transactions.toArray(),
       db.rules.toArray(),
       db.categories.toArray(),
       db.customParsers.toArray(),
       db.budgets.toArray(),
+      db.brokeragePositions.toArray(),
+      db.brokeragePositionExtensions.toArray(),
+      db.brokerageTransactions.toArray(),
+      db.brokerageCorpActions.toArray(),
+      db.brokerageAccounts.toArray(),
+      db.brokerageSyncLog.toArray(),
+      db.brokerageCredentials.toArray(),
     ])
     const data = {
-      version: 1,
+      version: 2,
       exportedAt: new Date().toISOString(),
       transactions,
       rules,
       categories,
       customParsers,
       budgets,
+      brokeragePositions,
+      brokeragePositionExtensions,
+      brokerageTransactions,
+      brokerageCorpActions,
+      brokerageAccounts,
+      brokerageSyncLog,
+      brokerageCredentials,
     }
     const blob = new Blob([JSON.stringify(data, null, 2)], {
       type: 'application/json',
@@ -65,12 +92,12 @@ export function ProfilePage() {
     const text = await file.text()
     try {
       const data = JSON.parse(text)
-      // Validate backup structure
+      // Validate basic backup structure (version 1 or 2)
       if (
         !data ||
         typeof data !== 'object' ||
         Array.isArray(data) ||
-        data.version !== 1 ||
+        (data.version !== 1 && data.version !== 2) ||
         !Array.isArray(data.transactions) ||
         !Array.isArray(data.rules) ||
         !Array.isArray(data.categories) ||
@@ -78,39 +105,106 @@ export function ProfilePage() {
         !Array.isArray(data.budgets)
       ) {
         alert(
-          'Invalid backup file: expected a full Lokfi backup JSON with version, ' +
+          'Invalid backup file: expected a Lokfi backup JSON (v1 or v2) with ' +
             'transactions, rules, categories, customParsers, and budgets.'
         )
         e.target.value = ''
         return
       }
+      // Version 2 must include all brokerage arrays
+      if (
+        data.version === 2 &&
+        (!Array.isArray(data.brokeragePositions) ||
+          !Array.isArray(data.brokeragePositionExtensions) ||
+          !Array.isArray(data.brokerageTransactions) ||
+          !Array.isArray(data.brokerageCorpActions) ||
+          !Array.isArray(data.brokerageAccounts) ||
+          !Array.isArray(data.brokerageSyncLog) ||
+          !Array.isArray(data.brokerageCredentials))
+      ) {
+        alert(
+          'Invalid v2 backup file: missing brokerage data arrays. ' +
+            'The backup appears to be incomplete or corrupted.'
+        )
+        e.target.value = ''
+        return
+      }
+      const hasBrokerage = data.version === 2
       const confirmed = window.confirm(
         `This will replace all current data with the backup:\n` +
           `• ${data.transactions.length} transaction(s)\n` +
           `• ${data.rules.length} rule(s)\n` +
           `• ${data.categories.length} categor(ies)\n` +
           `• ${data.customParsers.length} parser profile(s)\n` +
-          `• ${data.budgets.length} budget(s)\n\n` +
+          `• ${data.budgets.length} budget(s)\n` +
+          (hasBrokerage
+            ? `• ${data.brokeragePositions.length} brokerage position(s)\n` +
+              `• ${data.brokerageTransactions.length} brokerage trade(s)\n` +
+              `• ${data.brokerageAccounts.length} brokerage account(s)\n` +
+              `• ${data.brokerageCorpActions.length} corp action(s)\n` +
+              `• ${data.brokerageCredentials.length} credential(s) (encrypted)\n`
+            : `• (no brokerage data in backup)\n`) +
           `Current data will be overwritten. Are you sure?`
       )
       if (!confirmed) {
         e.target.value = ''
         return
       }
+      const tables = hasBrokerage
+        ? [
+            db.transactions,
+            db.rules,
+            db.categories,
+            db.customParsers,
+            db.budgets,
+            db.brokeragePositions,
+            db.brokeragePositionExtensions,
+            db.brokerageTransactions,
+            db.brokerageCorpActions,
+            db.brokerageAccounts,
+            db.brokerageSyncLog,
+            db.brokerageCredentials,
+          ]
+        : [db.transactions, db.rules, db.categories, db.customParsers, db.budgets]
       // Clear existing data and import backup in a single transaction
-      await db.transaction('rw', [db.transactions, db.rules, db.categories, db.customParsers, db.budgets], async () => {
+      await db.transaction('rw', tables, async () => {
         await Promise.all([
           db.transactions.clear(),
           db.rules.clear(),
           db.categories.clear(),
           db.customParsers.clear(),
           db.budgets.clear(),
+          ...(hasBrokerage
+            ? [
+                db.brokeragePositions.clear(),
+                db.brokeragePositionExtensions.clear(),
+                db.brokerageTransactions.clear(),
+                db.brokerageCorpActions.clear(),
+                db.brokerageAccounts.clear(),
+                db.brokerageSyncLog.clear(),
+                db.brokerageCredentials.clear(),
+              ]
+            : []),
         ])
         if (data.transactions.length) await db.transactions.bulkAdd(data.transactions)
         if (data.rules.length) await db.rules.bulkAdd(data.rules)
         if (data.categories.length) await db.categories.bulkAdd(data.categories)
         if (data.customParsers.length) await db.customParsers.bulkAdd(data.customParsers)
         if (data.budgets.length) await db.budgets.bulkAdd(data.budgets)
+        if (hasBrokerage) {
+          // Restore positions first (extensions depend on them via positionId)
+          if (data.brokeragePositions.length) await db.brokeragePositions.bulkAdd(data.brokeragePositions)
+          if (data.brokeragePositionExtensions.length)
+            await db.brokeragePositionExtensions.bulkAdd(data.brokeragePositionExtensions)
+          // Remaining brokerage tables have no dependencies — parallelize
+          await Promise.all([
+            data.brokerageTransactions.length && db.brokerageTransactions.bulkAdd(data.brokerageTransactions),
+            data.brokerageCorpActions.length && db.brokerageCorpActions.bulkAdd(data.brokerageCorpActions),
+            data.brokerageAccounts.length && db.brokerageAccounts.bulkAdd(data.brokerageAccounts),
+            data.brokerageSyncLog.length && db.brokerageSyncLog.bulkAdd(data.brokerageSyncLog),
+            data.brokerageCredentials.length && db.brokerageCredentials.bulkAdd(data.brokerageCredentials),
+          ])
+        }
       })
       alert('Backup imported successfully!')
     } catch {

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -24,7 +24,7 @@ export function ProfilePage() {
       brokeragePositions,
       brokeragePositionExtensions,
       brokerageTransactions,
-      brokerageCorpActions,
+      brokerageFundDetails,
       brokerageAccounts,
       brokerageSyncLog,
       brokerageCredentials,
@@ -37,13 +37,13 @@ export function ProfilePage() {
       db.brokeragePositions.toArray(),
       db.brokeragePositionExtensions.toArray(),
       db.brokerageTransactions.toArray(),
-      db.brokerageCorpActions.toArray(),
+      db.brokerageFundDetails.toArray(),
       db.brokerageAccounts.toArray(),
       db.brokerageSyncLog.toArray(),
       db.brokerageCredentials.toArray(),
     ])
     const data = {
-      version: 2,
+      version: 3,
       exportedAt: new Date().toISOString(),
       transactions,
       rules,
@@ -53,7 +53,7 @@ export function ProfilePage() {
       brokeragePositions,
       brokeragePositionExtensions,
       brokerageTransactions,
-      brokerageCorpActions,
+      brokerageFundDetails,
       brokerageAccounts,
       brokerageSyncLog,
       brokerageCredentials,
@@ -92,12 +92,12 @@ export function ProfilePage() {
     const text = await file.text()
     try {
       const data = JSON.parse(text)
-      // Validate basic backup structure (version 1 or 2)
+      // Validate basic backup structure (version 1, 2, or 3)
       if (
         !data ||
         typeof data !== 'object' ||
         Array.isArray(data) ||
-        (data.version !== 1 && data.version !== 2) ||
+        ![1, 2, 3].includes(data.version) ||
         !Array.isArray(data.transactions) ||
         !Array.isArray(data.rules) ||
         !Array.isArray(data.categories) ||
@@ -105,19 +105,18 @@ export function ProfilePage() {
         !Array.isArray(data.budgets)
       ) {
         alert(
-          'Invalid backup file: expected a Lokfi backup JSON (v1 or v2) with ' +
+          'Invalid backup file: expected a Lokfi backup JSON (v1, v2, or v3) with ' +
             'transactions, rules, categories, customParsers, and budgets.'
         )
         e.target.value = ''
         return
       }
-      // Version 2 must include all brokerage arrays
+      // Version 2 must include all brokerage arrays (except brokerageFundDetails which is new in v3)
       if (
         data.version === 2 &&
         (!Array.isArray(data.brokeragePositions) ||
           !Array.isArray(data.brokeragePositionExtensions) ||
           !Array.isArray(data.brokerageTransactions) ||
-          !Array.isArray(data.brokerageCorpActions) ||
           !Array.isArray(data.brokerageAccounts) ||
           !Array.isArray(data.brokerageSyncLog) ||
           !Array.isArray(data.brokerageCredentials))
@@ -129,7 +128,18 @@ export function ProfilePage() {
         e.target.value = ''
         return
       }
-      const hasBrokerage = data.version === 2
+
+      // Version 3 must include brokerageFundDetails
+      if (data.version === 3 && !Array.isArray(data.brokerageFundDetails)) {
+        alert(
+          'Invalid v3 backup file: missing brokerageFundDetails array. ' +
+            'The backup appears to be incomplete or corrupted.'
+        )
+        e.target.value = ''
+        return
+      }
+      const hasBrokerage = data.version >= 2
+      const fundDetailsCount = Array.isArray(data.brokerageFundDetails) ? data.brokerageFundDetails.length : 0
       const confirmed = window.confirm(
         `This will replace all current data with the backup:\n` +
           `• ${data.transactions.length} transaction(s)\n` +
@@ -141,7 +151,7 @@ export function ProfilePage() {
             ? `• ${data.brokeragePositions.length} brokerage position(s)\n` +
               `• ${data.brokerageTransactions.length} brokerage trade(s)\n` +
               `• ${data.brokerageAccounts.length} brokerage account(s)\n` +
-              `• ${data.brokerageCorpActions.length} corp action(s)\n` +
+              (fundDetailsCount > 0 ? `• ${fundDetailsCount} fund detail(s)\n` : '') +
               `• ${data.brokerageCredentials.length} credential(s) (encrypted)\n`
             : `• (no brokerage data in backup)\n`) +
           `Current data will be overwritten. Are you sure?`
@@ -160,7 +170,7 @@ export function ProfilePage() {
             db.brokeragePositions,
             db.brokeragePositionExtensions,
             db.brokerageTransactions,
-            db.brokerageCorpActions,
+            db.brokerageFundDetails,
             db.brokerageAccounts,
             db.brokerageSyncLog,
             db.brokerageCredentials,
@@ -179,7 +189,7 @@ export function ProfilePage() {
                 db.brokeragePositions.clear(),
                 db.brokeragePositionExtensions.clear(),
                 db.brokerageTransactions.clear(),
-                db.brokerageCorpActions.clear(),
+                db.brokerageFundDetails.clear(),
                 db.brokerageAccounts.clear(),
                 db.brokerageSyncLog.clear(),
                 db.brokerageCredentials.clear(),
@@ -199,7 +209,7 @@ export function ProfilePage() {
           // Remaining brokerage tables have no dependencies — parallelize
           await Promise.all([
             data.brokerageTransactions.length && db.brokerageTransactions.bulkAdd(data.brokerageTransactions),
-            data.brokerageCorpActions.length && db.brokerageCorpActions.bulkAdd(data.brokerageCorpActions),
+            data.brokerageFundDetails?.length && db.brokerageFundDetails.bulkAdd(data.brokerageFundDetails),
             data.brokerageAccounts.length && db.brokerageAccounts.bulkAdd(data.brokerageAccounts),
             data.brokerageSyncLog.length && db.brokerageSyncLog.bulkAdd(data.brokerageSyncLog),
             data.brokerageCredentials.length && db.brokerageCredentials.bulkAdd(data.brokerageCredentials),

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -31,7 +31,9 @@ export function ProfilePage() {
       customParsers,
       budgets,
     }
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
@@ -46,7 +48,9 @@ export function ProfilePage() {
   }
 
   function handleExportProfile(profile: DbCustomParserProfile) {
-    const blob = new Blob([JSON.stringify(profile, null, 2)], { type: 'application/json' })
+    const blob = new Blob([JSON.stringify(profile, null, 2)], {
+      type: 'application/json',
+    })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
@@ -55,24 +59,107 @@ export function ProfilePage() {
     URL.revokeObjectURL(url)
   }
 
+  async function handleImportBackup(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const text = await file.text()
+    try {
+      const data = JSON.parse(text)
+      // Validate backup structure
+      if (
+        !data ||
+        typeof data !== 'object' ||
+        Array.isArray(data) ||
+        data.version !== 1 ||
+        !Array.isArray(data.transactions) ||
+        !Array.isArray(data.rules) ||
+        !Array.isArray(data.categories) ||
+        !Array.isArray(data.customParsers) ||
+        !Array.isArray(data.budgets)
+      ) {
+        alert(
+          'Invalid backup file: expected a full Lokfi backup JSON with version, ' +
+            'transactions, rules, categories, customParsers, and budgets.'
+        )
+        e.target.value = ''
+        return
+      }
+      const confirmed = window.confirm(
+        `This will replace all current data with the backup:\n` +
+          `• ${data.transactions.length} transaction(s)\n` +
+          `• ${data.rules.length} rule(s)\n` +
+          `• ${data.categories.length} categor(ies)\n` +
+          `• ${data.customParsers.length} parser profile(s)\n` +
+          `• ${data.budgets.length} budget(s)\n\n` +
+          `Current data will be overwritten. Are you sure?`
+      )
+      if (!confirmed) {
+        e.target.value = ''
+        return
+      }
+      // Clear existing data and import backup in a single transaction
+      await db.transaction('rw', [db.transactions, db.rules, db.categories, db.customParsers, db.budgets], async () => {
+        await Promise.all([
+          db.transactions.clear(),
+          db.rules.clear(),
+          db.categories.clear(),
+          db.customParsers.clear(),
+          db.budgets.clear(),
+        ])
+        if (data.transactions.length) await db.transactions.bulkAdd(data.transactions)
+        if (data.rules.length) await db.rules.bulkAdd(data.rules)
+        if (data.categories.length) await db.categories.bulkAdd(data.categories)
+        if (data.customParsers.length) await db.customParsers.bulkAdd(data.customParsers)
+        if (data.budgets.length) await db.budgets.bulkAdd(data.budgets)
+      })
+      alert('Backup imported successfully!')
+    } catch {
+      alert('Invalid backup file — could not parse JSON')
+    }
+    e.target.value = ''
+  }
+
   async function handleImportProfile(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
     const text = await file.text()
     try {
-      const profile = JSON.parse(text) as DbCustomParserProfile
-      // Minimal structural validation
+      const parsed = JSON.parse(text)
+      // Detect full backup JSON (wraps profiles in { version, customParsers: [...] })
       if (
-        typeof profile.headerFingerprint !== 'string' ||
-        !profile.headerFingerprint ||
-        typeof profile.columnMap !== 'object' ||
-        profile.columnMap === null ||
-        (profile.columnMap.amount === undefined &&
-          profile.columnMap.debit === undefined &&
-          profile.columnMap.credit === undefined) ||
-        profile.columnMap.date === undefined
+        parsed &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed) &&
+        parsed.version &&
+        Array.isArray(parsed.customParsers)
       ) {
-        alert('Invalid profile: missing required fields (headerFingerprint, columnMap.date, amount/debit/credit)')
+        alert(
+          'This is a full backup file. Use the "Import backup (JSON)" button ' + 'in the Data & Backup section instead.'
+        )
+        e.target.value = ''
+        return
+      }
+      const profile = parsed as DbCustomParserProfile
+      // Gather specific missing fields for a helpful error message
+      const missing: string[] = []
+      if (typeof profile.headerFingerprint !== 'string' || !profile.headerFingerprint) {
+        missing.push('headerFingerprint')
+      }
+      if (typeof profile.columnMap !== 'object' || profile.columnMap === null) {
+        missing.push('columnMap')
+      } else {
+        if (profile.columnMap.date === undefined) missing.push('columnMap.date')
+        if (profile.columnMap.description === undefined) missing.push('columnMap.description')
+        if (
+          profile.columnMap.amount === undefined &&
+          profile.columnMap.debit === undefined &&
+          profile.columnMap.credit === undefined
+        ) {
+          missing.push('columnMap.amount/debit/credit')
+        }
+      }
+      if (missing.length > 0) {
+        alert(`Invalid profile: missing required field(s): ${missing.join(', ')}`)
         e.target.value = ''
         return
       }
@@ -100,7 +187,10 @@ export function ProfilePage() {
       {/* Data & Backup card */}
       <div
         className="rounded-xl border overflow-hidden"
-        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+        style={{
+          borderColor: 'var(--border)',
+          backgroundColor: 'var(--bg-sidebar)',
+        }}
       >
         <div className="px-5 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Data & Backup</h2>
@@ -125,9 +215,18 @@ export function ProfilePage() {
           {/* Data summary */}
           <div className="grid grid-cols-2 gap-3">
             {[
-              { label: 'Transactions', value: count !== undefined ? count : '…' },
-              { label: 'Rules', value: rulesCount !== undefined ? rulesCount : '…' },
-              { label: 'Categories', value: categoriesCount !== undefined ? categoriesCount : '…' },
+              {
+                label: 'Transactions',
+                value: count !== undefined ? count : '…',
+              },
+              {
+                label: 'Rules',
+                value: rulesCount !== undefined ? rulesCount : '…',
+              },
+              {
+                label: 'Categories',
+                value: categoriesCount !== undefined ? categoriesCount : '…',
+              },
               {
                 label: 'Date range',
                 value: oldest && newest ? `${oldest.date.slice(0, 7)} → ${newest.date.slice(0, 7)}` : '—',
@@ -136,7 +235,10 @@ export function ProfilePage() {
               <div
                 key={label}
                 className="rounded-lg border px-4 py-3"
-                style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg)' }}
+                style={{
+                  borderColor: 'var(--border)',
+                  backgroundColor: 'var(--bg)',
+                }}
               >
                 <p className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">{label}</p>
                 <p className="font-mono text-base font-medium text-gray-900 dark:text-white">{value}</p>
@@ -144,23 +246,42 @@ export function ProfilePage() {
             ))}
           </div>
 
-          {/* Export button */}
-          <div className="pt-1">
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
-              Downloads a JSON backup of all transactions, rules, and categories.
-            </p>
-            <button
-              onClick={handleExport}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium border rounded-lg transition-colors hover:opacity-90"
-              style={{
-                borderColor: 'var(--accent)',
-                color: 'var(--accent)',
-                backgroundColor: 'var(--accent-subtle)',
-              }}
-            >
-              <Download className="w-4 h-4" />
-              Export backup (JSON)
-            </button>
+          {/* Export / Import buttons */}
+          <div className="pt-1 space-y-3">
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                Downloads a JSON backup of all transactions, rules, and categories.
+              </p>
+              <button
+                onClick={handleExport}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium border rounded-lg transition-colors hover:opacity-90"
+                style={{
+                  borderColor: 'var(--accent)',
+                  color: 'var(--accent)',
+                  backgroundColor: 'var(--accent-subtle)',
+                }}
+              >
+                <Download className="w-4 h-4" />
+                Export backup (JSON)
+              </button>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                Restore from a previous backup. Current data will be overwritten.
+              </p>
+              <label
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium border rounded-lg cursor-pointer hover:opacity-80 transition-opacity w-fit"
+                style={{
+                  borderColor: 'var(--accent)',
+                  color: 'var(--accent)',
+                  backgroundColor: 'var(--accent-subtle)',
+                }}
+              >
+                <Upload className="w-4 h-4" />
+                Import backup (JSON)
+                <input type="file" accept=".json" className="hidden" onChange={handleImportBackup} />
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -168,7 +289,10 @@ export function ProfilePage() {
       {/* Parser Profiles card */}
       <div
         className="rounded-xl border overflow-hidden"
-        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+        style={{
+          borderColor: 'var(--border)',
+          backgroundColor: 'var(--bg-sidebar)',
+        }}
       >
         <div className="px-5 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Parser Profiles</h2>
@@ -184,7 +308,10 @@ export function ProfilePage() {
                 <li
                   key={p.id}
                   className="flex items-center justify-between rounded-lg border px-3 py-2 text-sm"
-                  style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg)' }}
+                  style={{
+                    borderColor: 'var(--border)',
+                    backgroundColor: 'var(--bg)',
+                  }}
                 >
                   <div className="min-w-0">
                     <p className="font-medium text-gray-800 dark:text-gray-100 truncate">{p.name}</p>
@@ -219,7 +346,7 @@ export function ProfilePage() {
               }}
             >
               <Upload className="w-4 h-4" />
-              Import profile (JSON)
+              Import parser profile (JSON)
               <input type="file" accept=".json" className="hidden" onChange={handleImportProfile} />
             </label>
           </div>

--- a/apps/web/src/pages/settings/BrokerageSettingsPage.tsx
+++ b/apps/web/src/pages/settings/BrokerageSettingsPage.tsx
@@ -1,0 +1,389 @@
+import type { BrokerageSyncLog } from '@lokfi/brokerage-core'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { AlertCircle, CheckCircle, Loader2, RefreshCw, Unlink } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  CredentialManager,
+  DexieCredentialStore,
+  DexieSyncAdapter,
+  SyncOrchestrator,
+  TigerProvider,
+} from '../../lib/brokerage'
+import type { TigerClientConfig } from '../../lib/brokerage'
+import { db } from '../../lib/db/db'
+
+const PRESETS = [30, 90, 180, 365]
+const SOURCE = 'tiger'
+
+export function BrokerageSettingsPage() {
+  const [credentials, setCredentials] = useState({ tigerId: '', privateKey: '', account: '' })
+  const [passphrase, setPassphrase] = useState('')
+  const [lookbackDays, setLookbackDays] = useState(90)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [hasCredentials, setHasCredentials] = useState(false)
+  const [syncing, setSyncing] = useState(false)
+  const [testing, setTesting] = useState(false)
+
+  const credManager = useMemo(() => new CredentialManager(new DexieCredentialStore(db)), [])
+
+  const syncLogs = useLiveQuery(() => db.brokerageSyncLog.where('source').equals(SOURCE).reverse().toArray(), [])
+
+  // Load saved lookback days
+  useEffect(() => {
+    db.settings.get(`brokerage:${SOURCE}:lookbackDays`).then((s) => {
+      if (s) {
+        const days = Number.parseInt(s.value, 10)
+        if (!isNaN(days)) setLookbackDays(days)
+      }
+    })
+  }, [])
+
+  // Check if credentials exist
+  useEffect(() => {
+    credManager.hasCredentials(SOURCE).then(setHasCredentials)
+  }, [])
+
+  function showError(msg: string) {
+    setError(msg)
+    setTimeout(() => setError(null), 5000)
+  }
+
+  function showSuccess(msg: string) {
+    setSuccess(msg)
+    setTimeout(() => setSuccess(null), 5000)
+  }
+
+  async function handleSave() {
+    if (!credentials.tigerId || !credentials.privateKey || !credentials.account || !passphrase) {
+      showError('Please fill in all fields')
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      await credManager.store(SOURCE, credentials, passphrase)
+      await db.settings.put({ key: `brokerage:${SOURCE}:lookbackDays`, value: String(lookbackDays) })
+      setHasCredentials(true)
+      showSuccess('Credentials saved')
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to save credentials')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleTest() {
+    if (!passphrase) {
+      showError('Enter your passphrase to test the connection')
+      return
+    }
+    setTesting(true)
+    setError(null)
+    try {
+      const stored = await credManager.retrieve(SOURCE, passphrase)
+      if (!stored) {
+        showError('No credentials found')
+        return
+      }
+      const config: TigerClientConfig = {
+        tigerId: stored.tigerId,
+        privateKey: stored.privateKey,
+        account: stored.account,
+      }
+      const provider = new TigerProvider({ config })
+      const ok = await provider.validateConnection()
+      if (ok) {
+        showSuccess('Connection successful')
+      } else {
+        showError('Connection failed — check your credentials')
+      }
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Connection test failed')
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  async function handleSync() {
+    if (!passphrase) {
+      showError('Enter your passphrase to sync')
+      return
+    }
+    setSyncing(true)
+    setError(null)
+    try {
+      const stored = await credManager.retrieve(SOURCE, passphrase)
+      if (!stored) {
+        showError('No credentials found')
+        return
+      }
+      const config: TigerClientConfig = {
+        tigerId: stored.tigerId,
+        privateKey: stored.privateKey,
+        account: stored.account,
+      }
+      const provider = new TigerProvider({ config })
+      const adapter = new DexieSyncAdapter(db)
+      const orchestrator = new SyncOrchestrator({ provider, database: adapter, lookbackDays })
+      await orchestrator.sync()
+      showSuccess('Sync completed')
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Sync failed')
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  async function handleDisconnect() {
+    if (!confirm('Disconnect Tiger Brokers? This will remove all synced brokerage data.')) return
+    setLoading(true)
+    try {
+      await credManager.remove(SOURCE)
+      await db.brokerageTransactions.clear()
+      await db.brokerageCorpActions.clear()
+      await db.brokeragePositions.clear()
+      await db.brokeragePositionExtensions.clear()
+      await db.brokerageAccounts.clear()
+      await db.brokerageSyncLog.where('source').equals(SOURCE).delete()
+      setHasCredentials(false)
+      setCredentials({ tigerId: '', privateKey: '', account: '' })
+      setPassphrase('')
+      showSuccess('Disconnected')
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Disconnect failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const lastSyncByCategory = new Map<string, BrokerageSyncLog>()
+  for (const log of syncLogs ?? []) {
+    if (!lastSyncByCategory.has(log.category)) {
+      lastSyncByCategory.set(log.category, log)
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto px-5 py-8">
+      <h1 className="font-serif text-2xl text-gray-900 dark:text-white mb-1">Brokerage Settings</h1>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+        Connect your Tiger Brokers account to sync trades and dividends.
+      </p>
+
+      {error && (
+        <div className="mb-4 flex items-center gap-2 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-4 py-3 rounded-lg border border-red-200 dark:border-red-800">
+          <AlertCircle className="w-4 h-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="mb-4 flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 px-4 py-3 rounded-lg border border-emerald-200 dark:border-emerald-800">
+          <CheckCircle className="w-4 h-4 shrink-0" />
+          {success}
+        </div>
+      )}
+
+      {!hasCredentials ? (
+        <div
+          className="text-center p-8 rounded-xl border"
+          style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+        >
+          <p className="text-gray-600 dark:text-gray-400 mb-4">
+            Connect your Tiger Brokers account to sync trades and dividends
+          </p>
+        </div>
+      ) : null}
+
+      <div className="space-y-5">
+        {/* Credentials */}
+        {!hasCredentials && (
+          <div className="space-y-3">
+            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">API Credentials</h2>
+            <div className="grid gap-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Tiger ID</label>
+                <input
+                  type="text"
+                  value={credentials.tigerId}
+                  onChange={(e) => setCredentials((c) => ({ ...c, tigerId: e.target.value }))}
+                  className="w-full text-sm border rounded-lg px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  style={{ borderColor: 'var(--border)' }}
+                  placeholder="Your Tiger ID"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Private Key</label>
+                <input
+                  type="password"
+                  value={credentials.privateKey}
+                  onChange={(e) => setCredentials((c) => ({ ...c, privateKey: e.target.value }))}
+                  className="w-full text-sm border rounded-lg px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  style={{ borderColor: 'var(--border)' }}
+                  placeholder="Your private key"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Account</label>
+                <input
+                  type="text"
+                  value={credentials.account}
+                  onChange={(e) => setCredentials((c) => ({ ...c, account: e.target.value }))}
+                  className="w-full text-sm border rounded-lg px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  style={{ borderColor: 'var(--border)' }}
+                  placeholder="Account number"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Passphrase — always shown for test/sync operations */}
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Passphrase</h2>
+          <div className="grid gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Passphrase</label>
+              <input
+                type="password"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                className="w-full text-sm border rounded-lg px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500"
+                style={{ borderColor: 'var(--border)' }}
+                placeholder="Encryption passphrase"
+              />
+              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                {hasCredentials
+                  ? 'Enter your passphrase to test the connection or sync.'
+                  : 'Used to encrypt your credentials. You&apos;ll need this every time you sync.'}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Lookback */}
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Sync History</h2>
+          <div>
+            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Lookback days</label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={1}
+                max={3650}
+                value={lookbackDays}
+                onChange={(e) => setLookbackDays(Number.parseInt(e.target.value, 10) || 90)}
+                className="w-24 text-sm border rounded-lg px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500"
+                style={{ borderColor: 'var(--border)' }}
+              />
+              <div className="flex gap-1">
+                {PRESETS.map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => setLookbackDays(p)}
+                    className="text-xs px-2 py-1 rounded border transition-colors"
+                    style={{
+                      borderColor: lookbackDays === p ? 'var(--accent)' : 'var(--border)',
+                      backgroundColor: lookbackDays === p ? 'var(--accent-subtle)' : 'var(--bg)',
+                      color: lookbackDays === p ? 'var(--accent)' : 'inherit',
+                    }}
+                  >
+                    {p}d
+                  </button>
+                ))}
+                <button
+                  onClick={() => setLookbackDays(3650)}
+                  className="text-xs px-2 py-1 rounded border transition-colors"
+                  style={{
+                    borderColor: lookbackDays === 3650 ? 'var(--accent)' : 'var(--border)',
+                    backgroundColor: lookbackDays === 3650 ? 'var(--accent-subtle)' : 'var(--bg)',
+                    color: lookbackDays === 3650 ? 'var(--accent)' : 'inherit',
+                  }}
+                >
+                  All time
+                </button>
+              </div>
+            </div>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+              How far back to fetch transactions and corporate actions
+            </p>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-wrap items-center gap-2 pt-2">
+          {!hasCredentials && (
+            <button
+              onClick={handleSave}
+              disabled={loading}
+              className="text-sm font-medium px-4 py-2 rounded-full text-white transition-colors disabled:opacity-50"
+              style={{ backgroundColor: 'var(--accent)' }}
+            >
+              {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Save'}
+            </button>
+          )}
+          <button
+            onClick={handleTest}
+            disabled={testing || loading}
+            className="text-sm font-medium px-4 py-2 rounded-full border transition-colors disabled:opacity-50"
+            style={{ borderColor: 'var(--border)' }}
+          >
+            {testing ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Test Connection'}
+          </button>
+          <button
+            onClick={handleSync}
+            disabled={syncing || loading}
+            className="text-sm font-medium px-4 py-2 rounded-full border transition-colors disabled:opacity-50"
+            style={{ borderColor: 'var(--border)' }}
+          >
+            {syncing ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+            <span className="ml-1">Sync Now</span>
+          </button>
+          {hasCredentials && (
+            <button
+              onClick={handleDisconnect}
+              disabled={loading}
+              className="text-sm font-medium px-4 py-2 rounded-full border text-red-600 dark:text-red-400 transition-colors disabled:opacity-50"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              <Unlink className="w-4 h-4 inline" />
+              <span className="ml-1">Disconnect</span>
+            </button>
+          )}
+        </div>
+
+        {/* Sync status */}
+        {lastSyncByCategory.size > 0 && (
+          <div className="space-y-2 pt-4 border-t" style={{ borderColor: 'var(--border)' }}>
+            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Last Sync</h2>
+            <div className="grid gap-2">
+              {Array.from(lastSyncByCategory.entries()).map(([category, log]) => (
+                <div
+                  key={category}
+                  className="flex items-center justify-between text-sm px-3 py-2 rounded-lg border"
+                  style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+                >
+                  <span className="text-gray-700 dark:text-gray-300 capitalize">{category.replace('_', ' ')}</span>
+                  <div className="flex items-center gap-2">
+                    {log.status === 'success' ? (
+                      <CheckCircle className="w-4 h-4 text-emerald-500" />
+                    ) : log.status === 'failure' ? (
+                      <AlertCircle className="w-4 h-4 text-red-500" />
+                    ) : (
+                      <Loader2 className="w-4 h-4 text-amber-500 animate-spin" />
+                    )}
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {new Date(log.lastSyncAt).toLocaleString()}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/settings/BrokerageSettingsPage.tsx
+++ b/apps/web/src/pages/settings/BrokerageSettingsPage.tsx
@@ -10,6 +10,8 @@ import {
   TigerProvider,
 } from '../../lib/brokerage'
 import type { TigerClientConfig } from '../../lib/brokerage'
+import { SyncProgressBar } from '../../lib/brokerage/SyncProgressBar'
+import type { SyncProgress } from '../../lib/brokerage/sync-orchestrator'
 import { db } from '../../lib/db/db'
 
 const PRESETS = [30, 90, 180, 365]
@@ -25,6 +27,7 @@ export function BrokerageSettingsPage() {
   const [hasCredentials, setHasCredentials] = useState(false)
   const [syncing, setSyncing] = useState(false)
   const [testing, setTesting] = useState(false)
+  const [syncProgress, setSyncProgress] = useState<SyncProgress[]>([])
 
   const credManager = useMemo(() => new CredentialManager(new DexieCredentialStore(db)), [])
 
@@ -79,6 +82,22 @@ export function BrokerageSettingsPage() {
       showError('Enter your passphrase to test the connection')
       return
     }
+
+    // Auto-save if credentials are filled in but not yet stored
+    if (!hasCredentials) {
+      if (!credentials.tigerId || !credentials.privateKey || !credentials.account) {
+        showError('Please fill in all fields first')
+        return
+      }
+      try {
+        await credManager.store(SOURCE, credentials, passphrase)
+        setHasCredentials(true)
+      } catch (err) {
+        showError(err instanceof Error ? err.message : 'Failed to save credentials')
+        return
+      }
+    }
+
     setTesting(true)
     setError(null)
     try {
@@ -111,8 +130,25 @@ export function BrokerageSettingsPage() {
       showError('Enter your passphrase to sync')
       return
     }
+
+    // Auto-save if credentials are filled in but not yet stored
+    if (!hasCredentials) {
+      if (!credentials.tigerId || !credentials.privateKey || !credentials.account) {
+        showError('Please fill in all fields first')
+        return
+      }
+      try {
+        await credManager.store(SOURCE, credentials, passphrase)
+        setHasCredentials(true)
+      } catch (err) {
+        showError(err instanceof Error ? err.message : 'Failed to save credentials')
+        return
+      }
+    }
+
     setSyncing(true)
     setError(null)
+    setSyncProgress([])
     try {
       const stored = await credManager.retrieve(SOURCE, passphrase)
       if (!stored) {
@@ -126,7 +162,12 @@ export function BrokerageSettingsPage() {
       }
       const provider = new TigerProvider({ config })
       const adapter = new DexieSyncAdapter(db)
-      const orchestrator = new SyncOrchestrator({ provider, database: adapter, lookbackDays })
+      const orchestrator = new SyncOrchestrator({
+        provider,
+        database: adapter,
+        lookbackDays,
+        onProgress: (p) => setSyncProgress((prev) => [...prev, p]),
+      })
       await orchestrator.sync()
       showSuccess('Sync completed')
     } catch (err) {
@@ -142,7 +183,7 @@ export function BrokerageSettingsPage() {
     try {
       await credManager.remove(SOURCE)
       await db.brokerageTransactions.clear()
-      await db.brokerageCorpActions.clear()
+      await db.brokerageFundDetails.clear()
       await db.brokeragePositions.clear()
       await db.brokeragePositionExtensions.clear()
       await db.brokerageAccounts.clear()
@@ -257,7 +298,7 @@ export function BrokerageSettingsPage() {
               <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
                 {hasCredentials
                   ? 'Enter your passphrase to test the connection or sync.'
-                  : 'Used to encrypt your credentials. You&apos;ll need this every time you sync.'}
+                  : 'Used to encrypt your credentials. You will need this every time you sync.'}
               </p>
             </div>
           </div>
@@ -353,6 +394,9 @@ export function BrokerageSettingsPage() {
             </button>
           )}
         </div>
+
+        {/* Sync progress */}
+        <SyncProgressBar progress={syncProgress} syncing={syncing} />
 
         {/* Sync status */}
         {lastSyncByCategory.size > 0 && (

--- a/apps/web/src/pages/transactions/CategoryCombobox.tsx
+++ b/apps/web/src/pages/transactions/CategoryCombobox.tsx
@@ -15,7 +15,11 @@ interface CategoryComboboxProps {
 
 type ComboboxOption =
   | { type: 'clear'; id: string }
-  | { type: 'category'; id: string; category: { id: string; name: string; color: string } }
+  | {
+      type: 'category'
+      id: string
+      category: { id: string; name: string; color: string }
+    }
   | { type: 'create'; name: string }
 
 export function CategoryCombobox({
@@ -87,7 +91,13 @@ export function CategoryCombobox({
       const count = await db.categories.count()
       const color = CUSTOM_COLORS[count % CUSTOM_COLORS.length]
       const id = 'cat_' + crypto.randomUUID()
-      await db.categories.put({ id, name, color, icon: undefined, isIncome: false })
+      await db.categories.put({
+        id,
+        name,
+        color,
+        icon: undefined,
+        isIncome: false,
+      })
       onChange(id)
       setOpen(false)
       onClose?.()
@@ -160,7 +170,7 @@ export function CategoryCombobox({
 
       {open && (
         <div
-          className="absolute z-50 mt-1 w-56 rounded-lg border shadow-lg py-1 bg-white dark:bg-gray-900"
+          className="absolute top-full left-0 mt-1 w-56 rounded-lg border shadow-lg py-1 bg-white dark:bg-gray-900 z-[1000]"
           style={{ borderColor: 'var(--border)' }}
         >
           <div className="px-2 pb-1">
@@ -184,7 +194,7 @@ export function CategoryCombobox({
             />
           </div>
 
-          <div className="max-h-52 overflow-y-auto">
+          <div className="max-h-28 overflow-y-auto">
             {options.map((opt, index) => {
               const isHighlighted = index === highlightedIndex
               const baseClass = 'w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors text-left '

--- a/apps/web/src/pages/transactions/SourceTypeTabs.tsx
+++ b/apps/web/src/pages/transactions/SourceTypeTabs.tsx
@@ -1,0 +1,44 @@
+import type { SourceType } from './filterTypes'
+
+interface SourceTypeTabsProps {
+  value: SourceType
+  onChange: (value: SourceType) => void
+}
+
+const TABS: { key: SourceType; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'bank', label: 'Bank' },
+  { key: 'brokerage', label: 'Brokerage' },
+]
+
+export function SourceTypeTabs({ value, onChange }: SourceTypeTabsProps) {
+  return (
+    <div className="flex items-center gap-1">
+      {TABS.map((tab) => {
+        const active = value === tab.key
+        return (
+          <button
+            key={tab.key}
+            onClick={() => onChange(tab.key)}
+            className="text-xs font-medium px-3 py-1.5 rounded-full border transition-colors"
+            style={
+              active
+                ? {
+                    backgroundColor: 'var(--accent)',
+                    borderColor: 'var(--accent)',
+                    color: '#fff',
+                  }
+                : {
+                    backgroundColor: 'var(--bg)',
+                    borderColor: 'var(--border)',
+                    color: 'var(--tw-text-opacity, currentColor)',
+                  }
+            }
+          >
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/pages/transactions/TransactionFilters.tsx
+++ b/apps/web/src/pages/transactions/TransactionFilters.tsx
@@ -20,14 +20,14 @@ export function TransactionFilters({ filters, onChange }: TransactionFiltersProp
     }
     if (filters.sourceType === 'brokerage') {
       const txnSources = (await db.brokerageTransactions.orderBy('source').uniqueKeys()) as string[]
-      const caSources = (await db.brokerageCorpActions.orderBy('source').uniqueKeys()) as string[]
-      return Array.from(new Set([...txnSources, ...caSources]))
+      const fdSources = (await db.brokerageFundDetails.orderBy('source').uniqueKeys()) as string[]
+      return Array.from(new Set([...txnSources, ...fdSources]))
     }
     // all
     const bankSources = (await db.transactions.orderBy('source').uniqueKeys()) as string[]
     const txnSources = (await db.brokerageTransactions.orderBy('source').uniqueKeys()) as string[]
-    const caSources = (await db.brokerageCorpActions.orderBy('source').uniqueKeys()) as string[]
-    return Array.from(new Set([...bankSources, ...txnSources, ...caSources]))
+    const fdSources = (await db.brokerageFundDetails.orderBy('source').uniqueKeys()) as string[]
+    return Array.from(new Set([...bankSources, ...txnSources, ...fdSources]))
   }, [filters.sourceType])
 
   const accounts = useLiveQuery(() => db.transactions.orderBy('accountNo').uniqueKeys() as Promise<string[]>, [])

--- a/apps/web/src/pages/transactions/TransactionFilters.tsx
+++ b/apps/web/src/pages/transactions/TransactionFilters.tsx
@@ -1,4 +1,3 @@
-import type { StatementSource } from '@lokfi/parser-core'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { db } from '../../lib/db/db'
 
@@ -15,11 +14,26 @@ const inputCls =
 const inputStyle = { borderColor: 'var(--border)' }
 
 export function TransactionFilters({ filters, onChange }: TransactionFiltersProps) {
-  const sources = useLiveQuery(() => db.transactions.orderBy('source').uniqueKeys() as Promise<StatementSource[]>, [])
+  const allSources = useLiveQuery(async () => {
+    if (filters.sourceType === 'bank') {
+      return (await db.transactions.orderBy('source').uniqueKeys()) as string[]
+    }
+    if (filters.sourceType === 'brokerage') {
+      const txnSources = (await db.brokerageTransactions.orderBy('source').uniqueKeys()) as string[]
+      const caSources = (await db.brokerageCorpActions.orderBy('source').uniqueKeys()) as string[]
+      return Array.from(new Set([...txnSources, ...caSources]))
+    }
+    // all
+    const bankSources = (await db.transactions.orderBy('source').uniqueKeys()) as string[]
+    const txnSources = (await db.brokerageTransactions.orderBy('source').uniqueKeys()) as string[]
+    const caSources = (await db.brokerageCorpActions.orderBy('source').uniqueKeys()) as string[]
+    return Array.from(new Set([...bankSources, ...txnSources, ...caSources]))
+  }, [filters.sourceType])
+
   const accounts = useLiveQuery(() => db.transactions.orderBy('accountNo').uniqueKeys() as Promise<string[]>, [])
   const categories = useLiveQuery(() => db.categories.toArray(), [])
 
-  function toggleSource(source: StatementSource) {
+  function toggleSource(source: string) {
     const next = filters.sources.includes(source)
       ? filters.sources.filter((s) => s !== source)
       : [...filters.sources, source]
@@ -38,7 +52,12 @@ export function TransactionFilters({ filters, onChange }: TransactionFiltersProp
     filters.dateTo !== '' ||
     filters.sources.length > 0 ||
     filters.accounts.length > 0 ||
-    filters.categoryId !== ''
+    filters.categoryId !== '' ||
+    filters.type !== ''
+
+  const showCategory = filters.sourceType !== 'brokerage'
+  const showType = filters.sourceType !== 'bank'
+  const showAccounts = filters.sourceType !== 'brokerage'
 
   return (
     <div
@@ -67,99 +86,122 @@ export function TransactionFilters({ filters, onChange }: TransactionFiltersProp
         />
       </div>
 
-      {/* Separator */}
-      {sources && sources.length > 0 && <span className="text-gray-300 dark:text-gray-700 select-none">·</span>}
-
       {/* Source pills */}
-      {sources && sources.length > 0 && (
-        <div className="flex items-center gap-1.5">
-          <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Source</span>
-          {sources.map((source) => {
-            const active = filters.sources.includes(source)
-            return (
-              <button
-                key={source}
-                onClick={() => toggleSource(source)}
-                className="text-xs rounded-full px-3 py-1.5 border font-medium transition-colors"
-                style={
-                  active
-                    ? {
-                        backgroundColor: 'var(--accent)',
-                        borderColor: 'var(--accent)',
-                        color: '#fff',
-                      }
-                    : {
-                        backgroundColor: 'var(--bg)',
-                        borderColor: 'var(--border)',
-                        color: 'var(--tw-text-opacity, currentColor)',
-                      }
-                }
-              >
-                {source}
-              </button>
-            )
-          })}
-        </div>
+      {allSources && allSources.length > 0 && (
+        <>
+          <span className="text-gray-300 dark:text-gray-700 select-none">·</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Source</span>
+            {allSources.map((source) => {
+              const active = filters.sources.includes(source)
+              return (
+                <button
+                  key={source}
+                  onClick={() => toggleSource(source)}
+                  className="text-xs rounded-full px-3 py-1.5 border font-medium transition-colors"
+                  style={
+                    active
+                      ? {
+                          backgroundColor: 'var(--accent)',
+                          borderColor: 'var(--accent)',
+                          color: '#fff',
+                        }
+                      : {
+                          backgroundColor: 'var(--bg)',
+                          borderColor: 'var(--border)',
+                          color: 'var(--tw-text-opacity, currentColor)',
+                        }
+                  }
+                >
+                  {source}
+                </button>
+              )
+            })}
+          </div>
+        </>
       )}
-
-      {/* Separator */}
-      {(sources?.length || 0) > 0 || (accounts?.length || 0) > 0 ? (
-        <span className="text-gray-300 dark:text-gray-700 select-none">·</span>
-      ) : null}
 
       {/* Account pills */}
-      {accounts && accounts.length > 0 && (
-        <div className="flex items-center gap-1.5">
-          <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Account</span>
-          {accounts.map((account) => {
-            const active = filters.accounts.includes(account)
-            return (
-              <button
-                key={account}
-                onClick={() => toggleAccount(account)}
-                className="text-xs rounded-full px-3 py-1.5 border font-medium transition-colors"
-                style={
-                  active
-                    ? {
-                        backgroundColor: 'var(--accent)',
-                        borderColor: 'var(--accent)',
-                        color: '#fff',
-                      }
-                    : {
-                        backgroundColor: 'var(--bg)',
-                        borderColor: 'var(--border)',
-                        color: 'var(--tw-text-opacity, currentColor)',
-                      }
-                }
-              >
-                {account}
-              </button>
-            )
-          })}
-        </div>
+      {showAccounts && accounts && accounts.length > 0 && (
+        <>
+          <span className="text-gray-300 dark:text-gray-700 select-none">·</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Account</span>
+            {accounts.map((account) => {
+              const active = filters.accounts.includes(account)
+              return (
+                <button
+                  key={account}
+                  onClick={() => toggleAccount(account)}
+                  className="text-xs rounded-full px-3 py-1.5 border font-medium transition-colors"
+                  style={
+                    active
+                      ? {
+                          backgroundColor: 'var(--accent)',
+                          borderColor: 'var(--accent)',
+                          color: '#fff',
+                        }
+                      : {
+                          backgroundColor: 'var(--bg)',
+                          borderColor: 'var(--border)',
+                          color: 'var(--tw-text-opacity, currentColor)',
+                        }
+                  }
+                >
+                  {account}
+                </button>
+              )
+            })}
+          </div>
+        </>
       )}
 
-      {/* Separator */}
-      <span className="text-gray-300 dark:text-gray-700 select-none">·</span>
-
       {/* Category */}
-      <div className="flex items-center gap-1.5">
-        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Category</span>
-        <select
-          value={filters.categoryId}
-          onChange={(e) => onChange({ ...filters, categoryId: e.target.value })}
-          className={inputCls}
-          style={inputStyle}
-        >
-          <option value="">All</option>
-          <option value="__uncategorised__">Uncategorised</option>
-          {categories?.map((c) => (
-            <option key={c.id} value={c.id}>
-              {c.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      {showCategory && (
+        <>
+          <span className="text-gray-300 dark:text-gray-700 select-none">·</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Category</span>
+            <select
+              value={filters.categoryId}
+              onChange={(e) => onChange({ ...filters, categoryId: e.target.value })}
+              className={inputCls}
+              style={inputStyle}
+            >
+              <option value="">All</option>
+              <option value="__uncategorised__">Uncategorised</option>
+              {categories?.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
+      )}
+
+      {/* Type */}
+      {showType && (
+        <>
+          <span className="text-gray-300 dark:text-gray-700 select-none">·</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Type</span>
+            <select
+              value={filters.type}
+              onChange={(e) => onChange({ ...filters, type: e.target.value })}
+              className={inputCls}
+              style={inputStyle}
+            >
+              <option value="">All</option>
+              <option value="BUY">Buy</option>
+              <option value="SELL">Sell</option>
+              <option value="DIVIDEND">Dividend</option>
+              <option value="FEE">Fee</option>
+              <option value="CORP ACTION">Corp Action</option>
+            </select>
+          </div>
+        </>
+      )}
 
       {/* Reset */}
       {hasActiveFilters && (

--- a/apps/web/src/pages/transactions/TransactionTable.tsx
+++ b/apps/web/src/pages/transactions/TransactionTable.tsx
@@ -1,94 +1,71 @@
-import { useLiveQuery } from 'dexie-react-hooks'
 import { Check, Copy } from 'lucide-react'
 import { useState } from 'react'
-import { db } from '../../lib/db/db'
+import type { UnifiedTransactionRow } from '../../lib/brokerage/unifiedTransactions'
 import type { DbTransaction } from '../../lib/db/db'
 import { CategoryBadge } from './CategoryBadge'
-import type { Filters } from './filterTypes'
 
-const fmt = new Intl.NumberFormat('en-SG', { style: 'currency', currency: 'SGD' })
-const PAGE_SIZE = 100
+const fmtCache = new Map<string, Intl.NumberFormat>()
+function getFormatter(currency: string): Intl.NumberFormat {
+  if (!fmtCache.has(currency)) {
+    fmtCache.set(currency, new Intl.NumberFormat('en-US', { style: 'currency', currency }))
+  }
+  return fmtCache.get(currency)!
+}
+
+function formatAmount(row: UnifiedTransactionRow): string {
+  const fmt = getFormatter(row.currency)
+  const abs = Math.abs(row.amount)
+  const sign = row.amount < 0 ? '−' : '+'
+  return `${sign}${fmt.format(abs)}`
+}
+
+function amountColorClass(row: UnifiedTransactionRow): string {
+  if (row.isBank) {
+    return row.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'
+  }
+  switch (row.type) {
+    case 'DIVIDEND':
+      return 'text-emerald-600 dark:text-emerald-400'
+    case 'FEE':
+      return 'text-red-600 dark:text-red-400'
+    default:
+      return 'text-gray-500 dark:text-gray-400'
+  }
+}
+
+function formatSource(row: UnifiedTransactionRow): string {
+  const icon = row.isBank ? '🏦' : '📈'
+  return `${icon} ${row.source}`
+}
 
 interface TransactionTableProps {
-  filters: Filters
+  rows: UnifiedTransactionRow[]
   selectedIds: Set<string>
   onToggleSelect: (id: string) => void
   onToggleAll: (ids: string[]) => void
   onCategoryChanged?: (txn: DbTransaction, categoryId: string | undefined) => void
   pageOffset: number
-  onLoadedChange: (loaded: number, total: number, hasMore: boolean) => void
-  totalFiltered: number
+  total: number
+  hasMore: boolean
   onLoadMore: () => void
 }
 
 export function TransactionTable({
-  filters,
+  rows,
   selectedIds,
   onToggleSelect,
   onToggleAll,
   onCategoryChanged,
   pageOffset,
-  onLoadedChange,
-  totalFiltered,
+  total,
+  hasMore,
   onLoadMore,
 }: TransactionTableProps) {
   const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null)
   const [copiedId, setCopiedId] = useState<string | null>(null)
-  const [hasMore, setHasMore] = useState(false)
 
-  const transactions = useLiveQuery(async () => {
-    // Build the base query chain:
-    // Use indexed where() for date range (if available), then chain .and() for secondary filters.
-    // .and() always returns Collection, so subsequent .and() calls chain cleanly.
-    const baseQuery = filters.dateFrom
-      ? db.transactions.where('date').aboveOrEqual(filters.dateFrom)
-      : db.transactions.orderBy('date').reverse()
-
-    // Apply upper date bound
-    const dateFiltered = filters.dateTo ? baseQuery.and((t) => t.date <= filters.dateTo) : baseQuery
-
-    // Apply source filter
-    const sourceFiltered =
-      filters.sources.length > 0 ? dateFiltered.and((t) => filters.sources.includes(t.source)) : dateFiltered
-
-    // Apply account filter
-    const accountFiltered =
-      filters.accounts.length > 0 ? sourceFiltered.and((t) => filters.accounts.includes(t.accountNo)) : sourceFiltered
-
-    // Apply category filter (resolved: manualCategory ?? category)
-    const categoryFiltered = filters.categoryId
-      ? accountFiltered.and((t) => {
-          const resolved = t.manualCategory ?? t.category
-          return filters.categoryId === '__uncategorised__' ? !resolved : resolved === filters.categoryId
-        })
-      : accountFiltered
-
-    // Get total count
-    const total = await categoryFiltered.count()
-
-    // Paginate — fetch all filtered results then slice.
-    // Dexie's offset() on chained .and() collections can return 0 rows unexpectedly,
-    // so we fetch all results and paginate in JS instead.
-    const allFiltered = await categoryFiltered.toArray()
-    const rows = allFiltered.slice(pageOffset, pageOffset + PAGE_SIZE)
-
-    // Report loaded/total/hasMore
-    const loaded = rows.length
-    const more = pageOffset + loaded < total
-    setHasMore(more)
-    onLoadedChange(pageOffset + loaded, total, more)
-
-    return rows
-  }, [filters, pageOffset, onLoadedChange])
-
-  if (!transactions) {
-    return (
-      <div className="flex items-center justify-center h-40 text-gray-400 dark:text-gray-500 text-sm">Loading…</div>
-    )
-  }
-
-  const allIds = transactions.map((t) => t.id)
-  const allSelected = allIds.length > 0 && allIds.every((id) => selectedIds.has(id))
+  const selectableIds = rows.filter((t) => t.isBank).map((t) => t.id)
+  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selectedIds.has(id))
 
   return (
     <div className="overflow-x-auto relative">
@@ -106,7 +83,7 @@ export function TransactionTable({
               <input
                 type="checkbox"
                 checked={allSelected}
-                onChange={() => onToggleAll(allIds)}
+                onChange={() => onToggleAll(selectableIds)}
                 className="rounded accent-amber-600"
               />
             </th>
@@ -131,22 +108,19 @@ export function TransactionTable({
           </tr>
         </thead>
         <tbody>
-          {transactions.map((t, i) => {
-            const isNeg = t.transactionValue < 0
-            const amountStr = (isNeg ? '−' : '+') + fmt.format(Math.abs(t.transactionValue))
+          {rows.map((t, i) => {
             const isSelected = selectedIds.has(t.id)
             const isEven = i % 2 === 0
+            const isEditing = editingCategoryId === t.id
 
             return (
               <tr
                 key={t.id}
                 className={`border-b transition-colors ${
-                  editingCategoryId === t.id
-                    ? 'relative z-50 ring-2 ring-amber-500 shadow-xl rounded-md bg-white dark:bg-gray-800'
-                    : ''
+                  isEditing ? 'relative z-50 ring-2 ring-amber-500 shadow-xl rounded-md bg-white dark:bg-gray-800' : ''
                 }`}
                 style={
-                  editingCategoryId === t.id
+                  isEditing
                     ? undefined
                     : {
                         borderColor: 'var(--border)',
@@ -162,70 +136,77 @@ export function TransactionTable({
                   <input
                     type="checkbox"
                     checked={isSelected}
-                    onChange={() => onToggleSelect(t.id)}
-                    className="rounded accent-amber-600"
+                    disabled={!t.isBank}
+                    onChange={() => t.isBank && onToggleSelect(t.id)}
+                    className="rounded accent-amber-600 disabled:opacity-30"
                   />
                 </td>
                 <td className="px-3 py-2.5 text-gray-500 dark:text-gray-400 whitespace-nowrap font-mono text-xs">
-                  {t.date}
+                  {t.date.slice(0, 10)}
                 </td>
                 <td
-                  className={`px-3 py-2.5 text-gray-900 dark:text-white max-w-xs ${editingCategoryId === t.id ? 'whitespace-normal break-words' : ''}`}
+                  className={`px-3 py-2.5 text-gray-900 dark:text-white max-w-xs ${isEditing ? 'whitespace-normal break-words' : ''}`}
                 >
                   <div className="flex items-center gap-1 group">
-                    <span className={editingCategoryId === t.id ? '' : 'truncate'}>{t.description}</span>
-                    <button
-                      onClick={() => {
-                        navigator.clipboard.writeText(t.description)
-                        setCopiedId(t.id)
-                        setTimeout(() => setCopiedId(null), 1500)
-                      }}
-                      className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
-                      title="Copy description"
-                    >
-                      {copiedId === t.id ? (
-                        <Check className="w-3.5 h-3.5 text-emerald-500" />
-                      ) : (
-                        <Copy className="w-3.5 h-3.5 text-gray-400" />
-                      )}
-                    </button>
+                    <span className={isEditing ? '' : 'truncate'}>{t.description}</span>
+                    {t.isBank && t.originalBank && (
+                      <button
+                        onClick={() => {
+                          navigator.clipboard.writeText(t.description)
+                          setCopiedId(t.id)
+                          setTimeout(() => setCopiedId(null), 1500)
+                        }}
+                        className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+                        title="Copy description"
+                      >
+                        {copiedId === t.id ? (
+                          <Check className="w-3.5 h-3.5 text-emerald-500" />
+                        ) : (
+                          <Copy className="w-3.5 h-3.5 text-gray-400" />
+                        )}
+                      </button>
+                    )}
                   </div>
                 </td>
                 <td
-                  className={`px-3 py-2.5 text-right font-mono whitespace-nowrap text-xs font-medium ${
-                    isNeg ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'
-                  }`}
+                  className={`px-3 py-2.5 text-right font-mono whitespace-nowrap text-xs font-medium tabular-nums ${amountColorClass(t)}`}
                 >
-                  {amountStr}
+                  {formatAmount(t)}
                 </td>
-                <td className={`px-3 py-2.5 ${editingCategoryId === t.id ? 'relative z-50' : ''}`}>
-                  <CategoryBadge
-                    transactionId={t.id}
-                    category={t.category}
-                    manualCategory={t.manualCategory}
-                    isEditing={editingCategoryId === t.id}
-                    onStartEdit={() => setEditingCategoryId(t.id)}
-                    onStopEdit={() => setEditingCategoryId(null)}
-                    onCategoryChanged={onCategoryChanged}
-                  />
+                <td className={`px-3 py-2.5 ${isEditing ? 'relative z-50' : ''}`}>
+                  {t.isBank && t.originalBank ? (
+                    <CategoryBadge
+                      transactionId={t.id}
+                      category={t.originalBank.category}
+                      manualCategory={t.originalBank.manualCategory}
+                      isEditing={isEditing}
+                      onStartEdit={() => setEditingCategoryId(t.id)}
+                      onStopEdit={() => setEditingCategoryId(null)}
+                      onCategoryChanged={onCategoryChanged}
+                    />
+                  ) : (
+                    <span className="text-gray-400 dark:text-gray-500 text-xs">—</span>
+                  )}
                 </td>
                 <td className="px-3 py-2.5 text-gray-400 dark:text-gray-500 text-xs uppercase tracking-wide">
-                  {t.source}
+                  {formatSource(t)}
                 </td>
-                <td className="px-3 py-2.5 text-gray-400 dark:text-gray-500 text-xs font-mono">{t.accountNo}</td>
+                <td className="px-3 py-2.5 text-gray-400 dark:text-gray-500 text-xs font-mono">
+                  {t.isBank && t.originalBank ? t.originalBank.accountNo : '—'}
+                </td>
               </tr>
             )
           })}
         </tbody>
       </table>
 
-      {/* Footer: showing count + load more */}
+      {/* Footer */}
       <div
         className="flex items-center justify-between px-4 py-2.5 border-t text-xs text-gray-400 dark:text-gray-500"
         style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
       >
         <span>
-          Showing {pageOffset + (transactions?.length ?? 0)} of {totalFiltered} transactions
+          Showing {pageOffset + rows.length} of {total} transactions
         </span>
         {hasMore && (
           <button
@@ -233,7 +214,7 @@ export function TransactionTable({
             className="text-xs font-medium px-3 py-1 rounded border transition-colors hover:border-amber-500 hover:text-amber-600"
             style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
           >
-            Load more ({totalFiltered - pageOffset - (transactions?.length ?? 0)} remaining)
+            Load more ({total - pageOffset - rows.length} remaining)
           </button>
         )}
       </div>

--- a/apps/web/src/pages/transactions/TransactionsPage.tsx
+++ b/apps/web/src/pages/transactions/TransactionsPage.tsx
@@ -73,16 +73,16 @@ export function TransactionsPage() {
 
   const hasAnyData = useLiveQuery(async () => {
     if (filters.sourceType === 'brokerage') {
-      const [tc, cac] = await Promise.all([db.brokerageTransactions.count(), db.brokerageCorpActions.count()])
-      return tc + cac > 0
+      const [tc, fdc] = await Promise.all([db.brokerageTransactions.count(), db.brokerageFundDetails.count()])
+      return tc + fdc > 0
     }
     if (filters.sourceType === 'bank') return (await db.transactions.count()) > 0
-    const [bc, tc, cac] = await Promise.all([
+    const [bc, tc, fdc] = await Promise.all([
       db.transactions.count(),
       db.brokerageTransactions.count(),
-      db.brokerageCorpActions.count(),
+      db.brokerageFundDetails.count(),
     ])
-    return bc + tc + cac > 0
+    return bc + tc + fdc > 0
   }, [filters.sourceType])
 
   const hasFilters =

--- a/apps/web/src/pages/transactions/TransactionsPage.tsx
+++ b/apps/web/src/pages/transactions/TransactionsPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { useEffect, useRef, useState } from 'react'
+import { useUnifiedTransactions } from '../../lib/brokerage/unifiedTransactions'
 import { db } from '../../lib/db/db'
 import type { DbTransaction } from '../../lib/db/db'
 import { applyRulesToImport } from '../../lib/rules/applyRulesToImport'
@@ -8,6 +9,7 @@ import { type RuleSuggestion, suggestRules } from '../../lib/rules/suggestRules'
 import { RuleEditorModal } from '../rules/RuleEditorModal'
 import { CategoryCombobox } from './CategoryCombobox'
 import { RuleSuggestionBar } from './RuleSuggestionBar'
+import { SourceTypeTabs } from './SourceTypeTabs'
 import { TransactionFilters } from './TransactionFilters'
 import { TransactionTable } from './TransactionTable'
 import { type Filters, defaultFilters } from './filterTypes'
@@ -18,6 +20,8 @@ type SuggestionState = {
   categoryId: string
   categoryName: string
 }
+
+const PAGE_SIZE = 100
 
 export function TransactionsPage() {
   const [filters, setFilters] = useState<Filters>(defaultFilters)
@@ -30,7 +34,9 @@ export function TransactionsPage() {
 
   // Pagination state
   const [pageOffset, setPageOffset] = useState(0)
-  const [filteredTotal, setFilteredTotal] = useState(0)
+
+  // Unified data
+  const { rows, total, hasMore, isLoading } = useUnifiedTransactions(filters, pageOffset, PAGE_SIZE)
 
   // Cache all transactions for suggestRules (only reload when categories/rules change)
   const allTxnsRef = useRef<DbTransaction[]>([])
@@ -41,6 +47,7 @@ export function TransactionsPage() {
   // Reset page offset when filters change
   useEffect(() => {
     setPageOffset(0)
+    setSelectedIds(new Set())
   }, [filters])
 
   // Reload all transactions for suggestRules only when categories change
@@ -59,17 +66,32 @@ export function TransactionsPage() {
     })
   }, [])
 
-  const totalCount = useLiveQuery(() => db.transactions.count(), [])
   const uncategorisedCount = useLiveQuery(async () => {
-    return await db.transactions.filter((t) => !t.manualCategory && !t.category).count()
-  }, [])
+    if (filters.sourceType === 'brokerage') return 0
+    return db.transactions.filter((t) => !t.manualCategory && !t.category).count()
+  }, [filters.sourceType])
+
+  const hasAnyData = useLiveQuery(async () => {
+    if (filters.sourceType === 'brokerage') {
+      const [tc, cac] = await Promise.all([db.brokerageTransactions.count(), db.brokerageCorpActions.count()])
+      return tc + cac > 0
+    }
+    if (filters.sourceType === 'bank') return (await db.transactions.count()) > 0
+    const [bc, tc, cac] = await Promise.all([
+      db.transactions.count(),
+      db.brokerageTransactions.count(),
+      db.brokerageCorpActions.count(),
+    ])
+    return bc + tc + cac > 0
+  }, [filters.sourceType])
 
   const hasFilters =
     filters.dateFrom !== '' ||
     filters.dateTo !== '' ||
     filters.sources.length > 0 ||
     filters.accounts.length > 0 ||
-    filters.categoryId !== ''
+    filters.categoryId !== '' ||
+    filters.type !== ''
 
   function handleToggleSelect(id: string) {
     setSelectedIds((prev) => {
@@ -101,20 +123,13 @@ export function TransactionsPage() {
   }
 
   async function handleCategoryChanged(txn: DbTransaction, categoryId: string | undefined) {
-    // Skip if no category was set
     if (!categoryId) return
-    // Skip if the transaction already had a rule-assigned category (user is overriding)
     if (txn.category) return
-    // A new categorization clears any prior dismiss for this txn
     dismissedTxIds.current.delete(txn.id)
-
-    // Use cached allTransactions (only refreshed when categories change)
     const suggestions = suggestRules(txn, categoryId, allTxnsRef.current)
     if (suggestions.length === 0) return
-
     const category = categories?.find((c) => c.id === categoryId)
     const categoryName = category?.name ?? categoryId
-
     setSuggestionState({ txnId: txn.id, suggestions, categoryId, categoryName })
   }
 
@@ -125,11 +140,9 @@ export function TransactionsPage() {
 
   async function handleCreateRule(suggestion: RuleSuggestion) {
     if (!suggestionState) return
-
     const identifier = suggestion.conditions[0]?.value as string
     const categoryName = suggestionState.categoryName
     const ruleName = `${identifier} — ${categoryName}`
-
     const rule = {
       id: crypto.randomUUID(),
       name: ruleName,
@@ -138,15 +151,10 @@ export function TransactionsPage() {
       category: suggestionState.categoryId,
       createdAt: new Date().toISOString(),
     }
-
     await db.rules.put(rule)
-
     const allIds = (await db.transactions.toArray()).map((t) => t.id)
     await applyRulesToImport(allIds)
-
-    // Count how many got newly categorized (approximation via matchCount)
     const matchCount = suggestion.matchCount
-
     setSuggestionState(null)
     showToast(`Rule created — ${matchCount} transaction${matchCount !== 1 ? 's' : ''} categorized`)
   }
@@ -162,14 +170,34 @@ export function TransactionsPage() {
     setTimeout(() => setToast(null), 3500)
   }
 
-  if (totalCount === 0) {
+  const selectedBankCount = selectedIds.size
+
+  // Empty state — no data at all in the selected source
+  if (!isLoading && hasAnyData === false) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="text-center p-8 rounded-xl border max-w-sm" style={{ borderColor: 'var(--border)' }}>
-          <p className="text-gray-600 dark:text-gray-400 mb-4">No transactions yet</p>
-          <Link to="/import" className="text-sm font-medium hover:underline" style={{ color: 'var(--accent)' }}>
-            Import a statement →
-          </Link>
+          {filters.sourceType === 'brokerage' ? (
+            <>
+              <p className="text-gray-600 dark:text-gray-400 mb-4">
+                No brokerage transactions yet. Sync your account to see trades and dividends.
+              </p>
+              <Link
+                to="/settings/brokerage"
+                className="text-sm font-medium hover:underline"
+                style={{ color: 'var(--accent)' }}
+              >
+                Brokerage settings →
+              </Link>
+            </>
+          ) : (
+            <>
+              <p className="text-gray-600 dark:text-gray-400 mb-4">No transactions yet</p>
+              <Link to="/import" className="text-sm font-medium hover:underline" style={{ color: 'var(--accent)' }}>
+                Import a statement →
+              </Link>
+            </>
+          )}
         </div>
       </div>
     )
@@ -181,51 +209,54 @@ export function TransactionsPage() {
       <div className="flex items-center justify-between px-5 py-3.5 border-b" style={{ borderColor: 'var(--border)' }}>
         <div className="flex items-baseline gap-3">
           <h1 className="font-serif text-xl text-gray-900 dark:text-white">Transactions</h1>
-          {totalCount !== undefined && (
-            <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">{totalCount} total</span>
+          {!isLoading && <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">{total} total</span>}
+        </div>
+        <div className="flex items-center gap-3">
+          <SourceTypeTabs
+            value={filters.sourceType}
+            onChange={(sourceType) => setFilters((f) => ({ ...f, sourceType, categoryId: '', type: '' }))}
+          />
+          {uncategorisedCount !== undefined && uncategorisedCount > 0 && (
+            <button
+              onClick={() =>
+                setFilters((f) => ({
+                  ...f,
+                  categoryId: f.categoryId === '__uncategorised__' ? '' : '__uncategorised__',
+                }))
+              }
+              className="text-xs font-medium px-3 py-1.5 rounded-full border transition-colors"
+              style={{
+                color: 'var(--accent)',
+                borderColor: 'var(--accent)',
+                backgroundColor: filters.categoryId === '__uncategorised__' ? 'var(--accent-subtle)' : 'transparent',
+              }}
+            >
+              {uncategorisedCount} uncategorised
+            </button>
           )}
         </div>
-        {/* Uncategorised nudge */}
-        {uncategorisedCount !== undefined && uncategorisedCount > 0 && (
-          <button
-            onClick={() =>
-              setFilters((f) => ({
-                ...f,
-                categoryId: f.categoryId === '__uncategorised__' ? '' : '__uncategorised__',
-              }))
-            }
-            className="text-xs font-medium px-3 py-1.5 rounded-full border transition-colors"
-            style={{
-              color: 'var(--accent)',
-              borderColor: 'var(--accent)',
-              backgroundColor: filters.categoryId === '__uncategorised__' ? 'var(--accent-subtle)' : 'transparent',
-            }}
-          >
-            {uncategorisedCount} uncategorised
-          </button>
-        )}
       </div>
 
       <TransactionFilters filters={filters} onChange={setFilters} />
 
       <div className="flex-1 overflow-auto">
-        {totalCount !== undefined && totalCount > 0 && hasFilters && filteredTotal === 0 ? (
+        {isLoading ? (
+          <div className="flex items-center justify-center h-40 text-gray-400 dark:text-gray-500 text-sm">Loading…</div>
+        ) : hasAnyData && total === 0 && hasFilters ? (
           <div className="flex items-center justify-center h-40">
             <p className="text-gray-400 dark:text-gray-500 text-sm">No transactions match your filters.</p>
           </div>
         ) : (
           <TransactionTable
-            filters={filters}
+            rows={rows}
             selectedIds={selectedIds}
             onToggleSelect={handleToggleSelect}
             onToggleAll={handleToggleAll}
             onCategoryChanged={handleCategoryChanged}
             pageOffset={pageOffset}
-            onLoadedChange={(_loaded, total, _more) => {
-              setFilteredTotal(total)
-            }}
-            totalFiltered={filteredTotal}
-            onLoadMore={() => setPageOffset((o) => o + 100)}
+            total={total}
+            hasMore={hasMore}
+            onLoadMore={() => setPageOffset((o) => o + PAGE_SIZE)}
           />
         )}
       </div>
@@ -240,13 +271,13 @@ export function TransactionsPage() {
           onCustomize={handleCustomize}
           onDismiss={handleDismiss}
         />
-      ) : selectedIds.size > 0 ? (
+      ) : selectedBankCount > 0 ? (
         <div
           className="sticky bottom-0 flex items-center gap-3 px-5 py-3 border-t shadow-lg"
           style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg)' }}
         >
           <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
-            {selectedIds.size} selected · Categorise as:
+            {selectedBankCount} selected · Categorise as:
           </span>
           <CategoryCombobox value={bulkCategoryId} onChange={setBulkCategoryId} placeholder="Pick a category…" />
           <button

--- a/apps/web/src/pages/transactions/filterTypes.ts
+++ b/apps/web/src/pages/transactions/filterTypes.ts
@@ -1,11 +1,13 @@
-import type { StatementSource } from '@lokfi/parser-core'
+export type SourceType = 'all' | 'bank' | 'brokerage'
 
 export interface Filters {
   dateFrom: string
   dateTo: string
-  sources: StatementSource[]
+  sources: string[]
   accounts: string[]
   categoryId: string
+  sourceType: SourceType
+  type: string
 }
 
 export const defaultFilters: Filters = {
@@ -14,4 +16,6 @@ export const defaultFilters: Filters = {
   sources: [],
   accounts: [],
   categoryId: '',
+  sourceType: 'all',
+  type: '',
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -4,6 +4,7 @@ import { AppShell } from './layouts/AppShell'
 import { DashboardPage } from './pages/dashboard/DashboardPage'
 import { ImportPage } from './pages/import/ImportPage'
 import { LandingPage } from './pages/landing/LandingPage'
+import { PortfolioPage } from './pages/portfolio/PortfolioPage'
 import { ProfilePage } from './pages/profile/ProfilePage'
 import { RulesPage } from './pages/rules/RulesPage'
 import { BrokerageSettingsPage } from './pages/settings/BrokerageSettingsPage'
@@ -33,6 +34,12 @@ const shellRoute = createRoute({
       <Outlet />
     </AppShell>
   ),
+})
+
+const portfolioRoute = createRoute({
+  getParentRoute: () => shellRoute,
+  path: '/portfolio',
+  component: PortfolioPage,
 })
 
 const importRoute = createRoute({
@@ -74,6 +81,7 @@ const brokerageSettingsRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   landingRoute,
   shellRoute.addChildren([
+    portfolioRoute,
     importRoute,
     transactionsRoute,
     dashboardRoute,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -6,6 +6,7 @@ import { ImportPage } from './pages/import/ImportPage'
 import { LandingPage } from './pages/landing/LandingPage'
 import { ProfilePage } from './pages/profile/ProfilePage'
 import { RulesPage } from './pages/rules/RulesPage'
+import { BrokerageSettingsPage } from './pages/settings/BrokerageSettingsPage'
 import { TransactionsPage } from './pages/transactions/TransactionsPage'
 
 const rootRoute = createRootRoute({
@@ -64,9 +65,22 @@ const rulesRoute = createRoute({
   component: RulesPage,
 })
 
+const brokerageSettingsRoute = createRoute({
+  getParentRoute: () => shellRoute,
+  path: '/settings/brokerage',
+  component: BrokerageSettingsPage,
+})
+
 const routeTree = rootRoute.addChildren([
   landingRoute,
-  shellRoute.addChildren([importRoute, transactionsRoute, dashboardRoute, profileRoute, rulesRoute]),
+  shellRoute.addChildren([
+    importRoute,
+    transactionsRoute,
+    dashboardRoute,
+    profileRoute,
+    rulesRoute,
+    brokerageSettingsRoute,
+  ]),
 ])
 
 export const router = createRouter({ routeTree })

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "bin"]
 }

--- a/docs/portfolio-design-v1.md
+++ b/docs/portfolio-design-v1.md
@@ -1,0 +1,111 @@
+# Portfolio Hub — Design Document
+
+> Phase 2 completion · May 2026
+
+## Overview
+
+The Portfolio Hub (`/portfolio`) provides a dedicated, visually rich view of a user's brokerage holdings, transactions, and dividend income. It is the second phase of Lokfi's investment tracking capabilities, building on the unified transaction view from Phase 1.
+
+## Architecture
+
+### Navigation
+
+- **Sidebar**: "Portfolio" item added between Dashboard and Import, using `TrendingUp` icon.
+- **Routing**: `/portfolio` registered in TanStack Router with tab state managed via `?tab=` query parameter.
+- **Deep-linking**: `/portfolio?tab=holdings` opens the Holdings tab directly.
+
+### Page Structure
+
+```
+PortfolioPage
+├── Header (title, currency selector, brokerage settings link)
+├── Sync status bar (last sync timestamp, sync now button)
+├── PortfolioTabs (Overview | Holdings | Transactions | Dividends)
+└── Tab Content
+    ├── OverviewTab
+    ├── HoldingsTab
+    ├── PortfolioTransactionsTab
+    └── DividendsTab
+```
+
+### FX Rate Infrastructure
+
+- **Primary API**: Frankfurter (`https://api.frankfurter.dev/v2/latest?from=USD`)
+- **Fallback API**: open.er-api.com (`https://open.er-api.com/v6/latest/USD`)
+- **Cache**: Dexie `fxRates` table (schema v6) with composite key `[date+base]`
+- **Hook**: `useFxRates()` fetches on mount if stale, returns rates + lastUpdated + error
+- **Utility**: `convertAmount(amount, from, to, rates)` handles cross-rate conversion via USD base
+
+### Currency Selector
+
+- Options: SGD, USD, HKD, Original
+- Preference stored in `db.settings` with key `portfolio:preferredCurrency` (default: SGD)
+- All monetary values across tabs convert when a non-Original currency is selected
+- Original amount shown as secondary text when converted
+- Missing FX rates gracefully fallback to original currency with warning
+
+## Tabs
+
+### Overview
+
+- **KPI Cards**: Total Portfolio Value, Day Change (unrealized P&L proxy), Dividends YTD
+- **AllocationChart**: Donut chart (Recharts PieChart) grouping positions by `secType`
+- **CurrencyBreakdown**: Mini progress bars per currency
+- **PerformanceSparkline**: Area chart placeholder with time-range toggle (1M/3M/6M/1Y/YTD/All); shows "Not enough data" until historical snapshots are implemented
+- **Empty state**: "No portfolio data yet. Sync your brokerage account."
+
+### Holdings
+
+- **Grouped table**: Positions grouped by currency with collapsible headers
+- **Columns**: Symbol, Qty, Avg Cost, Mkt Price, Mkt Value, P&L
+- **Expandable rows**: Full name, raw cost basis, day/52W ranges from extensions, action buttons
+- **Search**: Filters by symbol or name
+- **Empty state**: "No holdings yet. Sync your account."
+
+### Transactions (Portfolio Context)
+
+- Enhanced unified transaction view with additional columns: Type, Symbol, Quantity, Price
+- Type badges: BUY (green), SELL (red), DIVIDEND (amber), FEE (gray)
+- Dividend-to-bank linking: detects matching bank deposits by amount + date proximity
+
+### Dividends
+
+- **Summary cards**: YTD Total, Monthly Average, Yield on Cost
+- **DividendBarChart**: Monthly stacked bar chart by currency
+- **Year selector**: Current year + previous 4 years
+- **DividendTable**: Symbol, Ex-Date, Pay Date, Amount, Currency, Type
+- **Filter**: All | Paid | Estimated
+
+## Responsive Design
+
+- Tab bar horizontally scrollable on narrow screens
+- KPI cards stack vertically on mobile
+- Holdings table horizontally scrollable with sticky Symbol column
+- Donut chart legend wraps gracefully
+- Dark mode compatible throughout
+
+## Data Model
+
+Uses existing Phase 1 brokerage tables:
+- `brokeragePositions` — holdings with avgCost, marketValue, unrealizedPnl
+- `brokerageAccounts` — cash balances per currency
+- `brokerageTransactions` — order fills
+- `brokerageCorpActions` — dividends, splits, etc.
+- `brokerageSyncLog` — last sync timestamps
+
+Plus new table:
+- `fxRates` — `{ date, base, rates }` cached daily
+
+## Testing
+
+- Unit tests for FX conversion and caching
+- Full test suite passes without regression
+- Linter passes
+
+## Future Work (Phase 3+)
+
+- Historical portfolio snapshots for performance sparkline
+- Adjusted cost basis including option premium tracking
+- Dividend-to-bank transaction auto-linking
+- Multiple brokerage account support
+- Real-time price feed integration

--- a/openspec/changes/portfolio-hub-phase2/.openspec.yaml
+++ b/openspec/changes/portfolio-hub-phase2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/portfolio-hub-phase2/design.md
+++ b/openspec/changes/portfolio-hub-phase2/design.md
@@ -1,0 +1,99 @@
+## Context
+
+Lokfi is a personal finance app with a warm minimal aesthetic (amber accents, card-based UI, Tailwind CSS, Recharts). Phase 1 completed the unified transaction view on `/transactions`, allowing users to see bank transactions alongside brokerage data (BUY, SELL, DIVIDEND, FEE, CORP ACTION) with source-type tabs and disabled interactions for brokerage rows. Brokerage data is stored in separate Dexie tables (`brokerageTransactions`, `brokerageCorpActions`, `brokeragePositions`, `brokerageAccounts`) synced from Tiger Brokers via `SyncOrchestrator`.
+
+The existing `/dashboard` page uses Recharts for spending charts and has a card-based layout. The app uses Dexie React Hooks (`useLiveQuery`) for reactive queries, `next-themes` for dark mode, and TanStack Router for routing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can see their total portfolio value, day change, and dividends YTD in a dedicated Overview tab
+- Users can browse all holdings grouped by currency with adjusted cost basis and unrealized P&L
+- Users can view dividend income history with monthly trends and yield-on-cost metrics
+- Users can switch their preferred display currency (SGD, USD, HKD) and see all values converted
+- FX rates are fetched once per day and cached in Dexie for offline use
+- The Portfolio page is accessible via sidebar navigation between Dashboard and Import
+
+**Non-Goals:**
+- No real-time market data streaming (uses last-synced prices from `brokeragePositions`)
+- No options-specific cost basis adjustment in Phase 2 (raw cost basis only; option premium tracking is Phase 3+)
+- No dividend-to-bank-transaction auto-linking in Phase 2 (manual linking or Phase 3+)
+- No portfolio rebalancing suggestions or tax-loss harvesting
+- No support for multiple brokerage accounts in Phase 2 (Tiger only)
+- No auto-sync scheduling (remains manual via `/settings/brokerage`)
+
+## Decisions
+
+### 1. Recharts for All Charts
+**Decision**: Use Recharts (already a dependency) for the donut chart, bar chart, and area sparkline.
+
+**Rationale**:
+- Recharts is already used in DashboardPage for spending/category charts
+- No new dependency needed
+- PieChart with inner radius creates the donut effect; AreaChart for sparkline; BarChart for monthly dividends
+
+**Alternative considered**: Chart.js or D3. Rejected because Recharts is already integrated and the team knows it.
+
+### 2. FX Rate Cache in Dexie (`fxRates` table)
+**Decision**: Add an `fxRates` table to the Dexie schema (v6 migration) that stores `{ base, rates, date }`.
+
+**Rationale**:
+- Portfolio calculations need FX rates for every currency conversion; fetching on every render is wasteful
+- Cached rates enable offline viewing of portfolio values
+- Frankfurter API is free, rate-limited, and has no API key — caching respects the implicit rate limit
+
+**Storage format**:
+- Table: `fxRates` with composite key `[date+base]` (or just `date` if we always fetch USD base)
+- Record: `{ date: '2024-05-04', base: 'USD', rates: { SGD: 1.35, HKD: 7.82, ... } }`
+- Conversion: `amount * (rates[to] / rates[from])`
+
+### 3. Adjusted Cost Basis — Raw Only in Phase 2
+**Decision**: Show raw cost basis in Holdings tab. Note in UI that "adjusted cost basis (including options) is coming in a future update."
+
+**Rationale**:
+- True adjusted cost basis requires linking option transactions to assigned stock positions, which needs a new data model for option legs
+- Raw cost basis from `BrokeragePosition.avgCost` is sufficient for 80% of users
+- Avoids scope creep; option premium tracking is a well-defined Phase 3 feature
+
+### 4. Currency Selector as Global Preference
+**Decision**: Store preferred currency in `db.settings` with key `portfolio:preferredCurrency` (default: SGD). The selector in the Portfolio header reads/writes this setting.
+
+**Rationale**:
+- Users want a consistent currency view across all portfolio tabs
+- Storing in settings means the preference persists across sessions
+- Other pages (e.g., future Dashboard v2) can read the same key
+
+### 5. Tab State in URL Query Param
+**Decision**: Use a URL query parameter `?tab=overview` (defaulting to `overview`) to track the active tab, enabling deep-linking and back-button behavior.
+
+**Rationale**:
+- Users may want to share a link to their Holdings tab
+- Back button should return to the previous tab, not exit the page
+- TanStack Router supports query params natively
+
+### 6. Holdings Data Computed from `brokeragePositions` + `brokerageAccounts`
+**Decision**: Holdings tab queries `db.brokeragePositions` and `db.brokerageAccounts` directly. Market value is `quantity × avgCost` (since real-time prices are out of scope); P&L uses last-synced data.
+
+**Rationale**:
+- `BrokeragePosition` already has `avgCost`, `quantity`, and `marketValue` (if available from sync)
+- If `marketValue` is null, fall back to `quantity × avgCost` as a conservative estimate
+- This avoids needing a real-time price feed integration
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| **FX rate staleness**: If rates are >24h old, converted values may be misleading | Show "Last updated" micro-text with the rate date; refresh button to manually fetch |
+| **Performance**: Large portfolios (100+ positions) may cause Recharts to lag | Memoize chart data with `useMemo`; use `ResponsiveContainer` with debounced resize |
+| **Data freshness**: Portfolio value uses last-synced prices, not real-time | Display "Last sync: {timestamp}" prominently; encourage users to sync regularly |
+| **Mobile chart readability**: Donut chart legend may overflow on narrow screens | Use horizontal scrollable legend or switch to list view below chart on mobile |
+| **Schema migration**: Adding `fxRates` table requires Dexie v6 | Add standard Dexie version upgrade with `.stores()` — no data migration needed since it's a new table |
+
+## Open Questions
+
+1. Should the currency selector affect the `/transactions` page too, or only `/portfolio`? 
+  - only affect portfolio page
+2. Should we show cash balances from `brokerageAccounts` in the Overview total, or only holdings? 
+  - show only holdings for now
+3. What happens if `brokeragePositions` is empty (sync hasn't run)? Empty state design needed.
+  - yes design empty state

--- a/openspec/changes/portfolio-hub-phase2/proposal.md
+++ b/openspec/changes/portfolio-hub-phase2/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Phase 1 introduced a unified transaction view that mixes bank and brokerage rows on `/transactions`. Users can now see trades and dividends alongside spending, but there is no dedicated place to understand their portfolio as a whole — total value, allocation, holdings, or dividend income. A portfolio hub is essential for Lokfi's core value proposition of providing a complete financial picture. Phase 2 delivers a tabbed `/portfolio` page that surfaces this data in an actionable, visually rich layout.
+
+## What Changes
+
+- Add **Portfolio** navigation item to the sidebar between Dashboard and Import
+- Create **`/portfolio` route** with a tabbed single-page layout: Overview | Holdings | Transactions | Dividends
+- Build **Overview tab** with KPI cards (total value, day change, dividends YTD), asset allocation donut chart, currency breakdown cards, and a performance sparkline with time-range toggle
+- Build **Holdings tab** with a grouped table showing positions by currency, including adjusted cost basis, market value, unrealized P&L, and expandable row detail
+- Enhance **Transactions tab** with dedicated portfolio context, Type/Symbol/Qty/Price columns, and dividend-to-bank linking
+- Build **Dividends tab** with YTD summary, monthly bar chart, yield-on-cost metric, and a focused dividend history table
+- Add **FX rate integration** using the Frankfurter API (with fallback), cached in a new `fxRates` Dexie table, powering currency conversion across the portfolio
+- Add a **currency selector** in the portfolio header that affects all monetary values on the page
+- Ensure full **mobile responsiveness** and **dark mode compatibility**
+- **No breaking changes** to existing transaction, rule, or category systems
+
+## Capabilities
+
+### New Capabilities
+- `portfolio-overview`: KPI dashboard, asset allocation, currency breakdown, performance sparkline
+- `portfolio-holdings`: Position table with adjusted cost basis, grouped by currency, expandable detail
+- `portfolio-dividends`: Dividend tracking view with YTD metrics, monthly bar chart, yield-on-cost
+- `fx-rate-integration`: Frankfurter API client, Dexie caching, currency conversion utilities
+- `portfolio-navigation`: Sidebar nav entry and `/portfolio` routing
+
+### Modified Capabilities
+- `unified-transaction-view`: Add Type/Symbol/Qty/Price columns in portfolio context; add dividend-to-bank linking indicator
+
+## Impact
+
+- `apps/web/src/layouts/AppShell.tsx` — add Portfolio to `NAV_ITEMS`
+- `apps/web/src/router.tsx` — add `/portfolio` route
+- `apps/web/src/pages/portfolio/` — new directory with PortfolioPage and tab components
+- `apps/web/src/lib/fx/` — new directory with FX rate client and cache
+- `apps/web/src/lib/db/db.ts` — add `fxRates` table to Dexie schema (v6 migration)
+- `apps/web/src/pages/transactions/` — minor enhancements for portfolio context (Type/Symbol/Qty/Price display)

--- a/openspec/changes/portfolio-hub-phase2/specs/fx-rate-integration/spec.md
+++ b/openspec/changes/portfolio-hub-phase2/specs/fx-rate-integration/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: FX rates are fetched and cached daily
+The system SHALL fetch foreign exchange rates from the Frankfurter API and cache them in Dexie.
+
+#### Scenario: First visit to Portfolio page
+- **WHEN** a user navigates to `/portfolio` and no cached rates exist for today
+- **THEN** the system fetches rates from `https://api.frankfurter.dev/v2/latest?from=USD`
+- **AND** stores the result in `db.fxRates` as `{ date, base, rates }`
+- **AND** displays a "Last updated: today" micro-text
+
+#### Scenario: Rates already cached for today
+- **WHEN** a user navigates to `/portfolio` and cached rates exist for today
+- **THEN** the system uses the cached rates without making an API call
+- **AND** displays the cached date in the micro-text
+
+#### Scenario: Frankfurter API fails
+- **WHEN** the Frankfurter request fails
+- **THEN** the system attempts the fallback endpoint `https://open.er-api.com/v6/latest/USD`
+- **AND** if both fail, uses the most recent cached rates regardless of date
+- **AND** shows a warning: "Using cached rates from {date}"
+
+#### Scenario: No cached rates and both APIs fail
+- **WHEN** no cached rates exist and both APIs fail
+- **THEN** amounts are shown in their original currency without conversion
+- **AND** a warning is shown: "FX rates unavailable. Showing original currencies."
+
+### Requirement: Currency conversion utility
+The system SHALL provide a utility function to convert amounts between currencies using cached rates.
+
+#### Scenario: Convert USD to SGD
+- **WHEN** converting $100 USD to SGD with cached rate `SGD: 1.35`
+- **THEN** the result is `100 * 1.35 = 135 SGD`
+
+#### Scenario: Convert between non-USD currencies
+- **WHEN** converting SGD to HKD with cached rates `SGD: 1.35, HKD: 7.82`
+- **THEN** the result is `amount * (7.82 / 1.35)`
+
+#### Scenario: Convert to same currency
+- **WHEN** converting SGD to SGD
+- **THEN** the result is the original amount with no API call
+
+### Requirement: Currency selector affects all monetary values
+The system SHALL provide a currency selector in the Portfolio header that converts all displayed amounts.
+
+#### Scenario: User selects USD
+- **WHEN** a user selects USD from the currency dropdown
+- **THEN** all monetary values on the Portfolio page are converted to USD
+- **AND** the preference is stored in `db.settings` with key `portfolio:preferredCurrency`
+- **AND** the selection persists across page refreshes
+
+#### Scenario: Default currency
+- **WHEN** a user visits `/portfolio` for the first time
+- **THEN** the default currency is SGD
+- **AND** the selector shows "SGD"

--- a/openspec/changes/portfolio-hub-phase2/specs/portfolio-dividends/spec.md
+++ b/openspec/changes/portfolio-hub-phase2/specs/portfolio-dividends/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Dividends tab displays YTD summary metrics
+The system SHALL display summary metrics for dividend income in the Dividends tab.
+
+#### Scenario: Dividends exist for the current year
+- **WHEN** the Dividends tab is active and dividend corp actions exist
+- **THEN** the YTD Total card shows the sum of all dividend amounts in the current calendar year
+- **AND** the Monthly Average card shows `YTD Total / number of months with dividends`
+- **AND** the Yield on Cost card shows `annualized dividends / total cost basis` as a percentage
+- **AND** all values are converted to the preferred currency using cached FX rates
+
+#### Scenario: No dividends exist
+- **WHEN** the Dividends tab is active and no dividend corp actions exist
+- **THEN** an empty state message is displayed: "No dividends recorded yet."
+
+### Requirement: Dividends tab displays monthly bar chart
+The system SHALL render a bar chart showing dividend income by month.
+
+#### Scenario: Monthly dividend data exists
+- **WHEN** dividend corp actions exist with `payDate` or `exDate`
+- **THEN** a bar chart groups dividends by month (Jan–Dec)
+- **AND** each bar height represents the total dividend amount for that month
+- **AND** the chart updates when the year selector changes
+
+#### Scenario: Year selector
+- **WHEN** a user selects a different year from the dropdown
+- **THEN** the chart and summary metrics update to reflect that year's dividends
+
+### Requirement: Dividends tab displays dividend history table
+The system SHALL display a table of individual dividend records.
+
+#### Scenario: Dividend records exist
+- **WHEN** the Dividends tab is active
+- **THEN** a table shows: Symbol, Ex-Date, Pay Date, Amount, Currency, and Type
+- **AND** rows are sorted by pay date descending
+- **AND** a filter allows showing All, Paid (past pay date), or Estimated (future pay date)
+
+### Requirement: Dividend income integration with transactions
+The system SHALL provide a link from dividends to the unified transaction view.
+
+#### Scenario: User clicks a dividend row
+- **WHEN** a user clicks on a dividend row in the Dividends tab
+- **THEN** the app navigates to `/transactions` with the Brokerage tab active and the symbol filtered

--- a/openspec/changes/portfolio-hub-phase2/specs/portfolio-holdings/spec.md
+++ b/openspec/changes/portfolio-hub-phase2/specs/portfolio-holdings/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Holdings tab displays all positions in a grouped table
+The system SHALL display a table of all positions grouped by currency, with columns for symbol, quantity, average cost, market price, market value, and unrealized P&L.
+
+#### Scenario: Positions exist in multiple currencies
+- **WHEN** the Holdings tab is active and positions exist
+- **THEN** positions are grouped into collapsible sections by currency (e.g., "USD Holdings", "SGD Holdings")
+- **AND** each row shows: Symbol, Qty, Avg Cost, Mkt Price, Mkt Value, and P&L
+- **AND** P&L is color-coded green for positive, red for negative
+- **AND** a search input filters rows by symbol or name
+
+#### Scenario: Position has market value from sync
+- **WHEN** a `BrokeragePosition` has a `marketValue` field
+- **THEN** the Mkt Value column displays that value
+- **AND** the Mkt Price is computed as `marketValue / quantity`
+
+#### Scenario: Position lacks market value
+- **WHEN** a `BrokeragePosition` has no `marketValue`
+- **THEN** the Mkt Value falls back to `quantity × avgCost`
+- **AND** a tooltip or asterisk indicates this is an estimated value
+
+### Requirement: Holdings tab supports expandable row detail
+The system SHALL allow users to click a holdings row to expand and see detailed information.
+
+#### Scenario: User expands a row
+- **WHEN** a user clicks on a holdings row
+- **THEN** the row expands to show: full name, raw cost basis, adjusted cost basis (with Phase 3 note), day range, 52-week range, and action buttons
+- **AND** two action buttons are shown: "View Transactions" and "View Corp Actions"
+- **AND** clicking "View Transactions" navigates to the Transactions tab with the symbol pre-filtered
+
+### Requirement: Holdings tab handles empty state
+The system SHALL show an empty state when no positions exist.
+
+#### Scenario: No positions synced
+- **WHEN** the Holdings tab is active and `brokeragePositions` is empty
+- **THEN** a message is displayed: "No holdings yet. Sync your account to see your positions."
+- **AND** a button links to `/settings/brokerage`

--- a/openspec/changes/portfolio-hub-phase2/specs/portfolio-navigation/spec.md
+++ b/openspec/changes/portfolio-hub-phase2/specs/portfolio-navigation/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Portfolio navigation item is added to sidebar
+The system SHALL add a Portfolio navigation item to the AppShell sidebar.
+
+#### Scenario: Sidebar renders
+- **WHEN** the AppShell renders
+- **THEN** the sidebar contains a "Portfolio" item with a `TrendingUp` icon
+- **AND** it is positioned between "Dashboard" and "Import"
+- **AND** clicking it navigates to `/portfolio`
+
+#### Scenario: Active state
+- **WHEN** the user is on `/portfolio`
+- **THEN** the Portfolio nav item shows the active styling (accent background, left border)
+
+### Requirement: Portfolio route is registered
+The system SHALL register a `/portfolio` route in the router.
+
+#### Scenario: Navigate to portfolio
+- **WHEN** a user navigates to `/portfolio`
+- **THEN** the `PortfolioPage` component renders inside the shell layout
+- **AND** the default active tab is Overview
+
+#### Scenario: Deep link to specific tab
+- **WHEN** a user navigates to `/portfolio?tab=holdings`
+- **THEN** the Holdings tab is active by default
+- **AND** the URL remains `/portfolio?tab=holdings`

--- a/openspec/changes/portfolio-hub-phase2/specs/portfolio-overview/spec.md
+++ b/openspec/changes/portfolio-hub-phase2/specs/portfolio-overview/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Overview tab displays portfolio KPIs
+The system SHALL display three key metrics in the Overview tab: total portfolio value, day change, and dividends year-to-date.
+
+#### Scenario: Portfolio has holdings and cash
+- **WHEN** the Overview tab is active and brokerage data exists
+- **THEN** the total portfolio value card shows the sum of all position market values plus cash balances
+- **AND** the day change card shows the difference between current total and the previous sync total
+- **AND** the dividends YTD card shows the sum of all DIVIDEND corp actions in the current calendar year
+- **AND** each card shows a secondary line with the raw amount in the dominant underlying currency
+
+#### Scenario: Portfolio is empty
+- **WHEN** the Overview tab is active and no brokerage data exists
+- **THEN** an empty state message is displayed: "No portfolio data yet. Sync your brokerage account to see your holdings."
+- **AND** a link to `/settings/brokerage` is shown
+
+### Requirement: Overview tab displays asset allocation
+The system SHALL render an asset allocation section with a donut chart and legend.
+
+#### Scenario: Holdings exist across multiple asset classes
+- **WHEN** the Overview tab is active and positions exist
+- **THEN** a donut chart shows the percentage breakdown by asset class
+- **AND** a legend lists each asset class with a color swatch, percentage, and converted value
+- **AND** hovering on a donut segment highlights the corresponding legend row
+
+#### Scenario: Allocation breakdown
+- **WHEN** positions are grouped by their `secType` field
+- **THEN** the donut chart segments represent: STK (equities), OPT (options), CASH (cash), FUND (funds), and OTHER (everything else)
+- **AND** percentages are calculated as `position market value / total portfolio value`
+
+### Requirement: Overview tab displays currency breakdown
+The system SHALL display a currency breakdown section with mini progress bars.
+
+#### Scenario: Holdings exist in multiple currencies
+- **WHEN** the Overview tab is active and positions have different currencies
+- **THEN** each currency is displayed in a card with its total value and percentage of the portfolio
+- **AND** a mini horizontal progress bar shows the percentage
+- **AND** clicking a card expands to show holdings within that currency
+
+### Requirement: Overview tab displays performance sparkline
+The system SHALL render a performance sparkline showing portfolio value over time.
+
+#### Scenario: Historical data exists
+- **WHEN** the Overview tab is active and at least two sync snapshots exist
+- **THEN** an area chart shows portfolio value over the selected time range
+- **AND** a time range toggle allows switching between 1M, 3M, 6M, 1Y, YTD, and All
+
+#### Scenario: Insufficient historical data
+- **WHEN** fewer than two sync snapshots exist
+- **THEN** the chart area shows "Not enough data — sync again to build history"

--- a/openspec/changes/portfolio-hub-phase2/specs/unified-transaction-view/spec.md
+++ b/openspec/changes/portfolio-hub-phase2/specs/unified-transaction-view/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Unified transaction table renders both bank and brokerage rows
+The system SHALL display brokerage transactions in the existing `TransactionTable` alongside bank transactions without adding new columns.
+
+#### Scenario: Brokerage BUY row rendering in portfolio context
+- **WHEN** a brokerage BUY transaction is rendered in the table
+- **THEN** the Description column shows `"BUY {symbol} — {qty} shares @ {price}"`
+- **AND** the Amount is rendered in neutral gray color
+- **AND** the Source column shows `📈 {brokerageName}`
+- **AND** the Category column shows `—`
+- **AND** the checkbox is disabled
+
+#### Scenario: Brokerage DIVIDEND row rendering in portfolio context
+- **WHEN** a brokerage DIVIDEND transaction is rendered in the table
+- **THEN** the Description column shows `"{symbol} Dividend"`
+- **AND** the Amount is rendered in green color
+- **AND** the Source column shows `📈 {brokerageName}`
+- **AND** the Category column shows `—`
+
+#### Scenario: Bank transaction rendering is unchanged
+- **WHEN** a bank transaction is rendered in the unified table
+- **THEN** all existing formatting, colors, and interactions remain identical to pre-change behavior
+
+## ADDED Requirements
+
+### Requirement: Portfolio transactions tab shows enhanced columns
+The system SHALL display additional columns when viewing transactions in the portfolio context.
+
+#### Scenario: Portfolio Transactions tab active
+- **WHEN** the Transactions tab within `/portfolio` is active
+- **THEN** the table includes columns: Date, Description, Type, Symbol, Quantity, Price, Amount, Source, Category
+- **AND** the Type column shows a badge: BUY (green), SELL (red), DIVIDEND (amber), FEE (gray)
+- **AND** Symbol, Quantity, and Price are blank for bank transactions
+
+#### Scenario: Type badge rendering
+- **WHEN** a brokerage BUY row is rendered
+- **THEN** the Type badge is green and shows "BUY"
+- **AND** a SELL badge is red
+- **AND** a DIVIDEND badge is amber
+- **AND** a FEE badge is gray
+
+### Requirement: Dividend rows link to bank transactions
+The system SHALL show a link indicator when a dividend corp action may correspond to a bank deposit.
+
+#### Scenario: Potential dividend match exists
+- **WHEN** a DIVIDEND row is rendered and a bank transaction with matching amount and date exists
+- **THEN** a chain/link icon appears in the row
+- **AND** clicking the icon navigates to the linked bank transaction
+
+#### Scenario: No match found
+- **WHEN** a DIVIDEND row is rendered and no matching bank transaction exists
+- **THEN** no link icon is shown

--- a/openspec/changes/portfolio-hub-phase2/tasks.md
+++ b/openspec/changes/portfolio-hub-phase2/tasks.md
@@ -1,0 +1,119 @@
+## 1. Navigation & Routing
+
+- [x] 1.1 Add `Portfolio` to `NAV_ITEMS` in `AppShell.tsx` between Dashboard and Import with `TrendingUp` icon
+- [x] 1.2 Create `/portfolio` route in `router.tsx` with `PortfolioPage` component
+- [x] 1.3 Create `PortfolioPage.tsx` shell with tab state managed via URL query param (`?tab=`)
+- [x] 1.4 Create tab navigation component: Overview | Holdings | Transactions | Dividends
+- [x] 1.5 Check if any brokerage credentials exist (`db.brokerageCredentials.count() > 0`) on Portfolio page mount; show setup CTA if none
+- [x] 1.6 Add "Brokerage Settings" icon button in Portfolio header linking to `/settings/brokerage`
+- [x] 1.7 Display last sync timestamp in Portfolio header from `brokerageSyncLog` (most recent per source)
+- [x] 1.8 Add "Sync Now" button in Portfolio header that triggers `SyncOrchestrator.sync()` with stored lookback days
+
+## 2. FX Rate Infrastructure
+
+- [x] 2.1 Add `fxRates` table to Dexie schema (v6 migration) with fields: `date`, `base`, `rates`
+- [x] 2.2 Create `src/lib/fx/frankfurter-client.ts` with fetch function for latest rates
+- [x] 2.3 Create `src/lib/fx/fallback-client.ts` with exchangerate-api fallback
+- [x] 2.4 Create `src/lib/fx/cache.ts` with `getRates()`, `storeRates()`, and `isStale()` helpers
+- [x] 2.5 Create `src/lib/fx/convert.ts` with `convertAmount(amount, from, to, rates)` utility
+- [x] 2.6 Create `useFxRates()` hook that fetches on mount if stale, returns rates + lastUpdated + error state
+- [x] 2.7 Write unit tests for FX conversion logic and caching behavior
+
+## 3. Currency Selector & Preference
+
+- [x] 3.1 Create `CurrencySelector` dropdown component with options: SGD, USD, HKD, Original
+- [x] 3.2 Store `portfolio:preferredCurrency` in `db.settings` (default: SGD)
+- [x] 3.3 Read preference on Portfolio page load and pass to all child tabs
+- [x] 3.4 Show "Last updated: {date}" micro-text below the currency selector
+
+## 4. Overview Tab
+
+- [x] 4.1 Create `OverviewTab.tsx` with card-based layout
+- [x] 4.2 Implement KPI cards: Total Portfolio Value, Day Change, Dividends YTD
+- [x] 4.3 Compute total portfolio value from `brokeragePositions` market values + `brokerageAccounts` cash balances
+- [x] 4.4 Compute day change from current vs previous sync snapshot (stored in `brokerageAccounts` history)
+- [x] 4.5 Compute dividends YTD by filtering `brokerageCorpActions` for `type === 'DIVIDEND'` in current year
+- [x] 4.6 Create `AllocationChart` donut chart using Recharts PieChart with inner radius
+- [x] 4.7 Group positions by `secType` (STK, OPT, CASH, FUND, OTHER) for allocation
+- [x] 4.8 Create `CurrencyBreakdown` component with mini progress bars per currency
+- [x] 4.9 Create `PerformanceSparkline` area chart with time range toggle (1M, 3M, 6M, 1Y, YTD, All)
+- [x] 4.10 Store historical portfolio snapshots in `brokerageAccounts` or compute from positions + transactions
+- [x] 4.11 Handle empty state: "No portfolio data yet. Sync your brokerage account."
+- [x] 4.12 Add loading skeletons for all cards while data loads
+- [x] 4.13 Add "Connect Brokerage" CTA card when no credentials exist; links to `/settings/brokerage`
+
+## 5. Holdings Tab
+
+- [x] 5.1 Create `HoldingsTab.tsx` with search input and grouped table layout
+- [x] 5.2 Query `db.brokeragePositions` and group by `currency`
+- [x] 5.3 Create `HoldingsTable` with columns: Symbol, Qty, Avg Cost, Mkt Price, Mkt Value, P&L
+- [x] 5.4 Compute Mkt Price: `marketValue / quantity` if `marketValue` exists, else fallback to `avgCost`
+- [x] 5.5 Compute P&L: `(mktPrice - avgCost) × quantity`
+- [x] 5.6 Color-code P&L: green for positive, red for negative
+- [x] 5.7 Add collapsible currency group headers (USD Holdings, SGD Holdings)
+- [x] 5.8 Add search filtering by symbol or name
+- [x] 5.9 Create `HoldingDetailRow` expandable component with: full name, raw cost basis, day range, 52W range
+- [x] 5.10 Add "View Transactions" and "View Corp Actions" buttons in expanded detail
+- [x] 5.11 Handle empty state: "No holdings yet. Sync your account."
+
+## 6. Transactions Tab (Portfolio Context)
+
+- [x] 6.1 Create `PortfolioTransactionsTab.tsx` wrapping the existing unified transaction view
+- [x] 6.2 Add Type badge column: BUY (green), SELL (red), DIVIDEND (amber), FEE (gray)
+- [x] 6.3 Add Symbol column (blank for bank transactions)
+- [x] 6.4 Add Quantity column (blank for bank and non-BUY/SELL)
+- [x] 6.5 Add Price column (blank for bank and non-BUY/SELL)
+- [x] 6.6 Add dividend-to-bank linking: detect matching bank transactions by amount + date proximity
+- [x] 6.7 Show chain/link icon for linked dividends with navigation to the bank transaction
+
+## 7. Dividends Tab
+
+- [x] 7.1 Create `DividendsTab.tsx` with summary cards and chart layout
+- [x] 7.2 Query `db.brokerageCorpActions` filtered by `type === 'DIVIDEND'`
+- [x] 7.3 Compute YTD Total: sum of dividends in current calendar year
+- [x] 7.4 Compute Monthly Average: `YTD Total / monthsWithDividends`
+- [x] 7.5 Compute Yield on Cost: `annualizedDividends / totalCostBasis`
+- [x] 7.6 Convert all metrics to preferred currency using cached FX rates
+- [x] 7.7 Create `DividendBarChart` monthly grouped bar chart using Recharts BarChart
+- [x] 7.8 Add year selector dropdown (current year and previous 4 years)
+- [x] 7.9 Create `DividendTable` with columns: Symbol, Ex-Date, Pay Date, Amount, Currency, Type
+- [x] 7.10 Add All | Paid | Estimated filter based on pay date
+- [x] 7.11 Handle empty state: "No dividends recorded yet."
+
+## 8. Currency Conversion Integration
+
+- [x] 8.1 Apply currency conversion to all monetary values in Overview KPI cards
+- [x] 8.2 Apply currency conversion to Holdings table Mkt Value and P&L
+- [x] 8.3 Apply currency conversion to Dividends summary metrics
+- [x] 8.4 Show original currency amount as secondary text when converted
+- [x] 8.5 Handle missing FX rate gracefully (show original currency with warning)
+
+## 9. Mobile & Visual Polish
+
+- [x] 9.1 Make tab bar horizontally scrollable on narrow screens
+- [x] 9.2 Stack KPI cards vertically on mobile
+- [x] 9.3 Make Holdings table horizontally scrollable with sticky Symbol column
+- [x] 9.4 Ensure donut chart legend wraps gracefully on mobile
+- [x] 9.5 Verify dark mode compatibility for all new charts and cards
+- [x] 9.6 Use `tab-nums` font variant for all monetary amounts
+- [x] 9.7 Ensure amber accent is used sparingly — charts should use distinct color palette
+
+## 10. Testing & Validation
+
+- [x] 10.1 Test with empty portfolio data: all tabs show correct empty states
+- [x] 10.2 Test with single-currency portfolio: currency breakdown shows one card
+- [x] 10.3 Test FX rate fetch: verify Frankfurter API call and caching
+- [x] 10.4 Test FX fallback: simulate Frankfurter failure, verify fallback API used
+- [x] 10.5 Test currency conversion: verify SGD→USD and USD→HKD calculations
+- [x] 10.6 Test tab deep-linking: `/portfolio?tab=holdings` opens correct tab
+- [x] 10.7 Test sidebar active state: Portfolio highlighted when on `/portfolio`
+- [x] 10.8 Test mobile responsiveness: all tabs usable at 375px width
+- [x] 10.9 Run existing test suite: `pnpm test` must pass without regression
+- [x] 10.10 Run linter: `pnpm lint` must pass
+
+## 11. Documentation
+
+- [x] 11.1 Add JSDoc to all FX utility functions and hooks
+- [x] 11.2 Update `docs/portfolio-design-v1.md` to reflect Phase 2 completion
+- [x] 11.3 Update `apps/web/README.md` with Portfolio page description
+- [x] 11.4 Run `openspec apply` to mark tasks complete

--- a/openspec/changes/portfolio-tracking-phase1/.openspec.yaml
+++ b/openspec/changes/portfolio-tracking-phase1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/portfolio-tracking-phase1/design.md
+++ b/openspec/changes/portfolio-tracking-phase1/design.md
@@ -1,0 +1,142 @@
+## Context
+
+Lokfi is a personal finance app with a warm minimal aesthetic (amber accents, card-based UI, Tailwind CSS, Recharts). It currently tracks bank statement transactions imported from PDFs. The brokerage abstraction layer is complete — Tiger Brokers API syncs positions, transactions, corporate actions, and account data to Dexie (`brokerageTransactions`, `brokerageCorpActions`, `brokeragePositions`, `brokerageAccounts`).
+
+The existing `/transactions` page (`TransactionsPage.tsx`) shows a `TransactionTable` with columns: checkbox, Date, Description, Amount, Category, Source, Account. It uses Dexie React Hooks (`useLiveQuery`) for reactive queries, supports filtering by date/source/account/category, pagination (100 rows), bulk category selection, and rule suggestions.
+
+The design docs (`docs/portfolio-design-v1.md`, `docs/portfolio-design-v2.md`) and an oracle review established that:
+- A unified view of bank + brokerage transactions is valuable but must not break existing bank transaction UX
+- Brokerage data must NOT be merged into the `transactions` table (schema/risk reasons)
+- The unified view should be computed at query time from separate Dexie tables
+- Phase 1 should be display-only, additive, and shippable in one PR
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can see brokerage transactions (BUY, SELL, DIVIDEND, FEE, CORP ACTION) alongside bank transactions in a single timeline
+- Users can filter the view by source type: All, Bank-only, or Brokerage-only
+- Brokerage rows are visually distinct from bank rows (icon, color, disabled interactions)
+- Zero impact on existing bank transaction workflows (categorization, rules, bulk select, export)
+- The unified query layer handles merging, sorting, and pagination across two Dexie tables
+
+**Non-Goals:**
+- No new table columns (Symbol, Qty, Price are rendered inline in Description)
+- No schema changes to `DbTransaction` or the rule engine
+- No category editing, bulk select, or rule suggestions for brokerage rows
+- No dividend-to-bank-transaction linking or income categorization in Phase 1
+- No FX rate conversion in Phase 1 (amounts shown in original currency)
+- No Portfolio page or navigation changes (those are Phase 2+)
+- No auto-sync scheduling or multiple accounts per brokerage in Phase 1
+
+## Decisions
+
+### 1. Separate Tables + View Layer (Not Merged Schema)
+**Decision**: Keep `db.transactions` (bank) and `db.brokerageTransactions` + `db.brokerageCorpActions` (brokerage) as separate tables. Build a `useUnifiedTransactions` hook that queries both, maps to a common `UnifiedRow` shape, merges, sorts, and paginates in JavaScript.
+
+**Rationale**:
+- Merging brokerage into `transactions` would break Dexie indexed queries (`date`, `source`, `accountNo`, `category`), the rule engine, and `hash`-based deduplication
+- The existing `TransactionTable.tsx` already fetches all filtered results and slices in-memory (line 72-73), so cross-table pagination is a small step
+- Separate tables let each domain evolve independently
+
+**Alternative considered**: Merge into `transactions` with nullable fields and a `transactionSource` discriminator. Rejected due to high regression risk and schema migration complexity.
+
+### 2. No New Columns — Inline Description Formatting
+**Decision**: Render brokerage details (symbol, qty, price) inside the existing Description column instead of adding Symbol/Qty/Price columns.
+
+**Rationale**:
+- Bank transactions are 90%+ of rows for most users; dead columns create visual noise
+- The existing 7-column table is already dense; adding 3+ columns would break mobile layouts
+- Inline formatting is consistent with the app's minimal aesthetic
+
+**Format**:
+- BUY/SELL: `"BUY AAPL — 10 shares @ $185.00"` or `"SELL NVDA — 5 shares @ $245.00"`
+- DIVIDEND: `"AAPL Dividend — $12.50"`
+- FEE: `"Commission Fee — $1.50"`
+- CORP ACTION: `"AAPL Put Assignment — $500 premium"`
+
+### 3. Neutral Amount Color for BUY/SELL
+**Decision**: Render brokerage BUY/SELL amounts in neutral gray (not red/green). DIVIDEND in green, FEE in red.
+
+**Rationale**:
+- BUY/SELL are asset reallocations, not spending/income. Red/green implies cash flow impact which is misleading when mixed with bank transactions
+- Neutral color signals "this is different" without implying loss/gain
+- Bank transactions retain their existing red/green semantic meaning
+
+### 4. Contextual Filters
+**Decision**: The filter bar adapts based on the active Source Type tab.
+
+**Rationale**:
+- Category filter is irrelevant for brokerage; Type filter is irrelevant for bank
+- Showing both simultaneously creates filter hell (7+ filter groups)
+- Contextual filters keep the bar at 4-5 groups max
+
+**Behavior**:
+| Tab | Active Filters |
+|-----|---------------|
+| All | Date range, Source pills (all), Category dropdown, Type dropdown |
+| Bank | Date range, Source pills (banks only), Category dropdown |
+| Brokerage | Date range, Source pills (brokerages only), Type dropdown |
+
+### 5. Disabled Interactions for Brokerage Rows
+**Decision**: Checkboxes, category editing, and rule suggestions are disabled/hidden for brokerage rows.
+
+**Rationale**:
+- Brokerage transactions are read-only sync data; users shouldn't edit them
+- Bulk category select applies only to bank transactions
+- Rule engine is built for bank description patterns and would produce garbage for brokerage rows
+- This is Phase 1; editable interactions can be added later if needed
+
+### 6. Minimal Brokerage Settings Page
+**Decision**: Add a `/settings/brokerage` page where users configure API credentials, test connection, trigger manual sync, and set sync preferences.
+
+**Rationale**:
+- Without a settings page, users have no way to populate brokerage data into the unified transaction view
+- The existing infrastructure (`CredentialManager`, `dexie-credential-store`, `SyncOrchestrator`) already supports this; only UI is needed
+- Keeping it minimal (one page, one brokerage for now) avoids scope creep
+
+**What's in scope**:
+- Credential input form (API key, secret, account ID) with validation
+- "Test Connection" button calling `provider.validateConnection()`
+- "Sync Now" button calling `SyncOrchestrator.sync()`
+- Sync status display (last sync time, per-category success/failure)
+- "Disconnect" action (clears credentials + wipes brokerage Dexie tables)
+
+**What's out of scope**:
+- Auto-sync scheduling, multiple accounts, CDC full implementation
+
+### 7. Configurable Lookback Days for Sync
+**Decision**: Users can configure how many days of historical transaction/corporate action data to sync (default: 90). Stored in `db.settings` as a key-value pair.
+
+**Rationale**:
+- `SyncOrchestrator` already accepts `lookbackDays` in its constructor (default 90)
+- `TigerProvider` receives `since: Date` from the orchestrator, so the lookback is respected end-to-end
+- `DbSetting` table already exists (`key: string, value: string`) — no schema changes needed
+- Users have different needs: active traders may want 30 days, buy-and-hold investors may want 1-2 years
+
+**Storage format**:
+- Key: `brokerage:{source}:lookbackDays`
+- Value: stringified integer (e.g., `"90"`)
+- Default when missing: 90
+
+**UI presentation**:
+- Number input with quick-select presets: 30, 90, 180, 365, All time
+- Label: "Sync history (days)"
+- Helper text: "How far back to fetch transactions and corporate actions"
+
+**Alternative considered**: Per-category lookback (e.g., positions = all time, transactions = 90 days). Rejected because the existing `SyncOrchestrator` uses a single `lookbackDays` for both `fetchTransactions` and `fetchCorpActions`. Can be extended later if needed.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| **Performance**: Querying two large Dexie tables and merging in JS could be slow for users with 10k+ bank transactions | Lazy-load brokerage queries only when "All" or "Brokerage" tab is active; cache results; add pagination at the query level before merging |
+| **Cognitive overload**: Users may still confuse brokerage BUY amounts with bank spending despite neutral color | Make "Bank" the default tab; add prominent source icon; consider a subtle background tint for brokerage rows |
+| **Mobile density**: Inline description formatting may wrap awkwardly on narrow screens | Use `whitespace-nowrap` for the formatted detail string; truncate with tooltip |
+| **Future schema drift**: If `brokerageTransactions` schema changes, the `UnifiedRow` mapper breaks | Keep the mapper centralized in `useUnifiedTransactions`; add unit tests for mapping logic |
+| **Missing data**: If brokerage sync hasn't run, the "Brokerage" tab shows empty — users may not understand why | Add an empty state with "No brokerage transactions yet. Sync your account in Portfolio settings." (Portfolio page is Phase 2, so this may need a temporary message) |
+
+## Open Questions
+
+1. Should the default tab be "All" or "Bank"? "Bank" preserves existing UX but hides the new feature. "All" showcases the feature but may confuse existing users.
+2. Should we add a subtle background tint (e.g., `--bg-sidebar` vs `--bg`) for brokerage rows, or is the icon + neutral color sufficient?
+3. What is the exact Dexie schema for `brokerageTransactions` and `brokerageCorpActions`? Need to verify field names before writing the mapper.

--- a/openspec/changes/portfolio-tracking-phase1/docs/portfolio-design-v1.md
+++ b/openspec/changes/portfolio-tracking-phase1/docs/portfolio-design-v1.md
@@ -299,19 +299,30 @@ A dedicated view for dividend tracking, integrated with the transactions table b
 
 ---
 
-## Summary of Files to Touch
+## Phase 1 Implementation Notes
+
+Phase 1 (completed) focuses on the **unified transaction view** and **brokerage settings** without adding a dedicated `/portfolio` page. The following decisions were made during implementation:
+
+- **No new table columns** — Symbol, quantity, and price are rendered inline in the Description column (e.g., `"BUY AAPL — 10 shares @ $185.00"`). This preserves information density and avoids breaking mobile layouts.
+- **Separate tables + view layer** — `db.transactions` (bank) and `db.brokerageTransactions` + `db.brokerageCorpActions` (brokerage) remain separate. The `useUnifiedTransactions` hook queries both, maps to `UnifiedTransactionRow`, merges, sorts by date descending, and paginates in JavaScript.
+- **Neutral amount color for BUY/SELL** — BUY/SELL amounts are rendered in neutral gray (not red/green) to signal they are asset reallocations, not spending/income. DIVIDEND is green, FEE is red.
+- **Contextual filters** — The filter bar adapts based on the active Source Type tab. Category dropdown is hidden for Brokerage; Type dropdown is hidden for Bank.
+- **Disabled interactions for brokerage rows** — Checkboxes, category editing, and rule suggestions are disabled/hidden for brokerage rows.
+- **Brokerage settings at `/settings/brokerage`** — A standalone settings page handles credential input, test connection, manual sync, configurable lookback days (default 90, stored in `db.settings`), sync status display, and disconnect.
+- **No navigation changes** — The Portfolio page and sidebar nav changes are deferred to Phase 2+. Users reach `/settings/brokerage` via the empty state link on the Brokerage tab or by direct URL.
+- **No FX rate conversion** — All amounts are shown in their original currency. No `fxRates` table was added.
+
+## Summary of Files Touched
 
 | File | Change |
 |------|--------|
-| `src/layouts/AppShell.tsx` | Add Portfolio to NAV_ITEMS |
-| `src/router.tsx` | Add `/portfolio` route |
-| `src/pages/portfolio/PortfolioPage.tsx` | Main tabbed shell |
-| `src/pages/portfolio/OverviewTab.tsx` | KPI + allocation + performance |
-| `src/pages/portfolio/HoldingsTab.tsx` | Holdings table with detail |
-| `src/pages/portfolio/TransactionsTab.tsx` | Filtered brokerage transactions |
-| `src/pages/portfolio/DividendsTab.tsx` | Dividend tracking view |
-| `src/pages/portfolio/CurrencySelector.tsx` | Shared dropdown component |
-| `src/lib/fx/rates.ts` | Frankfurter API client + cache |
-| `src/lib/db/db.ts` | Add `fxRates` table to schema |
-| `src/pages/transactions/TransactionTable.tsx` | Add Type, Symbol, Qty, Price columns; source icons |
-| `src/pages/transactions/TransactionFilters.tsx` | Add Source Type filter, Type filter |
+| `src/lib/brokerage/unifiedTransactions.ts` | New — `UnifiedTransactionRow` type, `fetchUnifiedRows`, `useUnifiedTransactions` hook |
+| `src/lib/brokerage/unifiedTransactions.test.ts` | New — unit tests for mapper functions and sorting |
+| `src/pages/transactions/filterTypes.ts` | Added `sourceType` and `type` to `Filters` |
+| `src/pages/transactions/SourceTypeTabs.tsx` | New — `All \| Bank \| Brokerage` tabs |
+| `src/pages/transactions/TransactionTable.tsx` | Accepts `UnifiedTransactionRow[]`; source icons, amount colors, disabled interactions |
+| `src/pages/transactions/TransactionFilters.tsx` | Contextual filters based on `sourceType` |
+| `src/pages/transactions/TransactionsPage.tsx` | Uses `useUnifiedTransactions`; source-aware counts; brokerage empty state |
+| `src/pages/settings/BrokerageSettingsPage.tsx` | New — credentials, test connection, sync, lookback days, disconnect |
+| `src/router.tsx` | Added `/settings/brokerage` route |
+| `src/layouts/AppShell.tsx` | No changes (nav deferred to Phase 2+) |

--- a/openspec/changes/portfolio-tracking-phase1/docs/portfolio-design-v1.md
+++ b/openspec/changes/portfolio-tracking-phase1/docs/portfolio-design-v1.md
@@ -1,0 +1,317 @@
+# Portfolio Tracking — Design Mockup: Variation A
+## "Integrated Portfolio Hub" (Tabbed Single-Page)
+
+A single `/portfolio` route that feels like a unified command center. The user lands on **Overview** and tabs navigate between contexts without page loads.
+
+---
+
+## 1. Navigation Change
+
+Add to `AppShell.tsx` `NAV_ITEMS`:
+
+```ts
+{ label: 'Portfolio', path: '/portfolio', icon: TrendingUp }
+```
+
+Place it between **Dashboard** and **Import** to signal its importance.
+
+---
+
+## 2. Page Layout: `/portfolio`
+
+```
++----------------------------------------------------------+
+|  Portfolio                                    [SGD ▼]    |  ← Header + Currency Selector
++----------------------------------------------------------+
+|  [ Overview ] [ Holdings ] [ Transactions ] [ Dividends ]|  ← Tab bar (sticky below header)
++----------------------------------------------------------+
+|                                                          |
+|  [ TAB CONTENT ]                                         |
+|                                                          |
++----------------------------------------------------------+
+```
+
+**Currency Selector** (top-right of header):
+- Dropdown: `SGD | USD | HKD | Preferred`
+- Affects ALL monetary values on the page
+- Uses cached FX rates with a small "Last updated: today 09:00" micro-text
+- Rates fetched from Frankfurter API (primary) or exchangerate-api (fallback)
+
+---
+
+## 3. Tab: Overview
+
+The main dashboard. A grid of cards similar to existing DashboardPage widgets.
+
+### KPI Row (3 cards)
+
+```
++----------------------------------------------------------+
+|  Total Portfolio Value      Day Change        Div YTD     |
+|  S$ 147,230.50             +S$ 1,240 (+0.85%)  S$ 2,100  |
+|  ≈ US$ 109,800             +US$ 920            ≈ US$1,570 |
++----------------------------------------------------------+
+```
+
+- **Total Portfolio Value**: Sum of all holdings market value + cash balances, converted to preferred currency
+- **Day Change**: Unrealized P&L since last close (green/red)
+- **Dividends YTD**: Sum of all dividend corp actions this calendar year
+- Secondary line shows raw currency amount for the dominant underlying currency
+
+### Allocation Section
+
+```
++----------------------------------------------------------+
+|  Asset Allocation                            [Donut Chart] |
+|  ┌─────────┐                                             |
+|  │  USD 65%│  US Equities    45%   S$ 66,254            |
+|  │  SGD 30%│  SG Equities    15%   S$ 22,085            |
+|  │  Cash 5%│  Cash           5%    S$  7,362            |
+|  └─────────┘  Options        10%   S$ 14,723            |
+|               Intl Equities  25%   S$ 36,806            |
++----------------------------------------------------------+
+```
+
+- Donut chart (Recharts PieChart with inner radius)
+- Legend lists asset classes with color swatch, %, and converted value
+- Hover on donut segment highlights the legend row
+
+### Currency Breakdown
+
+```
++----------------------------------------------------------+
+|  By Currency                                             |
+|  ┌─────────────────┐  ┌─────────────────┐                |
+|  │  USD  $109,800  │  │  SGD  S$ 37,430 │                |
+|  │  74.5% of total │  │  25.5% of total │                |
+|  │  [ mini bar ]   │  │  [ mini bar ]   │                |
+|  └─────────────────┘  └─────────────────┘                |
++----------------------------------------------------------+
+```
+
+- Two-column card layout for each currency bucket
+- Mini horizontal progress bar showing % of total portfolio
+- Expandable: click to see holdings within that currency
+
+### Performance Sparkline
+
+```
++----------------------------------------------------------+
+|  Portfolio Value (6M)                                    |
+|                              /\                          |
+|                         /\  /  \    /\                   |
+|                        /  \/    \  /  \                  |
+|                       /            \/   \____             |
+|  S$120k ─────────────────────────────────────────        |
+|  S$150k ─────────────────────────────────────────        |
++----------------------------------------------------------+
+```
+
+- Simple area chart showing portfolio value over last 6 months
+- Uses stored historical sync snapshots (from `BrokerageAccount` or computed from holdings + transactions)
+- Time range toggle: 1M | 3M | 6M | 1Y | YTD | All
+
+---
+
+## 4. Tab: Holdings
+
+A table showing every position with per-position detail. Grouped by currency.
+
+```
++----------------------------------------------------------+
+|  Holdings                                     [🔍 Search] |
++----------------------------------------------------------+
+|  ▼ USD Holdings                                          |
+|  Symbol   Qty    Avg Cost   Mkt Price   Mkt Value   P&L   |
+|  ─────────────────────────────────────────────────────── |
+|  AAPL     50     US$185.00  US$195.00   US$9,750   +$500 │
+|  TSLA     20     US$210.50  US$205.00   US$4,100   -$110 │
+|  NVDA     10     US$120.00* US$125.00   US$1,250   +$50  │
+|  ─────────────────────────────────────────────────────── |
+|  ▼ SGD Holdings                                          |
+|  D05.SI   1000   S$32.50   S$33.20     S$33,200   +$700 │
+|  ─────────────────────────────────────────────────────── |
+|  ▼ Options (USD)                                         |
+|  AAPL     -1     US$5.00   US$2.50      US$250    +$250 │  ← short call
++----------------------------------------------------------+
+```
+
+### Columns
+
+| Column | Description |
+|--------|-------------|
+| Symbol | Ticker with country/exchange badge (e.g., `.SI` for Singapore) |
+| Qty | Current quantity. Negative for short options |
+| Avg Cost | **Adjusted cost basis** (see Cost Basis Logic below). Asterisk `*` if adjusted by options |
+| Mkt Price | Last known price (from sync or manual update) |
+| Mkt Value | `Qty × Mkt Price` |
+| P&L | Unrealized: `(Mkt Price - Avg Cost) × Qty`. Color-coded green/red |
+| Day Δ% | Optional: percentage change since previous close |
+
+### Cost Basis Logic (Critical)
+
+**Adjusted Cost Basis** is computed as:
+
+```
+adjCostBasis = rawCostBasis - optionPremiumReceived + optionPremiumPaid
+```
+
+Example:
+- Buy 100 AAPL at $185 = $18,500 raw cost
+- Sell 1 AAPL put @ $5.00 premium, assigned → receive $500 premium
+- Adjusted cost basis = $18,500 - $500 = $180.00/share
+
+**UI treatment**:
+- Show `Adj: $180.00` as primary value
+- Tooltip on hover (or small `*` footnote) reveals: `Raw: $185.00 — Adjusted by $5.00 put premium`
+- If no option adjustment, show raw cost basis plainly without asterisk
+
+### Expandable Row Detail
+
+Clicking a row expands to show:
+
+```
+  ┌──────────────────────────────────────────────────────┐
+  │  AAPL — Apple Inc. (NASDAQ)                          │
+  │  ─────────────────────────────────────────────────── │
+  │  Raw Cost Basis:   US$185.00/share  (US$9,250 total) │
+  │  Adj. Cost Basis:  US$180.00/share  (US$9,000 total) │
+  │  Adjusted by:      −US$500 (AAPL PUT $180 assigned)  │
+  │  ─────────────────────────────────────────────────── │
+  │  Day Range:  US$192.00 — US$196.50                   │
+  │  52W Range:  US$164.08 — US$237.49                   │
+  │  ─────────────────────────────────────────────────── │
+  │  [View Transactions] [View Corp Actions]             │
+  └──────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Tab: Transactions
+
+**Unified with bank transactions**, but visually distinguished.
+
+### Filter Bar (enhanced from existing)
+
+```
++----------------------------------------------------------+
+|  [All] [Bank] [Brokerage]  [Source: ▼] [Date: ▼] [Type▼]|
++----------------------------------------------------------+
+```
+
+- **Source Type tabs**: All | Bank | Brokerage — quick filter without losing the table
+- **Source dropdown**: Now includes both banks ("DBS", "OCBC") and brokerages ("Tiger Brokers")
+- **Type dropdown**: BUY | SELL | DIVIDEND | DEPOSIT | WITHDRAWAL | FEE | TRANSFER | INTEREST
+
+### Transaction Table (enhanced)
+
+Same structure as existing `TransactionTable`, with these additions:
+
+| Column | Notes |
+|--------|-------|
+| Date | As existing |
+| Description | As existing |
+| Type | **New** — badge: `BUY` (green), `SELL` (red), `DIVIDEND` (amber), `FEE` (gray), etc. |
+| Symbol | **New** — for brokerage transactions only (blank for bank) |
+| Quantity | **New** — for BUY/SELL |
+| Price | **New** — per-share price for BUY/SELL |
+| Amount | Total value. Same red/green as existing |
+| Source | Enhanced: `🏦 DBS` or `📈 Tiger Brokers` — small icon prefix |
+| Category | For bank txns only. Brokerage txns show `—` or auto-tag `Investment` |
+
+**Dividend row example**:
+```
+| 2024-03-15 | AAPL Dividend       | DIVIDEND | AAPL | — | — | +US$12.50 | Tiger | —      |
+```
+
+**BUY row example**:
+```
+| 2024-02-01 | Buy AAPL           | BUY      | AAPL | 10 | $185.00 | −US$1,850 | Tiger | —      |
+```
+
+### Dividend Income Integration
+
+Dividends are tagged as `DIVIDEND` type. In the bank transaction world, they map to the **Income** category. To integrate:
+
+1. **Auto-categorize**: When a `DIVIDEND` corp action is synced, also create a linked bank-style transaction with `category = 'income'` (or a new `Dividend Income` subcategory)
+2. **On Portfolio > Dividends tab**: Show them in portfolio context
+3. **On Transactions page**: They appear with `Type: DIVIDEND`, `Source: Tiger Brokers`, and if linked to a bank deposit, show a chain icon linking to the bank txn
+
+---
+
+## 6. Tab: Dividends
+
+A dedicated view for dividend tracking, integrated with the transactions table but focused.
+
+```
++----------------------------------------------------------+
+|  Dividends                      [2024 ▼] [All | Paid | Est]|
++----------------------------------------------------------+
+|  YTD Total: S$ 2,100                                     |
+|  Monthly Average: S$ 350                                 |
+|  Yield on Cost: 1.42%                                    |
++----------------------------------------------------------+
+|  [Bar Chart: Monthly Dividend Income]                    |
+|  Jan  Feb  Mar  Apr  May  Jun  Jul  Aug  Sep  Oct...    |
+|  ▓▓   ▓    ▓▓▓  ▓    ▓    ▓▓   ▓    ▓▓▓  ▓    ▓       |
++----------------------------------------------------------+
+|  Symbol    Ex-Date   Pay Date   Amount    Currency  Type  |
+|  ─────────────────────────────────────────────────────── |
+|  AAPL      02-09     02-15     US$12.50   USD      Cash  |
+|  D05.SI    04-22     05-08     S$85.00    SGD      Cash  |
+|  ─────────────────────────────────────────────────────── |
++----------------------------------------------------------+
+```
+
+- **Yield on Cost**: Annual dividends / total adjusted cost basis
+- **Monthly bar chart**: Recharts BarChart, one bar per month
+- **Type**: Cash | DRIP | Stock (future-proofing)
+
+---
+
+## 7. FX Rate Integration
+
+**Recommended API: Frankfurter** (`https://api.frankfurter.dev/v2/latest?from=USD&to=SGD`)
+- No API key required
+- Open source, can self-host
+- ECB reference rates (updated daily ~16:00 CET)
+- Free for commercial use
+
+**Fallback: exchangerate-api open endpoint** (`https://open.er-api.com/v6/latest/USD`)
+- No API key
+- Daily updates
+- Requires attribution
+
+**Implementation**:
+- Cache rates in Dexie (`fxRates` table) with `date` key
+- Fetch once per day on app load
+- Store as: `{ base: 'USD', rates: { SGD: 1.35, HKD: 7.82, ... }, date: '2024-05-04' }`
+- Conversion: `amount * (rates[to] / rates[from])`
+
+---
+
+## 8. Mobile Responsiveness
+
+- Tabs become horizontal scrollable on narrow screens
+- Holdings table: horizontal scroll with sticky Symbol column
+- KPI cards stack vertically
+- Currency selector moves below page title
+
+---
+
+## Summary of Files to Touch
+
+| File | Change |
+|------|--------|
+| `src/layouts/AppShell.tsx` | Add Portfolio to NAV_ITEMS |
+| `src/router.tsx` | Add `/portfolio` route |
+| `src/pages/portfolio/PortfolioPage.tsx` | Main tabbed shell |
+| `src/pages/portfolio/OverviewTab.tsx` | KPI + allocation + performance |
+| `src/pages/portfolio/HoldingsTab.tsx` | Holdings table with detail |
+| `src/pages/portfolio/TransactionsTab.tsx` | Filtered brokerage transactions |
+| `src/pages/portfolio/DividendsTab.tsx` | Dividend tracking view |
+| `src/pages/portfolio/CurrencySelector.tsx` | Shared dropdown component |
+| `src/lib/fx/rates.ts` | Frankfurter API client + cache |
+| `src/lib/db/db.ts` | Add `fxRates` table to schema |
+| `src/pages/transactions/TransactionTable.tsx` | Add Type, Symbol, Qty, Price columns; source icons |
+| `src/pages/transactions/TransactionFilters.tsx` | Add Source Type filter, Type filter |

--- a/openspec/changes/portfolio-tracking-phase1/proposal.md
+++ b/openspec/changes/portfolio-tracking-phase1/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Users currently track bank transactions (spending, income) in Lokfi but have no visibility into their brokerage activity from Tiger Brokers or other brokerage. After completing the brokerage abstraction layer with Tiger OpenAPI, we need to surface synced brokerage data (trades, dividends, fees) in the UI. A unified timeline lets users see their complete financial picture — both spending and investing — in one place, which is the core value proposition of Lokfi.
+
+## What Changes
+
+- Add **Source Type tabs** (`All` | `Bank` | `Brokerage`) to the existing `/transactions` page filter bar
+- Build a **`useUnifiedTransactions` hook** that queries `db.transactions` (bank) and `db.brokerageTransactions` + `db.brokerageCorpActions` (brokerage), merges them into a common row shape, sorts by date, and paginates
+- Render **brokerage rows** in the existing `TransactionTable` with:
+  - Formatted description: `"BUY AAPL — 10 shares @ $185.00"` or `"AAPL Dividend"` or `"Commission Fee"`
+  - **Neutral gray** amount color for BUY/SELL (not red/green) to distinguish reallocation from spending
+  - Source column enhanced with icon prefix: `📈 Tiger Brokers`
+  - Category column shows `—` (no category interaction for brokerage rows)
+  - Checkbox **disabled** for brokerage rows (no bulk select)
+  - **Zero new table columns** — information density preserved
+- Keep the **existing bank transaction table completely unchanged** when "Bank" or default view is active
+- Add **contextual filters**: Type dropdown appears only when "Brokerage" tab is active; Category dropdown appears only when "Bank" tab is active
+- Create a **`/settings/brokerage` page** for configuring brokerage accounts:
+  - Credential input form (API key, secret, account ID) with encryption via `CredentialManager`
+  - "Test Connection" button calling `provider.validateConnection()`
+  - "Sync Now" button triggering `SyncOrchestrator.sync()`
+  - **Configurable lookback days** for historical sync (default 90, stored in `db.settings`)
+  - Sync status display and "Disconnect" action
+- **No schema changes** to `DbTransaction`; no changes to rule engine, category system, or export logic
+- **No duplicate records**: Brokerage data stays in its own Dexie tables; the unified view is computed at query time via the view layer
+
+## Capabilities
+
+### New Capabilities
+
+- `unified-transaction-view`: Displaying brokerage transactions (BUY, SELL, DIVIDEND, FEE, CORP ACTION) alongside bank transactions in the existing `/transactions` page with tabbed filtering and merged pagination.
+- `brokerage-ui-integration`: Reading synced brokerage data from Dexie (`brokerageTransactions`, `brokerageCorpActions`) and rendering it in UI components with proper formatting, icons, and visual distinction from bank data.
+- `brokerage-settings`: Configuring brokerage API credentials, testing connections, triggering manual sync, and setting sync preferences including configurable lookback days.
+
+### Modified Capabilities
+
+- *(none — this is a purely additive change with no spec-level requirement changes to existing capabilities)*
+
+## Impact
+
+- **`apps/web/src/pages/transactions/`**: `TransactionsPage.tsx`, `TransactionTable.tsx`, `TransactionFilters.tsx`, `filterTypes.ts`
+- **`apps/web/src/lib/db/db.ts`**: Potentially add `brokerageTransactions` and `brokerageCorpActions` to the Dexie schema if not already present (read-only, no migration needed for existing data)
+- **`apps/web/src/layouts/AppShell.tsx`**: Add Portfolio icon to NAV_ITEMS (future — out of scope for Phase 1, but noted)
+- **No API changes**, no backend changes, no breaking changes to existing bank transaction UX

--- a/openspec/changes/portfolio-tracking-phase1/specs/brokerage-settings/spec.md
+++ b/openspec/changes/portfolio-tracking-phase1/specs/brokerage-settings/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Users can configure brokerage API credentials and sync settings
+The system SHALL provide a settings page where users can enter brokerage credentials, test connectivity, trigger manual sync, and configure sync behavior.
+
+#### Scenario: Save credentials and test connection
+- **WHEN** a user enters Tiger Brokers API credentials and clicks "Test Connection"
+- **THEN** the system encrypts and stores credentials via `CredentialManager`
+- **AND** calls `provider.validateConnection()`
+- **AND** displays success or error status to the user
+
+#### Scenario: Trigger manual sync
+- **WHEN** a user clicks "Sync Now" on the brokerage settings page
+- **THEN** the system retrieves stored credentials
+- **AND** constructs a `SyncOrchestrator` with the configured `lookbackDays`
+- **AND** executes `sync()` across all categories
+- **AND** displays per-category success/failure status
+
+#### Scenario: Disconnect brokerage
+- **WHEN** a user clicks "Disconnect"
+- **THEN** the system removes encrypted credentials from `CredentialManager`
+- **AND** deletes all synced data from brokerage Dexie tables
+- **AND** updates the UI to show "Not connected" status
+
+### Requirement: Users can configure sync lookback window
+The system SHALL allow users to set how many days of historical brokerage data to sync, stored in `db.settings` and applied on every sync.
+
+#### Scenario: Default lookback is 90 days
+- **WHEN** a brokerage is connected for the first time
+- **THEN** the default lookback days is 90
+- **AND** the settings page shows "90 days" as the current value
+
+#### Scenario: Change lookback days
+- **WHEN** a user changes the lookback days from 90 to 180 and saves
+- **THEN** the system stores `brokerage:tiger:lookbackDays = "180"` in `db.settings`
+- **AND** the next sync fetches 180 days of transaction and corporate action history
+
+#### Scenario: Lookback days used by sync orchestrator
+- **WHEN** a sync is triggered with lookback days set to 30
+- **THEN** the `SyncOrchestrator` calculates `since = new Date(Date.now() - 30 days)`
+- **AND** passes that `since` date to `provider.fetchTransactions(since)` and `provider.fetchCorpActions(since)`

--- a/openspec/changes/portfolio-tracking-phase1/specs/brokerage-ui-integration/spec.md
+++ b/openspec/changes/portfolio-tracking-phase1/specs/brokerage-ui-integration/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Brokerage data is read from Dexie and mapped to UI rows
+The system SHALL read synced brokerage data from Dexie tables and map each record type to a standardized UI row shape for rendering.
+
+#### Scenario: Transaction mapping
+- **WHEN** a `BrokerageTransaction` record is read from `db.brokerageTransactions`
+- **THEN** it is mapped to a `UnifiedRow` with fields: `id`, `source`, `date`, `description`, `amount`, `type`, `symbol`, `quantity`, `price`, `currency`
+
+#### Scenario: Corporate action mapping
+- **WHEN** a `BrokerageCorpAction` record is read from `db.brokerageCorpActions`
+- **THEN** it is mapped to a `UnifiedRow` with `type` set to `DIVIDEND`, `SPLIT`, `RIGHTS`, or `OTHER` based on the corp action type
+- **AND** the `amount` reflects the dividend amount or adjustment value
+
+#### Scenario: Fee mapping
+- **WHEN** a brokerage transaction with `action: 'FEE'` or commission data is present
+- **THEN** it is mapped to a `UnifiedRow` with `type: 'FEE'` and negative `amount`
+
+### Requirement: Source icons distinguish bank and brokerage origins
+The system SHALL render a visual icon prefix in the Source column to differentiate bank transactions from brokerage transactions.
+
+#### Scenario: Bank source icon
+- **WHEN** a bank transaction is rendered
+- **THEN** the Source column displays `🏦 {bankName}`
+
+#### Scenario: Brokerage source icon
+- **WHEN** a brokerage transaction is rendered
+- **THEN** the Source column displays `📈 {brokerageName}`
+
+### Requirement: Amount formatting respects transaction type semantics
+The system SHALL render brokerage transaction amounts with colors that reflect their financial nature, distinct from bank transaction semantics.
+
+#### Scenario: BUY/SELL neutral color
+- **WHEN** a brokerage BUY or SELL transaction is rendered
+- **THEN** the amount is displayed in neutral gray (not red or green)
+- **AND** the sign prefix (`−` or `+`) is still shown
+
+#### Scenario: DIVIDEND green color
+- **WHEN** a brokerage DIVIDEND transaction is rendered
+- **THEN** the amount is displayed in green (same as bank income)
+
+#### Scenario: FEE red color
+- **WHEN** a brokerage FEE transaction is rendered
+- **THEN** the amount is displayed in red (same as bank spending)
+
+#### Scenario: Bank transaction colors unchanged
+- **WHEN** a bank transaction is rendered
+- **THEN** its amount color follows existing rules (red for negative, green for positive)

--- a/openspec/changes/portfolio-tracking-phase1/specs/unified-transaction-view/spec.md
+++ b/openspec/changes/portfolio-tracking-phase1/specs/unified-transaction-view/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Users can filter transactions by source type
+The system SHALL provide a tabbed filter on the `/transactions` page allowing users to switch between `All`, `Bank`, and `Brokerage` source type views.
+
+#### Scenario: Default view shows all transactions
+- **WHEN** a user navigates to the `/transactions` page
+- **THEN** the "All" tab is active by default and both bank and brokerage transactions are visible
+
+#### Scenario: Bank-only filter
+- **WHEN** a user clicks the "Bank" tab
+- **THEN** only bank transactions are displayed and the Type filter dropdown is hidden
+
+#### Scenario: Brokerage-only filter
+- **WHEN** a user clicks the "Brokerage" tab
+- **THEN** only brokerage transactions are displayed and the Category filter dropdown is hidden
+
+### Requirement: Unified transaction table renders both bank and brokerage rows
+The system SHALL display brokerage transactions in the existing `TransactionTable` alongside bank transactions without adding new columns.
+
+#### Scenario: Brokerage BUY row rendering
+- **WHEN** a brokerage BUY transaction is rendered in the table
+- **THEN** the Description column shows `"BUY {symbol} — {qty} shares @ {price}"`
+- **AND** the Amount is rendered in neutral gray color
+- **AND** the Source column shows `📈 {brokerageName}`
+- **AND** the Category column shows `—`
+- **AND** the checkbox is disabled
+
+#### Scenario: Brokerage DIVIDEND row rendering
+- **WHEN** a brokerage DIVIDEND transaction is rendered in the table
+- **THEN** the Description column shows `"{symbol} Dividend"`
+- **AND** the Amount is rendered in green color
+- **AND** the Source column shows `📈 {brokerageName}`
+- **AND** the Category column shows `—`
+
+#### Scenario: Bank transaction rendering is unchanged
+- **WHEN** a bank transaction is rendered in the unified table
+- **THEN** all existing formatting, colors, and interactions remain identical to pre-change behavior
+
+### Requirement: Unified query layer merges and paginates cross-table data
+The system SHALL provide a `useUnifiedTransactions` hook that queries both bank and brokerage tables, merges results into a common shape, sorts by date descending, and supports pagination.
+
+#### Scenario: Query returns merged sorted results
+- **WHEN** the hook is called with filters and pagination parameters
+- **THEN** it queries `db.transactions` and `db.brokerageTransactions` + `db.brokerageCorpActions`
+- **AND** returns a single array sorted by date descending
+- **AND** respects the provided offset and page size
+
+#### Scenario: Brokerage-only query skips bank table
+- **WHEN** the "Brokerage" source type tab is active
+- **THEN** the hook queries only brokerage tables (not `db.transactions`)
+- **AND** bank transactions are not fetched
+
+#### Scenario: Bank-only query skips brokerage tables
+- **WHEN** the "Bank" source type tab is active
+- **THEN** the hook queries only `db.transactions`
+- **AND** brokerage tables are not fetched
+
+### Requirement: Brokerage rows are non-interactive for category features
+The system SHALL disable category editing, bulk selection, and rule suggestion features for brokerage rows.
+
+#### Scenario: Brokerage row checkbox disabled
+- **WHEN** a brokerage row is rendered
+- **THEN** its checkbox is visually present but disabled
+- **AND** clicking it does nothing
+
+#### Scenario: Category badge is static for brokerage rows
+- **WHEN** a brokerage row is rendered
+- **THEN** the Category column shows `—` with no editing interaction
+- **AND** clicking it does not open the category combobox
+
+#### Scenario: Rule suggestions excluded for brokerage rows
+- **WHEN** a brokerage transaction is displayed
+- **THEN** the rule suggestion system does not evaluate or suggest rules for it

--- a/openspec/changes/portfolio-tracking-phase1/tasks.md
+++ b/openspec/changes/portfolio-tracking-phase1/tasks.md
@@ -1,0 +1,88 @@
+## 1. Research & Verify Schema
+
+- [ ] 1.1 Inspect `apps/web/src/lib/db/db.ts` to confirm `brokerageTransactions`, `brokerageCorpActions`, `brokeragePositions`, `brokerageAccounts`, `brokerageCredentials`, `brokerageSyncLog`, and `settings` table schemas
+- [ ] 1.2 Verify `BrokerageTransaction` and `BrokerageCorpAction` type definitions in `@lokfi/brokerage-core`
+- [ ] 1.3 Confirm `DbTransaction` schema has not changed and all existing indexed fields remain compatible
+- [ ] 1.4 Verify `SyncOrchestrator` constructor accepts `lookbackDays` and passes `since` date to provider methods
+
+## 2. Create Unified Data Layer
+
+- [ ] 2.1 Create `apps/web/src/lib/brokerage/unifiedTransactions.ts` with the `UnifiedTransactionRow` type definition
+- [ ] 2.2 Implement `fetchBankRows(filters)` function querying `db.transactions` with existing filter logic
+- [ ] 2.3 Implement `fetchBrokerageRows(filters)` function querying `db.brokerageTransactions` and `db.brokerageCorpActions`
+- [ ] 2.4 Implement `mergeAndSortRows(bankRows, brokerageRows)` helper sorting by date descending
+- [ ] 2.5 Implement `useUnifiedTransactions(filters, pageOffset, pageSize)` hook returning `{ rows, total, hasMore, isLoading }`
+- [ ] 2.6 Add lazy-loading: only query brokerage tables when sourceType is "all" or "brokerage"
+- [ ] 2.7 Write unit tests for mapper functions (BUY/SELL/DIVIDEND/FEE formatting, date sorting, pagination slicing)
+
+## 3. Create Brokerage Settings Page
+
+- [ ] 3.1 Create `/settings/brokerage` route and `BrokerageSettingsPage.tsx` component
+- [ ] 3.2 Build `BrokerageCredentialForm` with inputs for API key, secret, account ID, and passphrase
+- [ ] 3.3 Integrate `CredentialManager.store/retrieve/remove` for encrypted credential persistence
+- [ ] 3.4 Add "Test Connection" button that constructs `TigerProvider` and calls `validateConnection()`
+- [ ] 3.5 Add "Sync Now" button that reads credentials, constructs `SyncOrchestrator` with configured `lookbackDays`, and calls `sync()`
+- [ ] 3.6 Add configurable lookback days input with quick-select presets (30, 90, 180, 365, All time)
+- [ ] 3.7 Store `brokerage:tiger:lookbackDays` in `db.settings` (default: 90); read it on page load and pass to `SyncOrchestrator`
+- [ ] 3.8 Display sync status section: last sync time per category, success/failure indicators, error messages
+- [ ] 3.9 Add "Disconnect" button that removes credentials and wipes all `brokerage*` Dexie tables
+- [ ] 3.10 Handle empty state: show "Connect your Tiger Brokers account to sync trades and dividends" when no credentials exist
+- [ ] 3.11 Add loading and error states for all async actions (test connection, sync, disconnect)
+
+## 4. Enhance TransactionTable for Brokerage Rows
+
+- [ ] 3.1 Update `TransactionTable.tsx` to accept `UnifiedTransactionRow[]` instead of `DbTransaction[]`
+- [ ] 3.2 Add source icon rendering: `🏦` for bank, `📈` for brokerage in the Source column
+- [ ] 3.3 Implement brokerage row Description formatting: `"BUY AAPL — 10 shares @ $185.00"`, `"AAPL Dividend"`, `"Commission Fee"`
+- [ ] 3.4 Implement conditional amount colors: neutral gray for BUY/SELL, green for DIVIDEND, red for FEE, existing red/green for bank
+- [ ] 3.5 Disable checkbox for brokerage rows (visually present but non-interactive)
+- [ ] 3.6 Disable category editing for brokerage rows (show `—` instead of `CategoryBadge`)
+- [ ] 3.7 Ensure bank rows retain 100% of existing behavior (checkbox, category editing, colors, copy button)
+- [ ] 3.8 Handle empty state for brokerage tab: "No brokerage transactions yet. Sync your account to see trades and dividends."
+
+## 5. Add Source Type Tabs & Contextual Filters
+
+- [ ] 5.1 Add `sourceType: 'all' | 'bank' | 'brokerage'` to `Filters` type in `filterTypes.ts`
+- [ ] 5.2 Create `SourceTypeTabs` component with `All | Bank | Brokerage` tabs, styled to match existing UI
+- [ ] 5.3 Integrate `SourceTypeTabs` into `TransactionsPage.tsx` header area (above `TransactionFilters`)
+- [ ] 5.4 Make `TransactionFilters` contextual: hide Category dropdown when `sourceType === 'brokerage'`, hide Type dropdown when `sourceType === 'bank'`
+- [ ] 5.5 Add `type` filter field to `Filters` for brokerage types (BUY, SELL, DIVIDEND, FEE, CORP ACTION)
+- [ ] 5.6 Update `TransactionFilters` to show Type dropdown only when relevant
+- [ ] 5.7 Wire `SourceTypeTabs` state into `useUnifiedTransactions` hook
+
+## 6. Update TransactionsPage Orchestration
+
+- [ ] 6.1 Replace `useLiveQuery(db.transactions...)` with `useUnifiedTransactions` in `TransactionsPage.tsx`
+- [ ] 6.2 Ensure pagination (pageOffset, PAGE_SIZE) works correctly across merged results
+- [ ] 6.3 Update `totalCount` display to show combined total when "All" tab is active
+- [ ] 6.4 Update `uncategorisedCount` to exclude brokerage rows (they have no category)
+- [ ] 6.5 Disable bulk category bar for brokerage-only selections
+- [ ] 6.6 Ensure rule suggestion system (`suggestRules`) is not invoked for brokerage rows
+- [ ] 6.7 Verify toast, modal, and error states work with unified data
+
+## 7. Visual Polish & Consistency
+
+- [ ] 7.1 Add subtle background tint for brokerage rows (e.g., `--bg-sidebar` vs `--bg`) if design review approves
+- [ ] 7.2 Ensure mobile responsiveness: tabs wrap, description truncates gracefully
+- [ ] 7.3 Verify dark mode compatibility for all new elements
+- [ ] 7.4 Check that `tab-nums` font variant is used for brokerage amounts
+- [ ] 7.5 Ensure amber accent color is not overused — brokerage rows should feel distinct, not emphasized
+
+## 8. Testing & Validation
+
+- [ ] 8.1 Test with empty brokerage data: verify Bank tab works exactly as before
+- [ ] 8.2 Test with empty bank data: verify Brokerage tab shows only brokerage rows
+- [ ] 8.3 Test "All" tab with mixed data: verify correct sort order, pagination, and row counts
+- [ ] 8.4 Test filter interactions: date range, source pills, category dropdown, type dropdown
+- [ ] 8.5 Test bulk select: verify only bank rows can be selected
+- [ ] 8.6 Test category editing: verify only bank rows open the combobox
+- [ ] 8.7 Test settings page: credentials save/load, test connection, sync, disconnect, lookback days persist
+- [ ] 8.8 Run existing test suite: `pnpm test` must pass without regression
+- [ ] 8.9 Run linter: `pnpm lint` must pass
+
+## 9. Documentation & Handoff
+
+- [ ] 9.1 Add JSDoc to `useUnifiedTransactions` hook and mapper functions
+- [ ] 9.2 Update `docs/portfolio-design-v1.md` to reflect Phase 1 implementation decisions
+- [ ] 9.3 Add a brief note to `apps/web/README.md` (or relevant doc) about the unified transaction view and brokerage settings
+- [ ] 9.4 Run `openspec apply` to mark tasks complete and archive the change

--- a/openspec/changes/portfolio-tracking-phase1/tasks.md
+++ b/openspec/changes/portfolio-tracking-phase1/tasks.md
@@ -1,88 +1,88 @@
 ## 1. Research & Verify Schema
 
-- [ ] 1.1 Inspect `apps/web/src/lib/db/db.ts` to confirm `brokerageTransactions`, `brokerageCorpActions`, `brokeragePositions`, `brokerageAccounts`, `brokerageCredentials`, `brokerageSyncLog`, and `settings` table schemas
-- [ ] 1.2 Verify `BrokerageTransaction` and `BrokerageCorpAction` type definitions in `@lokfi/brokerage-core`
-- [ ] 1.3 Confirm `DbTransaction` schema has not changed and all existing indexed fields remain compatible
-- [ ] 1.4 Verify `SyncOrchestrator` constructor accepts `lookbackDays` and passes `since` date to provider methods
+- [x] 1.1 Inspect `apps/web/src/lib/db/db.ts` to confirm `brokerageTransactions`, `brokerageCorpActions`, `brokeragePositions`, `brokerageAccounts`, `brokerageCredentials`, `brokerageSyncLog`, and `settings` table schemas
+- [x] 1.2 Verify `BrokerageTransaction` and `BrokerageCorpAction` type definitions in `@lokfi/brokerage-core`
+- [x] 1.3 Confirm `DbTransaction` schema has not changed and all existing indexed fields remain compatible
+- [x] 1.4 Verify `SyncOrchestrator` constructor accepts `lookbackDays` and passes `since` date to provider methods
 
 ## 2. Create Unified Data Layer
 
-- [ ] 2.1 Create `apps/web/src/lib/brokerage/unifiedTransactions.ts` with the `UnifiedTransactionRow` type definition
-- [ ] 2.2 Implement `fetchBankRows(filters)` function querying `db.transactions` with existing filter logic
-- [ ] 2.3 Implement `fetchBrokerageRows(filters)` function querying `db.brokerageTransactions` and `db.brokerageCorpActions`
-- [ ] 2.4 Implement `mergeAndSortRows(bankRows, brokerageRows)` helper sorting by date descending
-- [ ] 2.5 Implement `useUnifiedTransactions(filters, pageOffset, pageSize)` hook returning `{ rows, total, hasMore, isLoading }`
-- [ ] 2.6 Add lazy-loading: only query brokerage tables when sourceType is "all" or "brokerage"
+- [x] 2.1 Create `apps/web/src/lib/brokerage/unifiedTransactions.ts` with the `UnifiedTransactionRow` type definition
+- [x] 2.2 Implement `fetchBankRows(filters)` function querying `db.transactions` with existing filter logic
+- [x] 2.3 Implement `fetchBrokerageRows(filters)` function querying `db.brokerageTransactions` and `db.brokerageCorpActions`
+- [x] 2.4 Implement `mergeAndSortRows(bankRows, brokerageRows)` helper sorting by date descending
+- [x] 2.5 Implement `useUnifiedTransactions(filters, pageOffset, pageSize)` hook returning `{ rows, total, hasMore, isLoading }`
+- [x] 2.6 Add lazy-loading: only query brokerage tables when sourceType is "all" or "brokerage"
 - [ ] 2.7 Write unit tests for mapper functions (BUY/SELL/DIVIDEND/FEE formatting, date sorting, pagination slicing)
 
 ## 3. Create Brokerage Settings Page
 
-- [ ] 3.1 Create `/settings/brokerage` route and `BrokerageSettingsPage.tsx` component
-- [ ] 3.2 Build `BrokerageCredentialForm` with inputs for API key, secret, account ID, and passphrase
-- [ ] 3.3 Integrate `CredentialManager.store/retrieve/remove` for encrypted credential persistence
-- [ ] 3.4 Add "Test Connection" button that constructs `TigerProvider` and calls `validateConnection()`
-- [ ] 3.5 Add "Sync Now" button that reads credentials, constructs `SyncOrchestrator` with configured `lookbackDays`, and calls `sync()`
-- [ ] 3.6 Add configurable lookback days input with quick-select presets (30, 90, 180, 365, All time)
-- [ ] 3.7 Store `brokerage:tiger:lookbackDays` in `db.settings` (default: 90); read it on page load and pass to `SyncOrchestrator`
-- [ ] 3.8 Display sync status section: last sync time per category, success/failure indicators, error messages
-- [ ] 3.9 Add "Disconnect" button that removes credentials and wipes all `brokerage*` Dexie tables
-- [ ] 3.10 Handle empty state: show "Connect your Tiger Brokers account to sync trades and dividends" when no credentials exist
-- [ ] 3.11 Add loading and error states for all async actions (test connection, sync, disconnect)
+- [x] 3.1 Create `/settings/brokerage` route and `BrokerageSettingsPage.tsx` component
+- [x] 3.2 Build `BrokerageCredentialForm` with inputs for API key, secret, account ID, and passphrase
+- [x] 3.3 Integrate `CredentialManager.store/retrieve/remove` for encrypted credential persistence
+- [x] 3.4 Add "Test Connection" button that constructs `TigerProvider` and calls `validateConnection()`
+- [x] 3.5 Add "Sync Now" button that reads credentials, constructs `SyncOrchestrator` with configured `lookbackDays`, and calls `sync()`
+- [x] 3.6 Add configurable lookback days input with quick-select presets (30, 90, 180, 365, All time)
+- [x] 3.7 Store `brokerage:tiger:lookbackDays` in `db.settings` (default: 90); read it on page load and pass to `SyncOrchestrator`
+- [x] 3.8 Display sync status section: last sync time per category, success/failure indicators, error messages
+- [x] 3.9 Add "Disconnect" button that removes credentials and wipes all `brokerage*` Dexie tables
+- [x] 3.10 Handle empty state: show "Connect your Tiger Brokers account to sync trades and dividends" when no credentials exist
+- [x] 3.11 Add loading and error states for all async actions (test connection, sync, disconnect)
 
 ## 4. Enhance TransactionTable for Brokerage Rows
 
-- [ ] 3.1 Update `TransactionTable.tsx` to accept `UnifiedTransactionRow[]` instead of `DbTransaction[]`
-- [ ] 3.2 Add source icon rendering: `🏦` for bank, `📈` for brokerage in the Source column
-- [ ] 3.3 Implement brokerage row Description formatting: `"BUY AAPL — 10 shares @ $185.00"`, `"AAPL Dividend"`, `"Commission Fee"`
-- [ ] 3.4 Implement conditional amount colors: neutral gray for BUY/SELL, green for DIVIDEND, red for FEE, existing red/green for bank
-- [ ] 3.5 Disable checkbox for brokerage rows (visually present but non-interactive)
-- [ ] 3.6 Disable category editing for brokerage rows (show `—` instead of `CategoryBadge`)
-- [ ] 3.7 Ensure bank rows retain 100% of existing behavior (checkbox, category editing, colors, copy button)
-- [ ] 3.8 Handle empty state for brokerage tab: "No brokerage transactions yet. Sync your account to see trades and dividends."
+- [x] 3.1 Update `TransactionTable.tsx` to accept `UnifiedTransactionRow[]` instead of `DbTransaction[]`
+- [x] 3.2 Add source icon rendering: `🏦` for bank, `📈` for brokerage in the Source column
+- [x] 3.3 Implement brokerage row Description formatting: `"BUY AAPL — 10 shares @ $185.00"`, `"AAPL Dividend"`, `"Commission Fee"`
+- [x] 3.4 Implement conditional amount colors: neutral gray for BUY/SELL, green for DIVIDEND, red for FEE, existing red/green for bank
+- [x] 3.5 Disable checkbox for brokerage rows (visually present but non-interactive)
+- [x] 3.6 Disable category editing for brokerage rows (show `—` instead of `CategoryBadge`)
+- [x] 3.7 Ensure bank rows retain 100% of existing behavior (checkbox, category editing, colors, copy button)
+- [x] 3.8 Handle empty state for brokerage tab: "No brokerage transactions yet. Sync your account to see trades and dividends."
 
 ## 5. Add Source Type Tabs & Contextual Filters
 
-- [ ] 5.1 Add `sourceType: 'all' | 'bank' | 'brokerage'` to `Filters` type in `filterTypes.ts`
-- [ ] 5.2 Create `SourceTypeTabs` component with `All | Bank | Brokerage` tabs, styled to match existing UI
-- [ ] 5.3 Integrate `SourceTypeTabs` into `TransactionsPage.tsx` header area (above `TransactionFilters`)
-- [ ] 5.4 Make `TransactionFilters` contextual: hide Category dropdown when `sourceType === 'brokerage'`, hide Type dropdown when `sourceType === 'bank'`
-- [ ] 5.5 Add `type` filter field to `Filters` for brokerage types (BUY, SELL, DIVIDEND, FEE, CORP ACTION)
-- [ ] 5.6 Update `TransactionFilters` to show Type dropdown only when relevant
-- [ ] 5.7 Wire `SourceTypeTabs` state into `useUnifiedTransactions` hook
+- [x] 5.1 Add `sourceType: 'all' | 'bank' | 'brokerage'` to `Filters` type in `filterTypes.ts`
+- [x] 5.2 Create `SourceTypeTabs` component with `All | Bank | Brokerage` tabs, styled to match existing UI
+- [x] 5.3 Integrate `SourceTypeTabs` into `TransactionsPage.tsx` header area (above `TransactionFilters`)
+- [x] 5.4 Make `TransactionFilters` contextual: hide Category dropdown when `sourceType === 'brokerage'`, hide Type dropdown when `sourceType === 'bank'`
+- [x] 5.5 Add `type` filter field to `Filters` for brokerage types (BUY, SELL, DIVIDEND, FEE, CORP ACTION)
+- [x] 5.6 Update `TransactionFilters` to show Type dropdown only when relevant
+- [x] 5.7 Wire `SourceTypeTabs` state into `useUnifiedTransactions` hook
 
 ## 6. Update TransactionsPage Orchestration
 
-- [ ] 6.1 Replace `useLiveQuery(db.transactions...)` with `useUnifiedTransactions` in `TransactionsPage.tsx`
-- [ ] 6.2 Ensure pagination (pageOffset, PAGE_SIZE) works correctly across merged results
-- [ ] 6.3 Update `totalCount` display to show combined total when "All" tab is active
-- [ ] 6.4 Update `uncategorisedCount` to exclude brokerage rows (they have no category)
-- [ ] 6.5 Disable bulk category bar for brokerage-only selections
-- [ ] 6.6 Ensure rule suggestion system (`suggestRules`) is not invoked for brokerage rows
-- [ ] 6.7 Verify toast, modal, and error states work with unified data
+- [x] 6.1 Replace `useLiveQuery(db.transactions...)` with `useUnifiedTransactions` in `TransactionsPage.tsx`
+- [x] 6.2 Ensure pagination (pageOffset, PAGE_SIZE) works correctly across merged results
+- [x] 6.3 Update `totalCount` display to show combined total when "All" tab is active
+- [x] 6.4 Update `uncategorisedCount` to exclude brokerage rows (they have no category)
+- [x] 6.5 Disable bulk category bar for brokerage-only selections
+- [x] 6.6 Ensure rule suggestion system (`suggestRules`) is not invoked for brokerage rows
+- [x] 6.7 Verify toast, modal, and error states work with unified data
 
 ## 7. Visual Polish & Consistency
 
-- [ ] 7.1 Add subtle background tint for brokerage rows (e.g., `--bg-sidebar` vs `--bg`) if design review approves
-- [ ] 7.2 Ensure mobile responsiveness: tabs wrap, description truncates gracefully
-- [ ] 7.3 Verify dark mode compatibility for all new elements
-- [ ] 7.4 Check that `tab-nums` font variant is used for brokerage amounts
-- [ ] 7.5 Ensure amber accent color is not overused — brokerage rows should feel distinct, not emphasized
+- [x] 7.1 Add subtle background tint for brokerage rows (e.g., `--bg-sidebar` vs `--bg`) if design review approves
+- [x] 7.2 Ensure mobile responsiveness: tabs wrap, description truncates gracefully
+- [x] 7.3 Verify dark mode compatibility for all new elements
+- [x] 7.4 Check that `tab-nums` font variant is used for brokerage amounts
+- [x] 7.5 Ensure amber accent color is not overused — brokerage rows should feel distinct, not emphasized
 
 ## 8. Testing & Validation
 
-- [ ] 8.1 Test with empty brokerage data: verify Bank tab works exactly as before
-- [ ] 8.2 Test with empty bank data: verify Brokerage tab shows only brokerage rows
-- [ ] 8.3 Test "All" tab with mixed data: verify correct sort order, pagination, and row counts
-- [ ] 8.4 Test filter interactions: date range, source pills, category dropdown, type dropdown
-- [ ] 8.5 Test bulk select: verify only bank rows can be selected
-- [ ] 8.6 Test category editing: verify only bank rows open the combobox
-- [ ] 8.7 Test settings page: credentials save/load, test connection, sync, disconnect, lookback days persist
-- [ ] 8.8 Run existing test suite: `pnpm test` must pass without regression
-- [ ] 8.9 Run linter: `pnpm lint` must pass
+- [x] 8.1 Test with empty brokerage data: verify Bank tab works exactly as before
+- [x] 8.2 Test with empty bank data: verify Brokerage tab shows only brokerage rows
+- [x] 8.3 Test "All" tab with mixed data: verify correct sort order, pagination, and row counts
+- [x] 8.4 Test filter interactions: date range, source pills, category dropdown, type dropdown
+- [x] 8.5 Test bulk select: verify only bank rows can be selected
+- [x] 8.6 Test category editing: verify only bank rows open the combobox
+- [x] 8.7 Test settings page: credentials save/load, test connection, sync, disconnect, lookback days persist
+- [x] 8.8 Run existing test suite: `pnpm test` must pass without regression
+- [x] 8.9 Run linter: `pnpm lint` must pass
 
 ## 9. Documentation & Handoff
 
-- [ ] 9.1 Add JSDoc to `useUnifiedTransactions` hook and mapper functions
-- [ ] 9.2 Update `docs/portfolio-design-v1.md` to reflect Phase 1 implementation decisions
-- [ ] 9.3 Add a brief note to `apps/web/README.md` (or relevant doc) about the unified transaction view and brokerage settings
-- [ ] 9.4 Run `openspec apply` to mark tasks complete and archive the change
+- [x] 9.1 Add JSDoc to `useUnifiedTransactions` hook and mapper functions
+- [x] 9.2 Update `docs/portfolio-design-v1.md` to reflect Phase 1 implementation decisions
+- [x] 9.3 Add a brief note to `apps/web/README.md` (or relevant doc) about the unified transaction view and brokerage settings
+- [x] 9.4 Run `openspec apply` to mark tasks complete and archive the change

--- a/openspec/changes/unify-fund-details-source/.openspec.yaml
+++ b/openspec/changes/unify-fund-details-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/unify-fund-details-source/design.md
+++ b/openspec/changes/unify-fund-details-source/design.md
@@ -1,0 +1,216 @@
+## Context
+
+The current pipeline has two separate Tiger API calls that partially overlap:
+
+```
+filled_orders ──→ adaptOrder() ──→ db.brokerageTransactions ──→ mapBrokerageTransaction()
+fund_details(CORP_ACTION) ──→ adaptCorpAction() ──→ db.brokerageCorpActions ──→ mapCorpAction()
+```
+
+The `fund_details` endpoint with `fund_type: 'ALL'` returns the brokerage's complete cash ledger — 13 distinct transaction types including trades, fees, dividends, dividend tax, transfers, and rebates. Currently only 3 of 13 types are captured (Dividend, Commission via filled_orders, and Trade via filled_orders). Another 10 types are silently lost.
+
+Additionally, `order_transactions` per-order detail is already fetched in `fetchTransactions()` (line 80-91 of `tiger-provider.ts`) but the results are discarded — the data is there, just unused.
+
+**Constraints:**
+- Tiger `fund_details ALL` provides cash amounts but NOT quantity/price data for trades
+- `filled_orders` provides quantity/price but NOT per-trade fee breakdown
+- `order_transactions` provides per-fill execution detail with quantity/price (already being fetched)
+- Must maintain Dexie as the persistence layer
+- Must not break the unified transactions view or its React hook
+
+## Goals / Non-Goals
+
+**Goals:**
+- Capture all 13 fund_detail types in a single pipeline
+- Preserve per-share execution detail (quantity, price) on trade records via enrichment
+- Replace the limited `CORPORATE_ACTION` pipeline entirely
+- Classify each fund_detail record into a meaningful unified view row type
+- Keep `filled_orders` for trade enrichment only, not as a separate transaction source
+
+**Non-Goals:**
+- Changing how bank transactions are handled
+- Adding position-level dividend tracking (dividend yield, DRIP tracking)
+- Real-time push subscriptions for fund details
+- Changing the unified view UI/UX beyond new row types
+- Supporting other brokerages beyond the provider interface contract change
+
+## Decisions
+
+### 1. New `BrokerageFundDetail` type over expanding `BrokerageCorpAction`
+
+**Decision:** Create `BrokerageFundDetail` as a new normalized type.
+
+**Why:** Fund_detail records are cash movements, not corporate actions. A "Commission Fee" or "Funds Transfer In" is fundamentally different from a dividend or stock split. Putting them in the same type loses semantic clarity and forces nullable fields. The `amount` sign convention differs: corp actions are positive events, fund_details are cash inflows (+)/outflows (-).
+
+**Alternative considered:** Expand `BrokerageCorpAction` to include optional fields for fee/transfer types. Rejected because it conflates two distinct concepts and would require nullable `symbol`, optional `amount` sign semantics, and confusing union types.
+
+**New type shape:**
+```typescript
+export type FundDetailType = 'DIVIDEND' | 'DIVIDEND_TAX' | 'TRADE' | 'FEE' | 'TRANSFER_IN' | 'REBATE' | 'CORP_ACTION'
+
+export interface BrokerageFundDetail {
+  id: string
+  source: BrokerageSource
+  /** Raw type string from the brokerage (e.g. "Commission", "Platform Fee") */
+  rawType: string
+  /** Classified type for the unified view */
+  classifiedType: FundDetailType
+  symbol?: string           // extracted from desc for trades/dividends
+  contractName?: string     // display name (e.g. "Broadcom")
+  amount: number
+  currency: string
+  /** Trade action (BUY/SELL) — only present when classifiedType is TRADE */
+  action?: TradeAction
+  /** Enriched from filled_orders — only present for TRADE records */
+  quantity?: number
+  price?: number
+  commission?: number
+  businessDate: string
+  segType?: string
+}
+```
+
+### 2. Type classification strategy
+
+**Decision:** Classify based on the `type` field from the `ALL` response using a static mapping table.
+
+```
+Tiger type              → FundDetailType
+─────────────────────────────────────────
+Dividend                → DIVIDEND
+Dividend Tax            → DIVIDEND_TAX
+Trade                   → TRADE
+Commission              → FEE
+Platform Fee            → FEE
+Settlement Fee          → FEE
+GST                     → FEE
+Trading Activity Fee    → FEE
+SEC Fee                 → FEE
+Option Regulatory Fee   → FEE
+Clearing Fee            → FEE
+Funds Transfer In       → TRANSFER_IN
+Campaign Subsidy        → REBATE
+```
+
+For unknown types: classify as `FEE` with a warning log.
+
+**Why mapping table over regex/pattern matching:** The type field is a reliable, structured value from Tiger. Pattern matching on descriptions is fragile (e.g., "Dividend" appears in both "Dividend" and "Dividend Tax" types, but the `type` field distinguishes them).
+
+### 3. Trade enrichment from filled_orders
+
+**Decision:** Trade fund_detail records are enriched with quantity/price from `filled_orders` by matching the fund_detail `desc` (e.g., "Buy-AVGO") to order records by symbol and date proximity.
+
+**Matching strategy (from most to least reliable):**
+1. Extract symbol from `desc` (first word: "Buy-AVGO" → "AVGO"), match to filled order by symbol and same-day execution
+2. Extract action from `desc` prefix ("Buy" = BUY, "Sell" = SELL), match to filled order by symbol + action + date
+3. If `order_transactions` per-order detail is available (already fetched), use it for exact fill-level price/quantity
+
+**Why not drop filled_orders entirely:** `fund_details` only gives total cash settlement amount. Without quantity/price, the unified view loses per-share detail ("100 shares @ $20.08") in favor of just a lump sum ("-$2008.80"). Users need both.
+
+### 4. Sync category: new `fund_details` vs modifying `corp_actions`
+
+**Decision:** Rename the sync category from `corp_actions` to `fund_details` in the orchestrator.
+
+**Why:** The category name should reflect what's actually being synced. `corp_actions` is misleading when the pipeline includes fees, transfers, and rebates. This is a semantic rename — the rate limit tier stays the same (Medium, 1100ms).
+
+### 5. Database table: new `brokerageFundDetails`
+
+**Decision:** Add a new `brokerageFundDetails` table at schema v7. Keep `brokerageCorpActions` at v5 but stop writing to it.
+
+**Why:** Dexie migrations can't rename tables. Adding a new table alongside the old one is safer and allows existing corp action data to be migrated or left as history. The old table can be dropped in a future cleanup migration.
+
+**v7 schema addition:**
+```typescript
+brokerageFundDetails: 'id, source, classifiedType, symbol, businessDate'
+```
+
+### 6. Provider interface change
+
+**Decision:** Remove `fetchCorpActions()` from `BrokerageProvider` entirely. Add `fetchFundDetails(since): Promise<BrokerageFundDetail[]>` as a required method.
+
+**Why:** We are in early development — no production users to break. Carrying deprecated methods adds maintenance debt with zero benefit. The CDC stub is trivially updated (return `[]`). The `fetchCorpActions()` semantic was always wrong for this data; `fetchFundDetails()` accurately describes what the method does.
+
+### 7. Unified view row types
+
+**Decision:** Extend `BrokerageRowType` with new types: `'DIVIDEND_TAX'`, `'TRANSFER_IN'`, `'REBATE'`. Keep existing `'FEE'` for all fee subtypes.
+
+**Why:** `DIVIDEND_TAX` is a distinct cash event users care about (tax withheld on dividends). `TRANSFER_IN` is a deposit event. `REBATE` is a fee rebate. These are semantically different from generic fees and users may want to filter on them. Individual fee types (Commission, SEC Fee, etc.) all map to `FEE` to avoid row-type explosion — the `rawType` field preserves the specific fee name for display.
+
+### 8. Dividend tax refund handling
+
+**Decision:** `DIVIDEND_TAX` rows use the sign of the amount to determine display semantics: negative = tax withheld (outflow), positive = tax refund (inflow, typically return of capital adjustment by Tiger).
+
+**Why:** Tiger occasionally issues "Dividend Tax" records with positive amounts as return-of-capital refunds. Treating all Dividend Tax records as outflows would incorrectly display refunds. The `amount` sign is the authoritative signal — negative means money left the account, positive means money entered.
+
+**Display convention:**
+- Negative amount → description reads "Dividend Tax withheld"
+- Positive amount → description reads "Dividend Tax refund (return of capital)"
+
+### 9. Pagination for fund_details ALL
+
+**Decision:** Implement cursor-based pagination for `fund_details ALL` using a `page` parameter. The provider fetches pages sequentially until no more data is returned, then merges all pages into a single result array.
+
+**Why:** The sample data shows ~90 fund_detail records over ~1 month of active trading. A 90-day lookback could easily exceed 100 records (the default page size). Without pagination, older records would be silently dropped. The Tiger `fund_details` API supports a `page` parameter (and returns an empty array when exhausted).
+
+**Pagination strategy:**
+1. Start with `page: 1`, `limit: 100`
+2. If response has 100 records, fetch `page: 2`, etc.
+3. Stop when response has fewer than 100 records (last page)
+4. Merge all pages before adapting
+5. Apply the single rate-limit delay between pages (600ms) to avoid triggering rate limits with sequential requests
+
+### 10. Profile export/import integration
+
+**Decision:** `brokerageFundDetails` SHALL be included in the profile backup/restore pipeline alongside other brokerage tables. The backup format version bumps from 2 to 3.
+
+**Why:** Users who export a backup and later restore it must not lose their fund_detail data (dividends, fees, transfers). Without this, restoring a backup would silently drop all fund_detail records, requiring a full re-sync.
+
+**Backward compatibility:**
+- Export: always writes version `3`
+- Import: accepts v1, v2, **and** v3 backups
+- v2 imports: `brokerageFundDetails` is optional (old backups won't have it — records repopulate on next sync)
+- v3 imports: `brokerageFundDetails` is required in validation
+
+**Confirmation dialog:** The import summary lists fund_detail count alongside other brokerage records.
+
+## Risks / Trade-offs
+
+**[Risk] Trade matching is probabilistic** — matching fund_detail trade records to filled_orders by symbol + date is not perfectly deterministic. A symbol traded twice on the same day could match incorrectly.
+→ **Mitigation:** Use `order_transactions` per-order detail data (already fetched) for exact fill-level matching. Fall back to simple symbol/date match only when `order_transactions` is unavailable. Log unmatched trade records so users can see them.
+
+**[Risk] `fund_details ALL` returns a different response shape than `CORPORATE_ACTION`** — the `type` field is present in `ALL` but may not be in `CORPORATE_ACTION`. This is confirmed from the sample data.
+→ **Mitigation:** The new `TigerFundDetail` type includes `type` as an optional field (it exists in ALL but may not in other fund_type values). The adapter handles missing `type` by falling back to `'UNKNOWN'`.
+
+**[Risk] Breaking change to `BrokerageProvider` interface** — `fetchCorpActions()` is removed.
+→ **Mitigation:** Early dev phase — no production users. CDC stub gets `fetchFundDetails() { return [] }` alongside the other methods. Single straightforward update for any future provider implementations.
+
+**[Risk] Deduplication across sync cycles** — fund_details with ALL may return the same records across multiple sync windows.
+→ **Mitigation:** The `brokerageFundDetails` table uses `id` (based on Tiger record ID) as the primary key. `bulkPut` in Dexie naturally deduplicates by key. Same strategy already used for `brokerageCorpActions`.
+
+**[Risk] API rate limits** — paginated `fund_details ALL` fetches multiple pages sequentially, each counting against the medium-tier rate limit (60 req/min).
+→ **Mitigation:** Apply 600ms delay between paginated pages. Typical usage: 2-3 pages per sync cycle (180-270 records over 90 days). Medium tier allows 60 req/min — well within limits. Monitor and adjust page delay if needed.
+
+## Migration Plan
+
+1. Add `BrokerageFundDetail` type to `@lokfi/brokerage-core`
+2. Replace `fetchCorpActions()` with `fetchFundDetails()` in `BrokerageProvider` interface (breaking)
+3. Add `TigerFundDetail` type to `tiger-types.ts`
+4. Add v7 schema with `brokerageFundDetails` table to `db.ts`
+5. Implement paginated `fetchFundDetails()` in `TigerProvider`
+6. Implement `adaptFundDetail()` in `tiger-adapter.ts`
+7. Implement trade enrichment logic (fund_detail + filled_orders merge)
+8. Add `appendFundDetails()` to `SyncDatabase` interface and `DexieSyncAdapter`
+9. Update `SyncOrchestrator` to sync `fund_details` category (replacing `corp_actions`)
+10. Update `unifiedTransactions.ts` with `mapFundDetail()` and new row types
+11. Update CDC stub — add `fetchFundDetails()` returning `[]`
+12. Update `ProfilePage.tsx` — add `brokerageFundDetails` to export dump, import validation (v3), import confirmation dialog, and restore logic
+13. Update tests for all changed modules
+14. Update README documentation for the Tiger provider
+
+**Rollback:** The old `brokerageCorpActions` table remains in place (unwritten after migration). Rolling back means reverting the unified view to query `brokerageCorpActions` instead of `brokerageFundDetails`. No data loss for existing records.
+
+## Open Questions
+
+- _Resolved: `fetchCorpActions()` removed entirely — early dev, no production users._
+- _Resolved: Separate rows for dividend and dividend tax. Dividend Tax with positive amount displayed as "refund (return of capital)"._
+- _Resolved: Pagination with `page` parameter, sequential fetches with 600ms inter-page delay._

--- a/openspec/changes/unify-fund-details-source/proposal.md
+++ b/openspec/changes/unify-fund-details-source/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The current portfolio transaction pipeline uses two separate Tiger API sources — `filled_orders` for trade execution data and `fund_details` (filtered to `CORPORATE_ACTION`) for dividends — but the `fund_details` endpoint with `fund_type: 'ALL'` returns a **complete cash ledger** of the brokerage account covering 13 distinct transaction types. By only requesting `CORPORATE_ACTION`, we silently drop 10 of those 13 types: Dividend Tax, Platform Fee, GST, Trading Activity Fee, SEC Fee, Option Regulatory Fee, Clearing Fee, Settlement Fee, Funds Transfer In, and Campaign Subsidy. This means the unified transaction view is missing deposits, fee rebates, and per-trade fee breakdowns that users can already see in their Tiger account statements.
+
+## What Changes
+
+- **BREAKING**: `fetchCorpActions()` in `TigerProvider` is replaced by a new `fetchFundDetails()` method that calls `fund_details` with `fund_type: 'ALL'` instead of `'CORPORATE_ACTION'`
+- `TigerCorpAction` type is replaced by `TigerFundDetail` with the richer field set (`type`, `contractName`, `segType`, `updatedAt` in addition to existing fields)
+- The adapter layer gains `adaptFundDetail()` handling all 13 fund_detail types, mapping them to appropriate unified transaction row types (DIVIDEND, FEE, TRANSFER, REBATE, etc.)
+- Trade fund_detail records (type: "Trade") are enriched with quantity/price data from `filled_orders` to preserve per-share execution detail in the unified view
+- `order_transactions` per-order detail (already fetched but currently discarded in `fetchTransactions`) is now utilized for enrichment
+- A new `BrokerageFundDetail` normalized type is introduced in `@lokfi/brokerage-core` to represent fund_detail records (replacing `BrokerageCorpAction` in the pipeline)
+- A new `brokerageFundDetails` Dexie table stores the comprehensive fund detail records
+- The sync orchestrator gains `appendFundDetails()` and a `fund_details` sync category
+- `unifiedTransactions.ts` gains `mapFundDetail()` replacing `mapCorpAction()`, handling all fund_detail types
+
+## Capabilities
+
+### New Capabilities
+- `fund-detail-source`: Unified fund_detail pipeline that captures all 13 cash movement types from Tiger, replacing the limited CORP_ACTION-only approach. Includes type classification, fee tracking, transfer logging, and dividend tax visibility.
+- `trade-enrichment`: Merging `filled_orders` quantity/price execution data into `fund_details` trade records so the unified view retains per-share detail while using a single cash-movement source of truth.
+
+### Modified Capabilities
+<!-- No existing specs to modify -->
+
+## Impact
+
+- **Affected code**: `tiger-provider.ts`, `tiger-adapter.ts`, `tiger-types.ts`, `sync-orchestrator.ts`, `dexie-sync-adapter.ts`, `db.ts`, `unifiedTransactions.ts`, `ProfilePage.tsx`, `DividendsTab.tsx`, `OverviewTab.tsx`, `TransactionsPage.tsx`, `TransactionFilters.tsx`, `BrokerageSettingsPage.tsx`, `cdc-stub.ts`, `brokerage-core/src/types.ts`, `brokerage-core/src/provider.ts`
+- **Affected tests**: `tiger-adapter.test.ts`, `unifiedTransactions.test.ts`, `sync-orchestrator.test.ts`
+- **Dependencies**: No new external dependencies; leverages existing `order_transactions` data that is already fetched but unused
+- **Database migration**: New `brokerageFundDetails` Dexie table at v7 schema; existing `brokerageCorpActions` table becomes unwritten (retained for history)
+- **Profile export format**: Bumped from v2 to v3 — `brokerageFundDetails` included in export dump, required in v3 import validation, optional in v2 imports for backward compatibility
+- **Breaking**: `BrokerageProvider.fetchCorpActions()` is removed from the interface; any other provider implementations (e.g., CDC stub) must adopt `fetchFundDetails()`

--- a/openspec/changes/unify-fund-details-source/specs/fund-detail-source/spec.md
+++ b/openspec/changes/unify-fund-details-source/specs/fund-detail-source/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: Provider fetches all fund_detail types
+
+The Tiger provider SHALL call the `fund_details` API with `fund_type: 'ALL'` instead of `'CORPORATE_ACTION'`, returning records for all 13 fund_detail types: Trade, Commission, Platform Fee, Settlement Fee, GST, Trading Activity Fee, SEC Fee, Option Regulatory Fee, Clearing Fee, Dividend, Dividend Tax, Funds Transfer In, and Campaign Subsidy.
+
+#### Scenario: Fetch ALL fund details within date range
+- **WHEN** the provider's `fetchFundDetails(since)` is called with a 90-day lookback
+- **THEN** the API request includes `fund_type: 'ALL'`, `seg_types: ['SEC']`, `start_date`, and `end_date`
+- **THEN** the response is parsed into `TigerFundDetail[]` records
+- **THEN** records of all 13 types are present in the result (assuming account activity)
+
+#### Scenario: Paginate when result set exceeds page size
+- **WHEN** the provider fetches `fund_details` with `limit: 100` and the response contains exactly 100 records
+- **THEN** the provider SHALL issue a subsequent request with `page: 2`
+- **THEN** the provider SHALL continue fetching pages until a response contains fewer than 100 records
+- **THEN** all pages SHALL be merged into a single result array before adaptation
+- **THEN** a 600ms delay SHALL be applied between consecutive page requests to respect rate limits
+
+#### Scenario: Single page when result set fits
+- **WHEN** the response contains fewer than 100 records on the first page
+- **THEN** the provider SHALL NOT issue additional page requests
+- **THEN** the result SHALL be adapted directly
+
+#### Scenario: Handle unknown fund_detail types gracefully
+- **WHEN** Tiger returns a fund_detail record with a `type` field not in the known mapping table
+- **THEN** the record SHALL be classified as `FEE` with the raw type preserved
+- **THEN** a warning SHALL be logged with the unknown type name
+- **THEN** the record SHALL still appear in the unified transaction view
+
+### Requirement: Fund details are adapted to normalized type
+
+Each raw `TigerFundDetail` record SHALL be adapted into a `BrokerageFundDetail` with a classified type, extracted symbol, and preserved raw type for display purposes.
+
+#### Scenario: Dividend record classification
+- **WHEN** a fund_detail record has `type: "Dividend"` and `desc: "XDTE-DIVIDEND"`
+- **THEN** `classifiedType` SHALL be `DIVIDEND`
+- **THEN** `symbol` SHALL be extracted as `"XDTE"` from the description
+- **THEN** `amount` SHALL be positive (cash inflow)
+
+#### Scenario: Dividend Tax withheld (outflow) classification
+- **WHEN** a fund_detail record has `type: "Dividend Tax"`, `desc: "XDTE-DIVIDEND"`, and negative amount
+- **THEN** `classifiedType` SHALL be `DIVIDEND_TAX`
+- **THEN** `symbol` SHALL be extracted as `"XDTE"` from the description
+- **THEN** the record SHALL be displayed as tax withheld
+
+#### Scenario: Dividend Tax refund (return of capital) classification
+- **WHEN** a fund_detail record has `type: "Dividend Tax"`, `desc: "XDTE-DIVIDEND"`, and positive amount
+- **THEN** `classifiedType` SHALL be `DIVIDEND_TAX`
+- **THEN** `symbol` SHALL be extracted as `"XDTE"` from the description
+- **THEN** the record SHALL be displayed as a tax refund (return of capital)
+
+#### Scenario: Fee record classification
+- **WHEN** a fund_detail record has `type: "Commission"` (or "Platform Fee", "Settlement Fee", etc.)
+- **THEN** `classifiedType` SHALL be `FEE`
+- **THEN** `rawType` SHALL preserve the original type string for display
+- **THEN** `symbol` SHALL be extracted from `desc` (e.g., "Buy-AVGO" → "AVGO")
+
+#### Scenario: Transfer record classification
+- **WHEN** a fund_detail record has `type: "Funds Transfer In"`
+- **THEN** `classifiedType` SHALL be `TRANSFER_IN`
+- **THEN** `amount` SHALL be positive (cash inflow)
+
+#### Scenario: Rebate record classification
+- **WHEN** a fund_detail record has `type: "Campaign Subsidy"`
+- **THEN** `classifiedType` SHALL be `REBATE`
+- **THEN** `amount` SHALL be positive (cash inflow)
+
+### Requirement: Fund details are persisted in a dedicated Dexie table
+
+All adapted `BrokerageFundDetail` records SHALL be stored in a new `brokerageFundDetails` Dexie table with natural key deduplication.
+
+#### Scenario: Append fund details without overwriting
+- **WHEN** the sync orchestrator calls `appendFundDetails()` with a batch of records
+- **THEN** records SHALL be persisted to `brokerageFundDetails` using `bulkPut`
+- **THEN** records with the same `id` SHALL be overwritten (last write wins)
+- **THEN** new records with unique `id` SHALL be inserted without affecting existing records
+
+### Requirement: Fund details appear in unified transaction view
+
+Fund_detail records SHALL be merged into the unified transaction view alongside bank transactions and filled order records.
+
+#### Scenario: Dividend appears as DIVIDEND row
+- **WHEN** a fund_detail record has `classifiedType: DIVIDEND` with amount $94.15
+- **THEN** the unified view SHALL display a row with type `DIVIDEND`
+- **THEN** the row description SHALL include the symbol and amount
+- **THEN** the row SHALL be sortable by date
+
+#### Scenario: Fee appears as FEE row with raw type in description
+- **WHEN** a fund_detail record has `classifiedType: FEE` and `rawType: "Platform Fee"`
+- **THEN** the unified view SHALL display a row with type `FEE`
+- **THEN** the row description SHALL mention "Platform Fee" and the amount
+- **THEN** the row SHALL use a negative amount (cash outflow)
+
+#### Scenario: Dividend Tax withheld displayed as DIVIDEND_TAX row
+- **WHEN** a fund_detail record has `classifiedType: DIVIDEND_TAX` with amount -$28.24
+- **THEN** the unified view SHALL display a row with type `DIVIDEND_TAX`
+- **THEN** the description SHALL indicate "Dividend Tax withheld"
+- **THEN** the row SHALL appear adjacent to its corresponding dividend row (same symbol and date)
+
+#### Scenario: Dividend Tax refund displayed as DIVIDEND_TAX row
+- **WHEN** a fund_detail record has `classifiedType: DIVIDEND_TAX` with positive amount
+- **THEN** the unified view SHALL display a row with type `DIVIDEND_TAX`
+- **THEN** the description SHALL indicate "Dividend Tax refund (return of capital)"
+- **THEN** the row SHALL appear adjacent to its corresponding dividend row (same symbol and date)
+
+#### Scenario: Transfer appears as TRANSFER_IN row
+- **WHEN** a fund_detail record has `classifiedType: TRANSFER_IN` with amount $20.29
+- **THEN** the unified view SHALL display a row with type `TRANSFER_IN`
+- **THEN** the row SHALL use a positive amount (cash inflow)
+
+### Requirement: Fund details are included in profile export and import
+
+The `brokerageFundDetails` table SHALL be included in the profile backup JSON (version 3) and restored during import alongside other brokerage tables.
+
+#### Scenario: Export includes fund details
+- **WHEN** the user exports a profile backup
+- **THEN** the backup JSON SHALL include a `brokerageFundDetails` array with all fund detail records
+- **THEN** the backup `version` SHALL be `3`
+
+#### Scenario: Import v3 backup restores fund details
+- **WHEN** the user imports a v3 backup containing `brokerageFundDetails`
+- **THEN** the `brokerageFundDetails` table SHALL be cleared and repopulated from the backup
+- **THEN** fund detail records SHALL be restored with their original `id`, `classifiedType`, `amount`, and `businessDate`
+
+#### Scenario: Import v2 backup without fund details is accepted
+- **WHEN** the user imports a v2 backup that does not contain `brokerageFundDetails`
+- **THEN** the import SHALL succeed without errors
+- **THEN** other brokerage tables SHALL be restored normally
+- **THEN** fund detail records SHALL be absent (repopulated on next sync)
+
+#### Scenario: Import v3 backup without fund details is rejected
+- **WHEN** the user imports a v3 backup missing the `brokerageFundDetails` array
+- **THEN** the import SHALL be rejected with a validation error message indicating missing brokerage data

--- a/openspec/changes/unify-fund-details-source/specs/trade-enrichment/spec.md
+++ b/openspec/changes/unify-fund-details-source/specs/trade-enrichment/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Trade fund_detail records are enriched with execution data
+
+Trade fund_detail records (classifiedType: TRADE) SHALL be enriched with quantity and price data from matched `filled_orders` records to preserve per-share execution detail in the unified view.
+
+#### Scenario: Trade record matched to filled order by symbol and date
+- **WHEN** a fund_detail record has `type: "Trade"`, `desc: "Buy-AVGO"`, and `businessDate: "2026-04-28"`
+- **THEN** the adapter SHALL extract symbol `"AVGO"` from `desc`
+- **THEN** the adapter SHALL extract action `BUY` from `desc` prefix
+- **THEN** the adapter SHALL query filled orders for symbol `"AVGO"` with execution date `2026-04-28`
+- **THEN** if a single match is found, the fund_detail record SHALL be enriched with `quantity`, `price`, and `commission` from the filled order
+
+#### Scenario: Trade record with multiple matches uses most recent
+- **WHEN** a fund_detail record matches multiple filled orders for the same symbol and date
+- **THEN** the adapter SHALL select the filled order with the closest matching total amount (quantity * price ≈ fund_detail amount)
+- **THEN** if no amount match, the adapter SHALL use the most recent filled order by execution time
+
+#### Scenario: Trade record cannot be matched
+- **WHEN** a fund_detail trade record has no matching filled order by symbol or date
+- **THEN** the trade record SHALL still be included in the unified view as type `TRADE`
+- **THEN** `quantity` and `price` SHALL be undefined
+- **THEN** the description SHALL show the total amount without per-share detail
+- **THEN** a debug log SHALL record the unmatched trade
+
+#### Scenario: Enriched trade record appears in unified view
+- **WHEN** a fund_detail trade record is enriched with `quantity: 10`, `price: 200.88`, `action: BUY`
+- **THEN** the unified view SHALL display a row with type `BUY`
+- **THEN** the row description SHALL include quantity and price per share
+- **THEN** the row SHALL use a negative amount (cash outflow for BUY)
+- **THEN** `symbol`, `quantity`, and `price` SHALL be available for display
+
+### Requirement: Filled orders are NOT duplicated as separate transaction rows
+
+When a trade fund_detail record is enriched from a filled order, the filled order SHALL NOT produce a separate row in the unified view to avoid double-counting.
+
+#### Scenario: Filled order is excluded when fund_detail trade record exists
+- **WHEN** the unified view merges brokerage data
+- **THEN** filled orders that have been matched to a fund_detail trade record SHALL be excluded from the separate `mapBrokerageTransaction()` output
+- **THEN** filled orders without a matching fund_detail record SHALL still appear as standalone BUY/SELL rows
+
+#### Scenario: Fee line items complement trade row
+- **WHEN** a trade has fund_detail fee records (Commission, Platform Fee, etc.) with the same symbol and date
+- **THEN** each fee SHALL appear as a separate FEE row in the unified view
+- **THEN** the total of fee rows plus trade amount SHALL equal the total cash impact of the trade

--- a/openspec/changes/unify-fund-details-source/tasks.md
+++ b/openspec/changes/unify-fund-details-source/tasks.md
@@ -1,0 +1,101 @@
+## 1. Type System — brokerage-core
+
+- [x] 1.1 Add `FundDetailType` union type to `packages/brokerage-core/src/types.ts` (`DIVIDEND | DIVIDEND_TAX | TRADE | FEE | TRANSFER_IN | REBATE | CORP_ACTION`)
+- [x] 1.2 Add `BrokerageFundDetail` interface to `packages/brokerage-core/src/types.ts` with fields: `id`, `source`, `rawType`, `classifiedType`, `symbol?`, `contractName?`, `amount`, `currency`, `action?`, `quantity?`, `price?`, `commission?`, `businessDate`, `segType?`
+- [x] 1.3 Remove `fetchCorpActions()` and add `fetchFundDetails(since: Date): Promise<BrokerageFundDetail[]>` as a required method in `BrokerageProvider` interface in `packages/brokerage-core/src/provider.ts`
+- [x] 1.4 Export new types from `packages/brokerage-core/src/index.ts`
+- [x] 1.5 Rebuild `@lokfi/brokerage-core` package
+
+## 2. Tiger Types — tiger-types.ts
+
+- [x] 2.1 Add `TigerFundDetail` interface to `apps/web/src/lib/brokerage/tiger/tiger-types.ts` with fields: `id?`, `account`, `currency?`, `amount?`, `desc?`, `type?`, `contractName?`, `segType?`, `businessDate?`, `updatedAt?`, `transactionTime?`
+- [x] 2.2 Rename existing `TigerCorpAction` comment section to reflect the broader fund_detail scope (or remove it and rely on `TigerFundDetail`)
+
+## 3. Database — db.ts (v7 schema)
+
+- [x] 3.1 Add `brokerageFundDetails` table declaration to `LokfiDatabase` class in `apps/web/src/lib/db/db.ts`
+- [x] 3.2 Add v7 schema version with `brokerageFundDetails: 'id, source, classifiedType, symbol, businessDate'` index
+- [x] 3.3 Import `BrokerageFundDetail` type from `@lokfi/brokerage-core` in db.ts
+
+## 4. Sync Adapter — dexie-sync-adapter.ts & sync-orchestrator.ts
+
+- [x] 4.1 Add `appendFundDetails(actions: BrokerageFundDetail[]): Promise<void>` to `SyncDatabase` interface in `apps/web/src/lib/brokerage/sync-orchestrator.ts`
+- [x] 4.2 Implement `appendFundDetails()` in `DexieSyncAdapter` (`apps/web/src/lib/brokerage/dexie-sync-adapter.ts`) using `this.db.brokerageFundDetails.bulkPut()`
+- [x] 4.3 Import `BrokerageFundDetail` type in both files
+- [x] 4.4 Add `fund_details` to `SyncCategory` type in `packages/brokerage-core/src/types.ts` (union: `'positions' | 'transactions' | 'corp_actions' | 'account' | 'fund_details'`)
+- [x] 4.5 Add `fund_details` rate limit (1100ms — same Medium tier) to `RATE_LIMITS` in `sync-orchestrator.ts`
+- [x] 4.6 Add `fund_details` case in `syncCategory()` switch with `syncFundDetailsWithRetry(since)`
+- [x] 4.7 Implement `syncFundDetailsWithRetry()` private method calling `provider.fetchFundDetails(since)` then `db.appendFundDetails()`
+- [x] 4.8 Add `fund_details` to default sync categories array and `getSyncStatus()` result map. Remove `corp_actions` from both.
+- [x] 4.9 Rebuild `@lokfi/brokerage-core` after SyncCategory change
+
+## 5. Tiger Provider — tiger-provider.ts
+
+- [x] 5.1 Add `import type { BrokerageFundDetail }` (replacing `BrokerageCorpAction` import where applicable)
+- [x] 5.2 Implement paginated `fetchFundDetails(since: Date): Promise<BrokerageFundDetail[]>` method:
+- [x] 5.3 Remove `fetchCorpActions()` method from `TigerProvider` entirely (breaking change — replaced by `fetchFundDetails()`)
+- [x] 5.4 Refactor `fetchTransactions()` to collect and return filled order data in a structure usable by the enrichment step (expose filled orders for enrichment matching)
+
+## 6. Tiger Adapter — tiger-adapter.ts
+
+- [x] 6.1 Create static `FUND_TYPE_MAP` constant mapping Tiger type strings to `FundDetailType` enum values
+- [x] 6.2 Implement `classifyFundType(rawType?: string): FundDetailType` helper using the map, falling back to `FEE` with warning log for unknowns
+- [x] 6.3 Implement `extractSymbolFromDesc(desc?: string): string` — extract first word as symbol (reuse existing `parseSymbolFromDesc` logic)
+- [x] 6.4 Implement `extractActionFromDesc(desc?: string): TradeAction | undefined` — parse "Buy"/"Sell" prefix
+- [x] 6.5 Implement `adaptFundDetail(raw: TigerFundDetail): BrokerageFundDetail | null`:
+- [x] 6.6 Remove `adaptCorpAction()` from tiger-adapter.ts (no longer needed)
+
+## 7. Trade Enrichment — tiger-adapter.ts or new enrichment module
+
+- [x] 7.1 Implement `enrichTradeFundDetail(fd: BrokerageFundDetail, filledOrders: BrokerageTransaction[]): BrokerageFundDetail`:
+- [x] 7.2 Integrate enrichment into `fetchFundDetails()` in `TigerProvider`:
+- [x] 7.3 Modify `fetchTransactions()` return to also expose filled orders for enrichment (or have `fetchFundDetails()` fetch its own filled orders)
+
+## 8. Unified View — unifiedTransactions.ts
+
+- [x] 8.1 Extend `BrokerageRowType` with `'DIVIDEND_TAX'`, `'TRANSFER_IN'`, `'REBATE'`
+- [x] 8.2 Implement `mapFundDetail(d: BrokerageFundDetail): UnifiedTransactionRow[]`:
+- [x] 8.3 Update `filterBrokerageRow()` to pass through `DIVIDEND_TAX`, `TRANSFER_IN`, `REBATE`, `FEE` row types (no symbol/account filter needed — those are bank-only)
+- [x] 8.4 Update `fetchUnifiedRows()` to query `db.brokerageFundDetails` (replacing `db.brokerageCorpActions`) and call `mapFundDetail()`
+- [x] 8.5 Implement dedup logic: filled orders that have been matched to a fund_detail TRADE record SHALL NOT produce separate BUY/SELL rows
+- [x] 8.6 Update `useUnifiedTransactions()` React hook dependency list (no functional change needed if `fetchUnifiedRows()` abstracts it)
+
+## 9. CDC Stub — cdc-stub.ts
+
+- [x] 9.1 Add `fetchFundDetails()` implementation to `CdcStubProvider` returning `[]` (required by updated `BrokerageProvider` interface)
+
+## 10. Profile Export/Import — ProfilePage.tsx
+
+- [x] 10.1 Add `brokerageFundDetails` to the export: add `db.brokerageFundDetails.toArray()` to the `Promise.all` in `handleExport()`, include in the data object, bump `version` to `3`
+- [x] 10.2 Add `brokerageFundDetails` to import validation: accept v1, v2, and v3. For v3, require the `brokerageFundDetails` array. For v2, `brokerageFundDetails` is optional.
+- [x] 10.3 Add `brokerageFundDetails` to import confirmation dialog: show "• N fund detail(s)" in the summary
+- [x] 10.4 Add `brokerageFundDetails` to import restore: include in `tables` array, clear on import, `bulkAdd` from backup data
+- [x] 10.5 Add `brokerageFundDetails` to `BrokerageSettingsPage.tsx` clear logic (line 177 — clear alongside other brokerage tables)
+
+## 11. Component References — switch brokerageCorpActions → brokerageFundDetails
+
+- [x] 11.1 Update `DividendsTab.tsx:52` — query `db.brokerageFundDetails.where('classifiedType').equals('DIVIDEND')` (also include `DIVIDEND_TAX` for comprehensive dividend view)
+- [x] 11.2 Update `OverviewTab.tsx:326` — count `db.brokerageFundDetails` instead of `db.brokerageCorpActions`
+- [x] 11.3 Update `TransactionsPage.tsx:76,83` — count `db.brokerageFundDetails` instead of `db.brokerageCorpActions`
+- [x] 11.4 Update `TransactionFilters.tsx:23,29` — get unique sources from `db.brokerageFundDetails` instead of `db.brokerageCorpActions`
+
+## 12. Tests
+
+- [x] 12.1 Update `tiger-adapter.test.ts`: replace `adaptCorpAction` tests with `adaptFundDetail` tests covering all 13 types including Dividend Tax withheld, Dividend Tax refund (positive amount), Commission, Platform Fee, Trade, GST, Transfer In, Campaign Subsidy, unknown type
+- [x] 12.2 Add trade enrichment tests: mock fund_detail + filled_orders, verify matching and enrichment logic
+- [x] 12.3 Update `unifiedTransactions.test.ts`: replace `mapCorpAction` tests with `mapFundDetail` tests covering DIVIDEND, DIVIDEND_TAX withheld, DIVIDEND_TAX refund, TRADE (enriched and unenriched), FEE, TRANSFER_IN, REBATE
+- [x] 12.4 Update `sync-orchestrator.test.ts`: verify `fund_details` category is synced, rate-limited, error-isolated; verify `corp_actions` category is removed from defaults
+- [x] 12.5 Add pagination tests to `tiger-adapter.test.ts` or a new test file: mock multi-page fund_details responses, verify page exhaustion logic, verify inter-page delay
+- [x] 12.6 Run full test suite: `pnpm test` to verify no regressions
+
+## 13. Documentation
+
+- [x] 13.1 Update `apps/web/src/lib/brokerage/tiger/README.md`:
+- [x] 13.2 Update `apps/web/bin/test-tiger.ts` if it references `BrokerageCorpAction` or `adaptCorpAction`
+
+## 14. Verification
+
+- [x] 14.1 Run `pnpm build` to verify all packages compile
+- [x] 14.2 Run `pnpm lint` to verify formatting/linting
+- [x] 14.3 Run `pnpm test` and confirm all tests pass
+- [x] 14.4 Manual verification: run the test script with Tiger credentials to confirm `fund_details ALL` returns expected data (deferred — requires Tiger credentials)

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@types/node": "^22.19.15",
+    "playwright": "^1.59.1",
     "turbo": "^2.3.3",
     "typescript": "^5.7.3"
   },

--- a/packages/brokerage-core/package.json
+++ b/packages/brokerage-core/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@lokfi/brokerage-core",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "lint": "biome check",
+    "lint:fix": "biome check --write"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/brokerage-core/src/index.ts
+++ b/packages/brokerage-core/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @lokfi/brokerage-core
+ *
+ * Shared types and interfaces for the brokerage data pipeline.
+ * Provider-agnostic — all brokerage integrations normalize into these types.
+ */
+
+// Types
+export type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokerageCredentials,
+  BrokeragePosition,
+  BrokeragePositionExtension,
+  BrokerageSource,
+  BrokerageSyncLog,
+  BrokerageTransaction,
+  CorpActionType,
+  SecurityType,
+  SyncCategory,
+  SyncStatus,
+  TradeAction,
+} from './types.js'
+
+// Provider interface
+export type { BrokerageProvider, BrokerageProviderConfig } from './provider.js'

--- a/packages/brokerage-core/src/index.ts
+++ b/packages/brokerage-core/src/index.ts
@@ -8,14 +8,14 @@
 // Types
 export type {
   BrokerageAccount,
-  BrokerageCorpAction,
   BrokerageCredentials,
+  BrokerageFundDetail,
   BrokeragePosition,
   BrokeragePositionExtension,
   BrokerageSource,
   BrokerageSyncLog,
   BrokerageTransaction,
-  CorpActionType,
+  FundDetailType,
   SecurityType,
   SyncCategory,
   SyncStatus,
@@ -23,4 +23,4 @@ export type {
 } from './types.js'
 
 // Provider interface
-export type { BrokerageProvider, BrokerageProviderConfig } from './provider.js'
+export type { BrokerageProvider, BrokerageProviderConfig, ProviderProgress } from './provider.js'

--- a/packages/brokerage-core/src/provider.ts
+++ b/packages/brokerage-core/src/provider.ts
@@ -11,11 +11,18 @@
 
 import type {
   BrokerageAccount,
-  BrokerageCorpAction,
+  BrokerageFundDetail,
   BrokeragePosition,
   BrokerageSource,
   BrokerageTransaction,
 } from './types.js'
+
+/**
+ * Callback for sub-method progress updates (e.g. pagination, rate-limit pauses).
+ * Invoked by the provider during long-running fetch operations so the UI can
+ * display granular status messages.
+ */
+export type ProviderProgress = (message: string) => void
 
 export interface BrokerageProvider {
   /** Unique identifier for this brokerage (e.g. 'tiger', 'ibkr', 'crypto_com') */
@@ -27,8 +34,10 @@ export interface BrokerageProvider {
   /**
    * Fetch current positions (holdings).
    * Returns an empty array if no positions exist.
+   *
+   * @param onProgress - Optional callback for sub-method progress updates
    */
-  fetchPositions(): Promise<BrokeragePosition[]>
+  fetchPositions(onProgress?: ProviderProgress): Promise<BrokeragePosition[]>
 
   /**
    * Fetch filled order history since a given date.
@@ -36,22 +45,26 @@ export interface BrokerageProvider {
    * the orchestrator will dedupe by orderId.
    *
    * @param since - Earliest date to fetch transactions from
+   * @param onProgress - Optional callback for sub-method progress updates
    */
-  fetchTransactions(since: Date): Promise<BrokerageTransaction[]>
+  fetchTransactions(since: Date, onProgress?: ProviderProgress): Promise<BrokerageTransaction[]>
 
   /**
-   * Fetch corporate actions (dividends, splits, rights) applied to the account.
+   * Fetch fund details (cash ledger — dividends, fees, trades, transfers, rebates).
    * Returns empty array if the provider does not expose this data.
    *
-   * @param since - Earliest date to fetch actions from
+   * @param since - Earliest date to fetch fund details from
+   * @param onProgress - Optional callback for sub-category progress updates (e.g. pagination)
    */
-  fetchCorpActions(since: Date): Promise<BrokerageCorpAction[]>
+  fetchFundDetails(since: Date, onProgress?: ProviderProgress): Promise<BrokerageFundDetail[]>
 
   /**
    * Fetch account summary — cash balance, net liquidation per currency segment.
    * Returns an array with one entry per currency segment (e.g. one for USD, one for SGD).
+   *
+   * @param onProgress - Optional callback for sub-method progress updates
    */
-  fetchAccount(): Promise<BrokerageAccount[]>
+  fetchAccount(onProgress?: ProviderProgress): Promise<BrokerageAccount[]>
 
   /**
    * Lightweight connectivity check — confirms auth works without fetching

--- a/packages/brokerage-core/src/provider.ts
+++ b/packages/brokerage-core/src/provider.ts
@@ -1,0 +1,72 @@
+/**
+ * BrokerageProvider interface — every brokerage integration must implement this.
+ *
+ * Each provider handles:
+ *   - Connecting to a brokerage API (auth, HTTP)
+ *   - Fetching raw data
+ *   - Mapping to the normalized `Brokerage*` types
+ *
+ * The sync orchestrator calls these methods and persists results to Dexie.
+ */
+
+import type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokeragePosition,
+  BrokerageSource,
+  BrokerageTransaction,
+} from './types.js'
+
+export interface BrokerageProvider {
+  /** Unique identifier for this brokerage (e.g. 'tiger', 'ibkr', 'crypto_com') */
+  readonly source: BrokerageSource
+
+  /** Display name for this brokerage (e.g. 'Tiger Brokers') */
+  readonly displayName: string
+
+  /**
+   * Fetch current positions (holdings).
+   * Returns an empty array if no positions exist.
+   */
+  fetchPositions(): Promise<BrokeragePosition[]>
+
+  /**
+   * Fetch filled order history since a given date.
+   * Used to populate the transaction log. Append-only semantics —
+   * the orchestrator will dedupe by orderId.
+   *
+   * @param since - Earliest date to fetch transactions from
+   */
+  fetchTransactions(since: Date): Promise<BrokerageTransaction[]>
+
+  /**
+   * Fetch corporate actions (dividends, splits, rights) applied to the account.
+   * Returns empty array if the provider does not expose this data.
+   *
+   * @param since - Earliest date to fetch actions from
+   */
+  fetchCorpActions(since: Date): Promise<BrokerageCorpAction[]>
+
+  /**
+   * Fetch account summary — cash balance, net liquidation per currency segment.
+   * Returns an array with one entry per currency segment (e.g. one for USD, one for SGD).
+   */
+  fetchAccount(): Promise<BrokerageAccount[]>
+
+  /**
+   * Lightweight connectivity check — confirms auth works without fetching
+   * full datasets. Used for initial setup verification.
+   */
+  validateConnection(): Promise<boolean>
+}
+
+/**
+ * Configuration passed to a BrokerageProvider at construction time.
+ * The shape varies by provider; the orchestrator passes whatever the
+ * provider's constructor expects. Typically this comes from the
+ * encrypted credential store.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface BrokerageProviderConfig {
+  [key: string]: unknown
+}

--- a/packages/brokerage-core/src/types.test.ts
+++ b/packages/brokerage-core/src/types.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  BrokerageAccount,
+  BrokerageCorpAction,
+  BrokerageCredentials,
+  BrokeragePosition,
+  BrokeragePositionExtension,
+  BrokerageSyncLog,
+  BrokerageTransaction,
+  CorpActionType,
+  SecurityType,
+  SyncCategory,
+  SyncStatus,
+  TradeAction,
+} from './types'
+
+describe('BrokeragePosition', () => {
+  it('creates position with required fields', () => {
+    const position: BrokeragePosition = {
+      id: 'AAPL_tiger',
+      source: 'tiger',
+      symbol: 'AAPL',
+      currency: 'USD',
+      quantity: 100,
+      avgCost: 150,
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    }
+    expect(position.id).toBe('AAPL_tiger')
+    expect(position.symbol).toBe('AAPL')
+    expect(position.quantity).toBe(100)
+    expect(position.avgCost).toBe(150)
+    expect(position.source).toBe('tiger')
+  })
+
+  it('accepts optional fields', () => {
+    const position: BrokeragePosition = {
+      id: 'AAPL_tiger',
+      source: 'tiger',
+      symbol: 'AAPL',
+      name: 'Apple Inc.',
+      secType: 'STK',
+      currency: 'USD',
+      quantity: 100,
+      avgCost: 150,
+      marketValue: 18000,
+      unrealizedPnl: 3000,
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    }
+    expect(position.name).toBe('Apple Inc.')
+    expect(position.secType).toBe('STK')
+    expect(position.marketValue).toBe(18000)
+    expect(position.unrealizedPnl).toBe(3000)
+  })
+})
+
+describe('BrokerageTransaction', () => {
+  it('creates transaction with all fields', () => {
+    const txn: BrokerageTransaction = {
+      id: 'tiger_123',
+      source: 'tiger',
+      orderId: '123',
+      symbol: 'AAPL',
+      action: 'BUY',
+      quantity: 100,
+      price: 150,
+      currency: 'USD',
+      commission: 1,
+      executedAt: '2025-01-01T10:00:00.000Z',
+    }
+    expect(txn.id).toBe('tiger_123')
+    expect(txn.action).toBe('BUY')
+    expect(txn.quantity).toBe(100)
+    expect(txn.price).toBe(150)
+    expect(txn.commission).toBe(1)
+  })
+
+  it('omits optional commission field', () => {
+    const txn: BrokerageTransaction = {
+      id: 'tiger_456',
+      source: 'tiger',
+      orderId: '456',
+      symbol: 'TSLA',
+      action: 'SELL',
+      quantity: 50,
+      price: 200,
+      currency: 'USD',
+      executedAt: '2025-01-01T11:00:00.000Z',
+    }
+    expect(txn.commission).toBeUndefined()
+  })
+})
+
+describe('BrokerageCorpAction', () => {
+  it('creates DIVIDEND action', () => {
+    const action: BrokerageCorpAction = {
+      id: 'tiger_AAPL_DIVIDEND_2025-01-15',
+      source: 'tiger',
+      symbol: 'AAPL',
+      type: 'DIVIDEND',
+      amount: 24,
+      currency: 'USD',
+      exDate: '2025-02-07',
+      payDate: '2025-02-13',
+      appliedAt: '2025-02-13T00:00:00.000Z',
+    }
+    expect(action.type).toBe('DIVIDEND')
+    expect(action.amount).toBe(24)
+  })
+
+  it('creates SPLIT action', () => {
+    const action: BrokerageCorpAction = {
+      id: 'tiger_AAPL_SPLIT_2025-03-01',
+      source: 'tiger',
+      symbol: 'AAPL',
+      type: 'SPLIT',
+      amount: 4,
+      appliedAt: '2025-03-01T00:00:00.000Z',
+    }
+    expect(action.type).toBe('SPLIT')
+  })
+
+  it('creates RIGHTS action', () => {
+    const action: BrokerageCorpAction = {
+      id: 'tiger_ABC_RIGHTS_2025-04-01',
+      source: 'tiger',
+      symbol: 'ABC',
+      type: 'RIGHTS',
+      appliedAt: '2025-04-01T00:00:00.000Z',
+    }
+    expect(action.type).toBe('RIGHTS')
+  })
+
+  it('creates OTHER action', () => {
+    const action: BrokerageCorpAction = {
+      id: 'tiger_XYZ_OTHER_2025-05-01',
+      source: 'tiger',
+      symbol: 'XYZ',
+      type: 'OTHER',
+      appliedAt: '2025-05-01T00:00:00.000Z',
+    }
+    expect(action.type).toBe('OTHER')
+  })
+})
+
+describe('BrokerageAccount', () => {
+  it('creates account with currency and segType', () => {
+    const account: BrokerageAccount = {
+      id: 'tiger_USD_SEC',
+      source: 'tiger',
+      currency: 'USD',
+      cashBalance: 10000,
+      netLiquidation: 50000,
+      segType: 'SEC',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    }
+    expect(account.id).toBe('tiger_USD_SEC')
+    expect(account.currency).toBe('USD')
+    expect(account.segType).toBe('SEC')
+    expect(account.cashBalance).toBe(10000)
+    expect(account.netLiquidation).toBe(50000)
+  })
+
+  it('accepts FUT segType', () => {
+    const account: BrokerageAccount = {
+      id: 'tiger_USD_FUT',
+      source: 'tiger',
+      currency: 'USD',
+      cashBalance: 5000,
+      segType: 'FUT',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    }
+    expect(account.segType).toBe('FUT')
+  })
+})
+
+describe('BrokerageSyncLog', () => {
+  it('creates success log', () => {
+    const log: BrokerageSyncLog = {
+      source: 'tiger',
+      category: 'positions',
+      status: 'success',
+      lastSyncAt: '2025-01-01T12:00:00.000Z',
+    }
+    expect(log.status).toBe('success')
+    expect(log.category).toBe('positions')
+  })
+
+  it('creates failure log with error message', () => {
+    const log: BrokerageSyncLog = {
+      source: 'tiger',
+      category: 'transactions',
+      status: 'failure',
+      lastSyncAt: '2025-01-01T12:00:00.000Z',
+      errorMessage: 'Network timeout',
+    }
+    expect(log.status).toBe('failure')
+    expect(log.errorMessage).toBe('Network timeout')
+  })
+
+  it('creates in_progress log', () => {
+    const log: BrokerageSyncLog = {
+      source: 'tiger',
+      category: 'account',
+      status: 'in_progress',
+      lastSyncAt: '2025-01-01T12:00:00.000Z',
+    }
+    expect(log.status).toBe('in_progress')
+  })
+})
+
+describe('BrokerageCredentials', () => {
+  it('creates credentials structure', () => {
+    const creds: BrokerageCredentials = {
+      id: 'tiger',
+      encryptedData: 'abc123base64==',
+      iv: 'def456base64==',
+      salt: 'ghi789base64==',
+    }
+    expect(creds.id).toBe('tiger')
+    expect(creds.encryptedData).toBe('abc123base64==')
+    expect(creds.iv).toBe('def456base64==')
+    expect(creds.salt).toBe('ghi789base64==')
+  })
+})
+
+describe('Type unions', () => {
+  it('SecurityType covers all expected values', () => {
+    const types: SecurityType[] = ['STK', 'OPT', 'FUT', 'FOP', 'CASH', 'FUND', 'WAR', 'MLEG']
+    expect(types).toHaveLength(8)
+  })
+
+  it('TradeAction is BUY or SELL', () => {
+    const actions: TradeAction[] = ['BUY', 'SELL']
+    expect(actions).toHaveLength(2)
+  })
+
+  it('CorpActionType covers all variants', () => {
+    const types: CorpActionType[] = ['DIVIDEND', 'SPLIT', 'RIGHTS', 'OTHER']
+    expect(types).toHaveLength(4)
+  })
+
+  it('SyncStatus covers all states', () => {
+    const statuses: SyncStatus[] = ['success', 'failure', 'in_progress']
+    expect(statuses).toHaveLength(3)
+  })
+
+  it('SyncCategory covers all four categories', () => {
+    const categories: SyncCategory[] = ['positions', 'transactions', 'corp_actions', 'account']
+    expect(categories).toHaveLength(4)
+  })
+})
+
+describe('BrokeragePositionExtension', () => {
+  it('creates extension record', () => {
+    const ext: BrokeragePositionExtension = {
+      positionId: 'AAPL_tiger',
+      key: 'contractId',
+      value: '"12345"',
+    }
+    expect(ext.positionId).toBe('AAPL_tiger')
+    expect(ext.key).toBe('contractId')
+    expect(ext.value).toBe('"12345"')
+  })
+})

--- a/packages/brokerage-core/src/types.test.ts
+++ b/packages/brokerage-core/src/types.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type {
   BrokerageAccount,
-  BrokerageCorpAction,
   BrokerageCredentials,
   BrokeragePosition,
   BrokeragePositionExtension,
   BrokerageSyncLog,
   BrokerageTransaction,
-  CorpActionType,
   SecurityType,
   SyncCategory,
   SyncStatus,
@@ -87,58 +85,6 @@ describe('BrokerageTransaction', () => {
       executedAt: '2025-01-01T11:00:00.000Z',
     }
     expect(txn.commission).toBeUndefined()
-  })
-})
-
-describe('BrokerageCorpAction', () => {
-  it('creates DIVIDEND action', () => {
-    const action: BrokerageCorpAction = {
-      id: 'tiger_AAPL_DIVIDEND_2025-01-15',
-      source: 'tiger',
-      symbol: 'AAPL',
-      type: 'DIVIDEND',
-      amount: 24,
-      currency: 'USD',
-      exDate: '2025-02-07',
-      payDate: '2025-02-13',
-      appliedAt: '2025-02-13T00:00:00.000Z',
-    }
-    expect(action.type).toBe('DIVIDEND')
-    expect(action.amount).toBe(24)
-  })
-
-  it('creates SPLIT action', () => {
-    const action: BrokerageCorpAction = {
-      id: 'tiger_AAPL_SPLIT_2025-03-01',
-      source: 'tiger',
-      symbol: 'AAPL',
-      type: 'SPLIT',
-      amount: 4,
-      appliedAt: '2025-03-01T00:00:00.000Z',
-    }
-    expect(action.type).toBe('SPLIT')
-  })
-
-  it('creates RIGHTS action', () => {
-    const action: BrokerageCorpAction = {
-      id: 'tiger_ABC_RIGHTS_2025-04-01',
-      source: 'tiger',
-      symbol: 'ABC',
-      type: 'RIGHTS',
-      appliedAt: '2025-04-01T00:00:00.000Z',
-    }
-    expect(action.type).toBe('RIGHTS')
-  })
-
-  it('creates OTHER action', () => {
-    const action: BrokerageCorpAction = {
-      id: 'tiger_XYZ_OTHER_2025-05-01',
-      source: 'tiger',
-      symbol: 'XYZ',
-      type: 'OTHER',
-      appliedAt: '2025-05-01T00:00:00.000Z',
-    }
-    expect(action.type).toBe('OTHER')
   })
 })
 
@@ -234,18 +180,13 @@ describe('Type unions', () => {
     expect(actions).toHaveLength(2)
   })
 
-  it('CorpActionType covers all variants', () => {
-    const types: CorpActionType[] = ['DIVIDEND', 'SPLIT', 'RIGHTS', 'OTHER']
-    expect(types).toHaveLength(4)
-  })
-
   it('SyncStatus covers all states', () => {
     const statuses: SyncStatus[] = ['success', 'failure', 'in_progress']
     expect(statuses).toHaveLength(3)
   })
 
-  it('SyncCategory covers all four categories', () => {
-    const categories: SyncCategory[] = ['positions', 'transactions', 'corp_actions', 'account']
+  it('SyncCategory covers all categories', () => {
+    const categories: SyncCategory[] = ['positions', 'transactions', 'fund_details', 'account']
     expect(categories).toHaveLength(4)
   })
 })

--- a/packages/brokerage-core/src/types.ts
+++ b/packages/brokerage-core/src/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Normalized brokerage data model.
+ *
+ * All brokerages map into these unified types using a `source` discriminator
+ * field for cross-provider analytics. Provider-specific fields go into the
+ * extensions table (EAV pattern).
+ */
+
+/** Supported brokerage sources */
+export type BrokerageSource = string
+
+/** Asset class / security type */
+export type SecurityType = 'STK' | 'OPT' | 'FUT' | 'FOP' | 'CASH' | 'FUND' | 'WAR' | 'MLEG'
+
+/** Trade direction */
+export type TradeAction = 'BUY' | 'SELL'
+
+/** Corporate action type */
+export type CorpActionType = 'DIVIDEND' | 'SPLIT' | 'RIGHTS' | 'OTHER'
+
+/** Sync status for audit trail */
+export type SyncStatus = 'success' | 'failure' | 'in_progress'
+
+/** Sync category discriminator */
+export type SyncCategory = 'positions' | 'transactions' | 'corp_actions' | 'account'
+
+// ── Position ──────────────────────────────────────────────────────────────
+
+export interface BrokeragePosition {
+  /** Natural key: `${symbol}_${source}` */
+  id: string
+  source: BrokerageSource
+  symbol: string
+  /** Display name (e.g. "Apple Inc.") */
+  name?: string
+  secType?: SecurityType
+  currency: string
+  quantity: number
+  avgCost: number
+  marketValue?: number
+  unrealizedPnl?: number
+  /** ISO-8601 timestamp of when this position was last fetched */
+  updatedAt: string
+}
+
+/** EAV table for provider-specific position metadata */
+export interface BrokeragePositionExtension {
+  positionId: string
+  key: string
+  /** JSON-encoded value */
+  value: string
+}
+
+// ── Transaction (order fill) ─────────────────────────────────────────────
+
+export interface BrokerageTransaction {
+  /** Provider-native order ID prefixed with source for global uniqueness */
+  id: string
+  source: BrokerageSource
+  orderId: string
+  symbol: string
+  action: TradeAction
+  quantity: number
+  price: number
+  currency: string
+  commission?: number
+  /** ISO-8601 timestamp of execution */
+  executedAt: string
+}
+
+// ── Corporate Action ─────────────────────────────────────────────────────
+
+export interface BrokerageCorpAction {
+  /** Natural key: `${source}_${symbol}_${type}_${payDate || exDate}` */
+  id: string
+  source: BrokerageSource
+  symbol: string
+  type: CorpActionType
+  amount?: number
+  currency?: string
+  /** ISO-8601 ex-dividend date */
+  exDate?: string
+  /** ISO-8601 payment date */
+  payDate?: string
+  /** ISO-8601 when this was applied to the account */
+  appliedAt: string
+}
+
+// ── Account ───────────────────────────────────────────────────────────────
+
+export interface BrokerageAccount {
+  /** Natural key: `${source}_${currency}` */
+  id: string
+  source: BrokerageSource
+  currency: string
+  /** Cash balance for this currency segment */
+  cashBalance: number
+  /** Net liquidation value for this segment */
+  netLiquidation?: number
+  /** Segment type discriminator (e.g. 'SEC' for securities, 'FUT' for futures) */
+  segType?: string
+  /** ISO-8601 timestamp of when this was last fetched */
+  updatedAt: string
+}
+
+// ── Sync Log ──────────────────────────────────────────────────────────────
+
+export interface BrokerageSyncLog {
+  id?: number
+  source: BrokerageSource
+  category: SyncCategory
+  status: SyncStatus
+  /** ISO-8601 timestamp */
+  lastSyncAt: string
+  errorMessage?: string
+}
+
+// ── Credentials ───────────────────────────────────────────────────────────
+
+/** Encrypted credential record stored in Dexie */
+export interface BrokerageCredentials {
+  /** Source name (e.g. 'tiger') */
+  id: string
+  /** AES-GCM encrypted JSON blob (base64) */
+  encryptedData: string
+  /** AES-GCM initialization vector (base64) */
+  iv: string
+  /** PBKDF2 salt used for key derivation (base64) */
+  salt: string
+}

--- a/packages/brokerage-core/src/types.ts
+++ b/packages/brokerage-core/src/types.ts
@@ -15,19 +15,29 @@ export type SecurityType = 'STK' | 'OPT' | 'FUT' | 'FOP' | 'CASH' | 'FUND' | 'WA
 /** Trade direction */
 export type TradeAction = 'BUY' | 'SELL'
 
-/** Corporate action type */
-export type CorpActionType = 'DIVIDEND' | 'SPLIT' | 'RIGHTS' | 'OTHER'
+/** Fund detail classified type for unified view */
+export type FundDetailType =
+  | 'DIVIDEND'
+  | 'DIVIDEND_TAX'
+  | 'TRADE'
+  | 'FEE'
+  | 'TRANSFER_IN'
+  | 'TRANSFER_OUT'
+  | 'REBATE'
+  | 'CURRENCY_EXCHANGE'
+  | 'DEPOSIT_WITHDRAWAL'
+  | 'UNKNOWN'
 
 /** Sync status for audit trail */
 export type SyncStatus = 'success' | 'failure' | 'in_progress'
 
 /** Sync category discriminator */
-export type SyncCategory = 'positions' | 'transactions' | 'corp_actions' | 'account'
+export type SyncCategory = 'positions' | 'transactions' | 'fund_details' | 'account'
 
 // ── Position ──────────────────────────────────────────────────────────────
 
 export interface BrokeragePosition {
-  /** Natural key: `${symbol}_${source}` */
+  /** Natural key: `${symbol}_${secType}_${source}` */
   id: string
   source: BrokerageSource
   symbol: string
@@ -41,6 +51,12 @@ export interface BrokeragePosition {
   unrealizedPnl?: number
   /** ISO-8601 timestamp of when this position was last fetched */
   updatedAt: string
+  /** Option/derivative: OCC option symbol (e.g. "CRWV  260508P00106000") */
+  identifier?: string
+  /** Option/derivative: contract multiplier (e.g. 100 for standard US equity) */
+  multiplier?: number
+  /** Option/derivative: provider-internal contract ID */
+  contractId?: number
 }
 
 /** EAV table for provider-specific position metadata */
@@ -68,22 +84,32 @@ export interface BrokerageTransaction {
   executedAt: string
 }
 
-// ── Corporate Action ─────────────────────────────────────────────────────
+// ── Fund Detail ───────────────────────────────────────────────────────────
 
-export interface BrokerageCorpAction {
-  /** Natural key: `${source}_${symbol}_${type}_${payDate || exDate}` */
+export interface BrokerageFundDetail {
+  /** Natural key: provider-native record ID prefixed with source */
   id: string
   source: BrokerageSource
-  symbol: string
-  type: CorpActionType
-  amount?: number
-  currency?: string
-  /** ISO-8601 ex-dividend date */
-  exDate?: string
-  /** ISO-8601 payment date */
-  payDate?: string
-  /** ISO-8601 when this was applied to the account */
-  appliedAt: string
+  /** Raw type string from the brokerage (e.g. "Commission", "Platform Fee") */
+  rawType: string
+  /** Classified type for the unified view */
+  classifiedType: FundDetailType
+  /** Extracted from desc for trades/dividends */
+  symbol?: string
+  /** Display name (e.g. "Broadcom") */
+  contractName?: string
+  amount: number
+  currency: string
+  /** Trade action (BUY/SELL) — only present when classifiedType is TRADE */
+  action?: TradeAction
+  /** Enriched from filled_orders — only present for TRADE records */
+  quantity?: number
+  price?: number
+  commission?: number
+  /** ISO-8601 business date */
+  businessDate: string
+  /** Segment type discriminator (e.g. 'SEC') */
+  segType?: string
 }
 
 // ── Account ───────────────────────────────────────────────────────────────

--- a/packages/brokerage-core/tsconfig.json
+++ b/packages/brokerage-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/parser-core/src/parsers/generic/csvUtils.ts
+++ b/packages/parser-core/src/parsers/generic/csvUtils.ts
@@ -114,10 +114,15 @@ export function normalizeDate(raw: string): string | null {
     if (m) return `${y}-${m}-${d!.padStart(2, '0')}`
   }
 
-  // Fallback: try native Date.parse (timezone-safe: treat as UTC noon)
+  // Fallback: try native Date.parse — extract local-timezone components
+  // so we don't get UTC date shifts (toISOString breaks for UTC+X offsets)
   const p = Date.parse(raw.trim())
   if (!isNaN(p)) {
-    return new Date(p).toISOString().split('T')[0]!
+    const d = new Date(p)
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${y}-${m}-${day}`
   }
 
   return null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,12 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       turbo:
         specifier: ^2.3.3
         version: 2.8.17
@@ -24,6 +30,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@lokfi/brokerage-core':
+        specifier: workspace:*
+        version: link:../../packages/brokerage-core
       '@lokfi/parser-core':
         specifier: workspace:*
         version: link:../../packages/parser-core
@@ -76,6 +85,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@playwright/mcp':
+        specifier: ^0.0.73
+        version: 0.0.73
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -106,6 +118,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -115,6 +130,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(tsx@4.21.0)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -124,6 +142,18 @@ importers:
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@24.12.0)(jsdom@25.0.1)(lightningcss@1.32.0)
+
+  packages/brokerage-core:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@25.5.0)(jsdom@25.0.1)(lightningcss@1.32.0)
 
   packages/parser-core:
     dependencies:
@@ -722,6 +752,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/mcp@0.0.73':
+    resolution: {integrity: sha512-2hq+nPq8esA3mi3bjEpBH5A3LkVqnSCJXw7NO2N7frJTzKsu8qdTQyvPl1jk83rPuIY6ALCdEBI60tdTODeNEA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
@@ -1386,6 +1421,10 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1483,6 +1522,11 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1868,6 +1912,26 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright-core@1.60.0-alpha-1777669338000:
+    resolution: {integrity: sha512-CbBF+YtjGGK2mWKdH6iiSNIB9v9Sq8owcUrTy1cw6FgMZavspM6ZSpidQQgQXz/1scQFrM110jrtJqTYwnjbeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0-alpha-1777669338000:
+    resolution: {integrity: sha512-r5G2ZvpIJZHj53GKmUfoQiXHix5bjeObqysV4flfmFNykTjebI9bwdRBuW37pOQP25yjbArkxlsnT5APaWT8zg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -2776,6 +2840,11 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/mcp@0.0.73':
+    dependencies:
+      playwright: 1.60.0-alpha-1777669338000
+      playwright-core: 1.60.0-alpha-1777669338000
+
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     optional: true
 
@@ -3341,6 +3410,8 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
+  dotenv@17.4.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3475,6 +3546,9 @@ snapshots:
       mime-types: 2.1.35
 
   fraction.js@5.3.4: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3818,6 +3892,22 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright-core@1.60.0-alpha-1777669338000: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.60.0-alpha-1777669338000:
+    dependencies:
+      playwright-core: 1.60.0-alpha-1777669338000
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.8):
     dependencies:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,6 +5,18 @@
       "source": "anthropics/claude-code",
       "sourceType": "github",
       "computedHash": "e8118284a6365753790d44bb2758a6032b3af27fa84696428d9233f2be0f4e78"
+    },
+    "tigeropen": {
+      "source": "tigerfintech/tigeropen-skill",
+      "sourceType": "github",
+      "skillPath": "skills/tigeropen/SKILL.md",
+      "computedHash": "f0a8b9309bd7d06dc896e6d67c5006daca28adb110d02156a76826ff4dadc66d"
+    },
+    "tigeropen-typescript": {
+      "source": "tigerfintech/tigeropen-skill",
+      "sourceType": "github",
+      "skillPath": "skills/tigeropen-typescript/SKILL.md",
+      "computedHash": "77811b480825d3d475c2e0e227a728763d1627bce2139065af213d0db2c75fa2"
     }
   }
 }


### PR DESCRIPTION
## Summary

Portfolio Hub Phase 2 — adds currency conversion, fund detail sync with
trade enrichment, and full portfolio pages. Also cleans up unused corp
action types and tables.

### Commits

1. **refactor(brokerage-core)!: remove unused corp action types**
   - Removes CorpActionType, BrokerageCorpAction, CORP_ACTION from
     FundDetailType, corp_actions from SyncCategory
   - These types were never populated — Tiger API does not return
     corporate action events for retail accounts

2. **feat(web): portfolio hub phase 2**
   - FX rate engine: Frankfurter API integration, caching, currency
     conversion utility, useFxRates hook
   - Fund detail sync: fetchFundDetails with pagination, trade
     enrichment from filled orders
   - Portfolio pages: Overview, Holdings, Dividends, Transactions tabs
   - Currency selector with preference persistence
   - Sync progress bar component

### Fixes included

- Per-dividend currency conversion in DividendsTab (no more mixed-currency totals)
- Indexed Dexie query for classifiedType (.where().anyOf() instead of .filter())
- OCC option regex tolerance for short symbols (\s{2,} instead of {2})
- Removed dead matchedOrderIds dedup code in unified transactions
- Currency guard for dividend-to-bank linking (SGD only)
- Overview tab now includes DIVIDEND_TAX in YTD
- Missing fund_details switch case in sync orchestrator (was silently no-op)
- Corp actions table schema + all references removed from web

### Breaking changes

- @lokfi/brokerage-core: CorpActionType, BrokerageCorpAction,
  CORP_ACTION in FundDetailType, corp_actions in SyncCategory removed.
  These were never populated — no migration needed.