### PR TITLE
feat(web): add parser badge with dropdown selector

### DIFF
--- a/apps/web/src/pages/import/FileStatusList.test.tsx
+++ b/apps/web/src/pages/import/FileStatusList.test.tsx
@@ -1,4 +1,5 @@
-import type { Statement, Transaction } from '@lokfi/parser-core'
+import type { Statement, StatementParser, Transaction } from '@lokfi/parser-core'
+import type { ParserEntry } from '@lokfi/parser-core'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,6 +10,22 @@ import { FileStatusList } from './FileStatusList'
 const mockFile = (name: string, size = 1024): File => {
   return { name, size } as unknown as File
 }
+
+/** Create a minimal mock parser entry. */
+function mockParserEntry(label: string): ParserEntry {
+  return {
+    label,
+    parser: { label, detect: vi.fn(), parse: vi.fn() } as unknown as StatementParser,
+  }
+}
+
+const DEFAULT_PARSERS: ParserEntry[] = [
+  mockParserEntry('My Custom Profile'),
+  mockParserEntry('CDC Debit'),
+  mockParserEntry('Generic CSV'),
+  mockParserEntry('OCBC Credit'),
+  mockParserEntry('Generic PDF'),
+]
 
 const mockTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
   date: '2024-01-15',
@@ -195,25 +212,20 @@ describe('formatDate', () => {
 // by rendering FileStatusList and inspecting the status text/icons rendered.
 
 describe('StatusBadge via FileStatusList', () => {
+  const badgeProps = {
+    availableParsers: DEFAULT_PARSERS,
+    onConfigure: vi.fn(),
+    onRemove: vi.fn(),
+    onChangeParser: vi.fn(),
+  }
+
   it('shows "Pending" with Clock icon for pending status', () => {
-    render(
-      <FileStatusList
-        items={[makeResult({ file: mockFile('test.pdf'), status: 'pending' })]}
-        onConfigure={vi.fn()}
-        onRemove={vi.fn()}
-      />
-    )
+    render(<FileStatusList items={[makeResult({ file: mockFile('test.pdf'), status: 'pending' })]} {...badgeProps} />)
     expect(screen.getByText('Pending')).toBeInTheDocument()
   })
 
   it('shows "Parsing…" with Loader2 icon for parsing status', () => {
-    render(
-      <FileStatusList
-        items={[makeResult({ file: mockFile('test.csv'), status: 'parsing' })]}
-        onConfigure={vi.fn()}
-        onRemove={vi.fn()}
-      />
-    )
+    render(<FileStatusList items={[makeResult({ file: mockFile('test.csv'), status: 'parsing' })]} {...badgeProps} />)
     expect(screen.getByText('Parsing…')).toBeInTheDocument()
   })
 
@@ -227,8 +239,7 @@ describe('StatusBadge via FileStatusList', () => {
             transactionCount: 0,
           }),
         ]}
-        onConfigure={vi.fn()}
-        onRemove={vi.fn()}
+        {...badgeProps}
       />
     )
     expect(screen.getByText('Done')).toBeInTheDocument()
@@ -238,8 +249,7 @@ describe('StatusBadge via FileStatusList', () => {
     render(
       <FileStatusList
         items={[makeResult({ file: mockFile('test.pdf'), status: 'error', error: 'fail' })]}
-        onConfigure={vi.fn()}
-        onRemove={vi.fn()}
+        {...badgeProps}
       />
     )
     expect(screen.getByText('Error')).toBeInTheDocument()
@@ -250,13 +260,16 @@ describe('StatusBadge via FileStatusList', () => {
 
 describe('FileStatusList', () => {
   const defaultProps = {
+    availableParsers: DEFAULT_PARSERS,
     onConfigure: vi.fn(),
     onRemove: vi.fn(),
+    onChangeParser: vi.fn(),
   }
 
   beforeEach(() => {
     defaultProps.onConfigure.mockClear()
     defaultProps.onRemove.mockClear()
+    defaultProps.onChangeParser.mockClear()
   })
 
   it('renders nothing when items is empty', () => {
@@ -342,7 +355,7 @@ describe('FileStatusList', () => {
     expect(toggle).toBeInTheDocument()
   })
 
-  it('shows yellow "Generic fallback" warning for success + generic source without profile', () => {
+  it('shows parser badge with "Generic CSV" when fallback parser is used', () => {
     render(
       <FileStatusList
         items={[
@@ -351,6 +364,7 @@ describe('FileStatusList', () => {
             status: 'success',
             transactionCount: 1,
             profileName: undefined,
+            parserLabel: 'Generic CSV',
             statement: mockStatement({ source: 'generic' }),
             rawText: 'date,description,amount\n2024-01-15,Test,10.00',
           }),
@@ -358,10 +372,10 @@ describe('FileStatusList', () => {
         {...defaultProps}
       />
     )
-    expect(screen.getByText(/Generic fallback/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Generic CSV' })).toBeInTheDocument()
   })
 
-  it('shows "Profile: XYZ" instead of warning when profile is set', () => {
+  it('shows parser badge with the profile name when profileName is set', () => {
     render(
       <FileStatusList
         items={[
@@ -370,14 +384,15 @@ describe('FileStatusList', () => {
             status: 'success',
             transactionCount: 1,
             profileName: 'My Bank',
+            parserLabel: 'My Bank',
             statement: mockStatement({ source: 'generic' }),
           }),
         ]}
         {...defaultProps}
       />
     )
-    expect(screen.getByText('Profile: My Bank')).toBeInTheDocument()
-    expect(screen.queryByText(/Generic fallback/i)).not.toBeInTheDocument()
+    // The parser badge is a button showing the label
+    expect(screen.getByRole('button', { name: 'My Bank' })).toBeInTheDocument()
   })
 
   it('clicking expand toggle shows all transactions', async () => {
@@ -501,5 +516,116 @@ describe('FileStatusList', () => {
     )
     // Should show 2 accounts label
     expect(screen.getByText('2 accounts')).toBeInTheDocument()
+  })
+
+  // ─── Parser Badge / Selector Tests ──────────────────────────────────────────
+
+  it('shows parser badge button when parserLabel is present', () => {
+    render(
+      <FileStatusList
+        items={[
+          makeResult({
+            file: mockFile('test.csv'),
+            status: 'success',
+            transactionCount: 5,
+            parserLabel: 'ocbc-nxt-main',
+            statement: mockStatement({ source: 'generic' }),
+          }),
+        ]}
+        {...defaultProps}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'ocbc-nxt-main' })).toBeInTheDocument()
+  })
+
+  it('shows parser badge on error state when parserLabel is set', () => {
+    render(
+      <FileStatusList
+        items={[
+          makeResult({
+            file: mockFile('bad.csv'),
+            status: 'error',
+            error: 'Parsing failed',
+            parserLabel: 'Generic CSV',
+          }),
+        ]}
+        {...defaultProps}
+      />
+    )
+    // Badge should be visible so user can try a different parser
+    expect(screen.getByRole('button', { name: 'Generic CSV' })).toBeInTheDocument()
+  })
+
+  it('does not show parser badge during initial parsing (no parserLabel yet)', () => {
+    render(
+      <FileStatusList
+        items={[
+          makeResult({
+            file: mockFile('parsing.csv'),
+            status: 'parsing',
+          }),
+        ]}
+        {...defaultProps}
+      />
+    )
+    // No parser badge when we don't know the parser yet
+    expect(screen.getByText('Parsing…')).toBeInTheDocument()
+  })
+
+  it('opens dropdown on badge click, lists parsers, and calls onChangeParser on selection', async () => {
+    const user = userEvent.setup()
+    const item = makeResult({
+      file: mockFile('select.csv'),
+      status: 'success',
+      transactionCount: 3,
+      parserLabel: 'My Custom Profile',
+      statement: mockStatement({ source: 'generic' }),
+    })
+    render(<FileStatusList items={[item]} {...defaultProps} />)
+
+    // Click the parser badge to open dropdown
+    const badge = screen.getByRole('button', { name: 'My Custom Profile' })
+    await user.click(badge)
+
+    // Dropdown should show available parsers (the button renders its label text)
+    // The dropdown contains items with these labels
+    expect(screen.getByText('Custom Profiles')).toBeInTheDocument()
+    expect(screen.getByText('Built-in')).toBeInTheDocument()
+
+    // Click a different parser to trigger onChangeParser
+    const gsvBtn = screen.getByRole('button', { name: 'Generic CSV' })
+    await user.click(gsvBtn)
+
+    // Should call onChangeParser with the item and the Generic CSV parser
+    expect(defaultProps.onChangeParser).toHaveBeenCalledTimes(1)
+    expect(defaultProps.onChangeParser).toHaveBeenCalledWith(item, expect.objectContaining({ label: 'Generic CSV' }))
+  })
+
+  it('closes dropdown when clicking outside', async () => {
+    const user = userEvent.setup()
+    render(
+      <FileStatusList
+        items={[
+          makeResult({
+            file: mockFile('outside.csv'),
+            status: 'success',
+            transactionCount: 1,
+            parserLabel: 'Generic CSV',
+            statement: mockStatement({ source: 'generic' }),
+          }),
+        ]}
+        {...defaultProps}
+      />
+    )
+
+    // Open dropdown
+    const badge = screen.getByRole('button', { name: 'Generic CSV' })
+    await user.click(badge)
+    expect(screen.getByText('Built-in')).toBeInTheDocument()
+
+    // Click the badge again to toggle the dropdown closed
+    await user.click(badge)
+    // Dropdown content should be gone
+    expect(screen.queryByText('Built-in')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/import/FileStatusList.tsx
+++ b/apps/web/src/pages/import/FileStatusList.tsx
@@ -1,6 +1,7 @@
-import type { Statement, Transaction } from '@lokfi/parser-core'
+import type { Statement, StatementParser, Transaction } from '@lokfi/parser-core'
+import type { ParserEntry } from '@lokfi/parser-core'
 import { AlertTriangle, CheckCircle2, ChevronDown, Clock, Loader2, X, XCircle } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export type FileParseStatus = 'pending' | 'parsing' | 'success' | 'error'
 
@@ -12,12 +13,18 @@ export interface FileParseResult {
   error?: string
   rawText?: string
   profileName?: string
+  /** Label of the parser used (e.g. "ocbc-nxt-main", "OCBC Credit"). Derived from StatementParser.label. */
+  parserLabel?: string
+  /** Raw ArrayBuffer for PDF files — needed for re-parsing with a different parser. */
+  rawBuffer?: ArrayBuffer
 }
 
 interface FileStatusListProps {
   items: FileParseResult[]
+  availableParsers: ParserEntry[]
   onConfigure: (item: FileParseResult) => void
   onRemove: (item: FileParseResult) => void
+  onChangeParser: (item: FileParseResult, parser: StatementParser) => void
 }
 
 // When adding a new parser, add its source key here so users see a human-readable label.
@@ -254,11 +261,137 @@ function StatusBadge({ status }: { status: FileParseStatus }) {
   )
 }
 
-export function FileStatusList({ items, onConfigure, onRemove }: FileStatusListProps) {
+/** Labels of built-in (non-custom) parsers — used to group in the parser selector. */
+const BUILTIN_PARSER_LABELS = new Set(['CDC Debit', 'Generic CSV', 'Generic PDF', 'OCBC Credit'])
+
+// ─── Parser Badge with Dropdown Selector ─────────────────────────────────────
+
+function ParserBadge({
+  label,
+  availableParsers,
+  onSelect,
+  disabled,
+}: {
+  label: string
+  availableParsers: ParserEntry[]
+  onSelect: (parser: StatementParser) => void
+  disabled?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  const customParsers = availableParsers.filter((p) => !BUILTIN_PARSER_LABELS.has(p.label))
+  const builtinParsers = availableParsers.filter((p) => BUILTIN_PARSER_LABELS.has(p.label))
+
+  function handleSelect(parser: StatementParser) {
+    setOpen(false)
+    onSelect(parser)
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        disabled={disabled}
+        className="flex items-center gap-1 text-xs font-medium rounded-md px-2 py-1
+          border border-gray-300 dark:border-gray-500
+          bg-white dark:bg-gray-700
+          text-gray-700 dark:text-gray-200
+          hover:bg-gray-100 dark:hover:bg-gray-600
+          transition-colors whitespace-nowrap"
+      >
+        {label}
+        <ChevronDown className={`h-3 w-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 z-20 w-56 rounded-lg shadow-lg
+            border border-gray-200 dark:border-gray-600
+            bg-white dark:bg-gray-800
+            overflow-hidden"
+        >
+          <div className="max-h-64 overflow-y-auto py-1">
+            {customParsers.length > 0 && (
+              <>
+                <div className="px-3 py-1.5 text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
+                  Custom Profiles
+                </div>
+                {customParsers.map((entry) => (
+                  <button
+                    key={entry.label}
+                    type="button"
+                    onClick={() => handleSelect(entry.parser)}
+                    className={`w-full text-left px-3 py-1.5 text-sm transition-colors
+                      ${
+                        entry.label === label
+                          ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium'
+                          : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700/50'
+                      }`}
+                  >
+                    {entry.label}
+                  </button>
+                ))}
+                <div className="border-t border-gray-100 dark:border-gray-700 my-1" />
+              </>
+            )}
+            <div className="px-3 py-1.5 text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
+              Built-in
+            </div>
+            {builtinParsers.map((entry) => (
+              <button
+                key={entry.label}
+                type="button"
+                onClick={() => handleSelect(entry.parser)}
+                className={`w-full text-left px-3 py-1.5 text-sm transition-colors
+                  ${
+                    entry.label === label
+                      ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium'
+                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700/50'
+                  }`}
+              >
+                {entry.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function FileStatusList({
+  items,
+  availableParsers,
+  onConfigure,
+  onRemove,
+  onChangeParser,
+}: FileStatusListProps) {
   if (items.length === 0) return null
 
   // Expand state per account (keyed by file name + file size + accountNo)
   const [expandedAccounts, setExpandedAccounts] = useState<Set<string>>(new Set())
+  const prevLabelsRef = useRef('')
+
+  // Clear expanded accounts when a file's parser changes (new parser may produce different account numbers)
+  useEffect(() => {
+    const labels = items.map((i) => `${i.file.name}:${i.file.size}:${i.parserLabel}`).join('|')
+    if (prevLabelsRef.current && prevLabelsRef.current !== labels) {
+      setExpandedAccounts(new Set())
+    }
+    prevLabelsRef.current = labels
+  }, [items])
 
   const toggleAccount = (accountKey: string) => {
     setExpandedAccounts((prev) => {
@@ -288,19 +421,26 @@ export function FileStatusList({ items, onConfigure, onRemove }: FileStatusListP
               </div>
               <div className="ml-4 flex items-start gap-2 shrink-0">
                 <div className="flex flex-col items-end gap-0.5">
-                  <StatusBadge status={item.status} />
+                  {/* Parser badge + status row */}
+                  <div className="flex items-center gap-1.5">
+                    {(item.status === 'success' || item.status === 'error') && item.parserLabel && (
+                      <ParserBadge
+                        label={item.parserLabel}
+                        availableParsers={availableParsers}
+                        onSelect={(parser) => onChangeParser(item, parser)}
+                      />
+                    )}
+                    {item.status === 'parsing' && item.parserLabel && (
+                      <span className="flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400 whitespace-nowrap">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        {item.parserLabel}
+                      </span>
+                    )}
+                    <StatusBadge status={item.status} />
+                  </div>
                   {item.status === 'success' && item.transactionCount !== undefined && (
                     <span className="text-xs text-green-600 dark:text-green-400">
                       {item.transactionCount} transactions found
-                    </span>
-                  )}
-                  {item.status === 'success' && item.profileName && (
-                    <span className="text-xs text-blue-600 dark:text-blue-400">Profile: {item.profileName}</span>
-                  )}
-                  {item.status === 'success' && item.statement?.source === 'generic' && !item.profileName && (
-                    <span className="flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-500 max-w-[200px] text-right">
-                      <AlertTriangle className="h-3 w-3 shrink-0" />
-                      Generic fallback — verify data
                     </span>
                   )}
                   {item.status === 'success' &&

--- a/apps/web/src/pages/import/ImportPage.tsx
+++ b/apps/web/src/pages/import/ImportPage.tsx
@@ -10,7 +10,7 @@ import {
   computeHeaderFingerprint,
   generateTransactionHash,
 } from '@lokfi/parser-core'
-import type { CustomParserProfile, Statement } from '@lokfi/parser-core'
+import type { CustomParserProfile, ParserEntry, Statement, StatementParser } from '@lokfi/parser-core'
 import { useLiveQuery } from 'dexie-react-hooks'
 import Papa from 'papaparse'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -55,6 +55,10 @@ export function ImportPage() {
     const predefined = new Set(PREDEFINED_SOURCES)
     return [...new Set(profiles.map((p) => p.source).filter((s) => !predefined.has(s as never)))]
   }, [profiles])
+
+  const availableParsers = useMemo<ParserEntry[]>(() => {
+    return registry.getAll()
+  }, [registry])
 
   // Compute all transaction hashes for the given successful items (same logic as handleImport)
   const computeHashes = useCallback((successItems: FileParseResult[]): string[] => {
@@ -107,14 +111,17 @@ export function ImportPage() {
     files.forEach(async (file) => {
       updateItem(file, { status: 'parsing' })
 
+      let parser: StatementParser | null = null
+      let pdfBuffer: ArrayBuffer | undefined
       try {
         const isPdf = file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')
 
         if (isPdf) {
           // PDF: read as ArrayBuffer, extract text via worker, then parse
           const buffer = await file.arrayBuffer()
+          pdfBuffer = buffer
           const extractedText = await parsePdf(buffer)
-          const parser = registry.getParser(extractedText)
+          parser = registry.getParser(extractedText)
           if (!parser) throw new ParseError('No parser found for this PDF')
           const statement = parser.parse(extractedText)
 
@@ -123,15 +130,17 @@ export function ImportPage() {
             transactionCount: statement.transactions.length,
             statement,
             rawText: extractedText,
+            rawBuffer: buffer,
+            parserLabel: parser.label,
           })
         } else {
           // CSV/text: read as text directly
           const text = await file.text()
-          const parser = registry.getParser(text)
+          parser = registry.getParser(text)
           if (!parser) throw new ParseError('No parser found for this file')
           const statement = parser.parse(text)
 
-          // Check if a custom profile was matched (for badge display)
+          // Check if a custom profile was matched (for profileName backward compat)
           const { data } = Papa.parse<string[]>(text, { skipEmptyLines: true })
           const fingerprint = computeHeaderFingerprint(data as string[][])
           const matchedProfile = profiles.find((p) => p.headerFingerprint === fingerprint)
@@ -142,13 +151,65 @@ export function ImportPage() {
             statement,
             rawText: text,
             profileName: matchedProfile?.name,
+            parserLabel: parser.label,
           })
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
-        updateItem(file, { status: 'error', error: message })
+        updateItem(file, {
+          status: 'error',
+          error: message,
+          rawBuffer: pdfBuffer,
+          parserLabel: parser?.label,
+        })
       }
     })
+  }
+
+  async function handleChangeParser(item: FileParseResult, parser: StatementParser) {
+    updateItem(item.file, { status: 'parsing' })
+
+    let buffer: ArrayBuffer | undefined
+    try {
+      const isPdf = item.file.type === 'application/pdf' || item.file.name.toLowerCase().endsWith('.pdf')
+      let text: string
+
+      if (isPdf) {
+        buffer = item.rawBuffer ?? (await item.file.arrayBuffer())
+        text = await parsePdf(buffer)
+      } else {
+        text = item.rawText ?? (await item.file.text())
+      }
+
+      const statement = parser.parse(text)
+
+      // For CSV: check if the new parser matched a custom profile (profileName backward compat)
+      let matchedProfileName: string | undefined
+      if (!isPdf) {
+        const { data } = Papa.parse<string[]>(text, { skipEmptyLines: true })
+        const fingerprint = computeHeaderFingerprint(data as string[][])
+        const matchedProfile = profiles.find((p) => p.headerFingerprint === fingerprint)
+        matchedProfileName = matchedProfile?.name
+      }
+
+      updateItem(item.file, {
+        status: 'success',
+        transactionCount: statement.transactions.length,
+        statement,
+        rawText: text,
+        rawBuffer: buffer,
+        profileName: matchedProfileName,
+        parserLabel: parser.label,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      updateItem(item.file, {
+        status: 'error',
+        error: message,
+        rawBuffer: buffer,
+        parserLabel: parser.label,
+      })
+    }
   }
 
   async function handleImport() {
@@ -216,6 +277,7 @@ export function ImportPage() {
       statement,
       rawText: configuringItem.rawText,
       profileName: profile.name,
+      parserLabel: profile.name,
     })
     setConfiguringItem(null)
   }
@@ -240,7 +302,13 @@ export function ImportPage() {
           </p>
         </div>
         <UploadZone onFilesAdded={handleFilesAdded} />
-        <FileStatusList items={items} onConfigure={setConfiguringItem} onRemove={handleRemoveItem} />
+        <FileStatusList
+          items={items}
+          availableParsers={availableParsers}
+          onConfigure={setConfiguringItem}
+          onRemove={handleRemoveItem}
+          onChangeParser={handleChangeParser}
+        />
         {importError && <p className="text-sm text-red-600 dark:text-red-400 px-1">{importError}</p>}
         <ImportSummary results={items} dupStats={dupStats} onImport={handleImport} onClear={handleClear} />
       </div>

--- a/packages/parser-core/src/ParserRegistry.test.ts
+++ b/packages/parser-core/src/ParserRegistry.test.ts
@@ -12,7 +12,7 @@ describe('ParserRegistry', () => {
 
   it('returns fallback when no parsers registered but fallback is set', () => {
     const registry = new ParserRegistry()
-    const mockFallback = { detect: () => true, parse: () => ({}) }
+    const mockFallback = { label: 'Fallback', detect: () => true, parse: () => ({}) }
     registry.registerFallback(mockFallback)
     expect(registry.getParser('anything')).toBe(mockFallback)
   })
@@ -44,10 +44,12 @@ describe('ParserRegistry', () => {
     const registry = new ParserRegistry()
 
     const firstParser = {
+      label: 'First',
       detect: (text: string) => text.includes('FIRST'),
       parse: () => ({}),
     }
     const secondParser = {
+      label: 'Second',
       detect: (text: string) => text.includes('SECOND'),
       parse: () => ({}),
     }
@@ -62,10 +64,12 @@ describe('ParserRegistry', () => {
     const registry = new ParserRegistry()
 
     const firstParser = {
+      label: 'First',
       detect: (text: string) => text.includes('NOTHERE'),
       parse: () => ({}),
     }
     const secondParser = {
+      label: 'Second',
       detect: (text: string) => text.includes('SECOND'),
       parse: () => ({}),
     }
@@ -81,7 +85,7 @@ describe('ParserRegistry', () => {
     const registry = new ParserRegistry()
     registry.register(new CdcDebitParser())
 
-    const mockFallback = { detect: () => true, parse: () => ({}) }
+    const mockFallback = { label: 'Fallback', detect: () => true, parse: () => ({}) }
     registry.registerFallback(mockFallback)
 
     const uobText = 'Transaction Date,Transaction Description,Balance\n2025-12-22,Test,-10'
@@ -92,7 +96,7 @@ describe('ParserRegistry', () => {
   // so any registered fallback is returned when no parser matches
   it('returns fallback regardless of its detect result when no parser matches', () => {
     const registry = new ParserRegistry()
-    const mockFallback = { detect: () => false, parse: () => ({}) }
+    const mockFallback = { label: 'Fallback', detect: () => false, parse: () => ({}) }
     registry.registerFallback(mockFallback)
 
     // Fallback is still returned even though detect() would return false

--- a/packages/parser-core/src/ParserRegistry.ts
+++ b/packages/parser-core/src/ParserRegistry.ts
@@ -1,5 +1,10 @@
 import type { StatementParser } from './types'
 
+export interface ParserEntry {
+  label: string
+  parser: StatementParser
+}
+
 export class ParserRegistry {
   private parsers: StatementParser[] = []
   private fallbackParser: StatementParser | null = null
@@ -26,5 +31,17 @@ export class ParserRegistry {
       }
     }
     return this.fallbackParser
+  }
+
+  /**
+   * Returns all registered parsers (including fallback) as labeled entries,
+   * in registration order, for building a parser selection UI.
+   */
+  getAll(): ParserEntry[] {
+    const entries: ParserEntry[] = this.parsers.map((p) => ({ label: p.label, parser: p }))
+    if (this.fallbackParser) {
+      entries.push({ label: this.fallbackParser.label, parser: this.fallbackParser })
+    }
+    return entries
   }
 }

--- a/packages/parser-core/src/extractors/pdf/GenericPdfParser.ts
+++ b/packages/parser-core/src/extractors/pdf/GenericPdfParser.ts
@@ -30,6 +30,7 @@ const AMOUNT_PATTERNS = [
 ]
 
 export class GenericPdfParser implements StatementParser {
+  readonly label = 'Generic PDF'
   detect(text: string): boolean {
     if (!text) return false
     // Must have some date-like patterns and numeric content

--- a/packages/parser-core/src/extractors/pdf/ocbc/OcbcCreditPdfParser.ts
+++ b/packages/parser-core/src/extractors/pdf/ocbc/OcbcCreditPdfParser.ts
@@ -28,6 +28,7 @@ const DATE_RE = /^(\d{1,2})\/(\d{2})\b/
 const AMOUNT_RE = /[(]?[$SGD]*\s*[\d,]+\.\d{2}[)]?/
 
 export class OcbcCreditPdfParser implements StatementParser {
+  readonly label = 'OCBC Credit PDF'
   detect(text: string): boolean {
     if (!text) return false
     const sample = text.slice(0, 3000).toLowerCase()

--- a/packages/parser-core/src/index.ts
+++ b/packages/parser-core/src/index.ts
@@ -14,6 +14,7 @@ export type {
 export { ParseError, PREDEFINED_SOURCES } from './types'
 export { generateTransactionHash } from './hashUtils'
 export { ParserRegistry } from './ParserRegistry'
+export type { ParserEntry } from './ParserRegistry'
 export { CdcDebitParser } from './parsers/cdc/CdcDebitParser'
 export { GenericCsvParser } from './parsers/generic/GenericCsvParser'
 export { CustomCsvParser } from './parsers/generic/CustomCsvParser'

--- a/packages/parser-core/src/parsers/cdc/CdcDebitParser.ts
+++ b/packages/parser-core/src/parsers/cdc/CdcDebitParser.ts
@@ -2,6 +2,7 @@ import Papa from 'papaparse'
 import { type DebitStatement, ParseError, type StatementParser, type Transaction } from '../../types'
 
 export class CdcDebitParser implements StatementParser {
+  readonly label = 'CDC Debit'
   detect(text: string): boolean {
     if (!text) return false
     const firstLine = text.split('\n')[0]?.trim() || ''

--- a/packages/parser-core/src/parsers/generic/CustomCsvParser.ts
+++ b/packages/parser-core/src/parsers/generic/CustomCsvParser.ts
@@ -10,7 +10,11 @@ function resolveIndex(headers: string[], ref: ColumnRef): number {
 }
 
 export class CustomCsvParser implements StatementParser {
-  constructor(private profile: CustomParserProfile) {}
+  readonly label: string
+
+  constructor(private profile: CustomParserProfile) {
+    this.label = this.profile.name
+  }
 
   detect(text: string): boolean {
     if (!text) return false

--- a/packages/parser-core/src/parsers/generic/GenericCsvParser.ts
+++ b/packages/parser-core/src/parsers/generic/GenericCsvParser.ts
@@ -76,6 +76,7 @@ function extractAccountNo(preHeaderRows: string[][]): string {
 // ---------------------------------------------------------------------------
 
 export class GenericCsvParser implements StatementParser {
+  readonly label = 'Generic CSV'
   detect(text: string): boolean {
     if (!text) return false
     const lines = text

--- a/packages/parser-core/src/types.ts
+++ b/packages/parser-core/src/types.ts
@@ -35,6 +35,8 @@ export interface ConsolidatedTransaction extends Transaction {
  * For CSV-first phase, `text` is the raw CSV string.
  */
 export interface StatementParser {
+  /** Human-readable parser name for display in the UI (e.g. "ocbc-nxt-main", "OCBC Credit"). */
+  label: string
   detect(text: string): boolean // non-throwing, fast heuristic
   parse(text: string): Statement // throws ParseError on unexpected format
 }


### PR DESCRIPTION
## Summary

Adds a parser badge to each file in the import file list, showing the current parser label with a dropdown to switch parsers without removing/re-adding files.

### Changes

**`@lokfi/parser-core`:**
- Add `label: string` to `StatementParser` interface — all parser classes now expose a human-readable label
- Add `ParserEntry` type and `getAll()` method to `ParserRegistry` for building parser selection UIs
- Export `ParserEntry` from package

**`@lokfi/web` (Import page):**
- `ParserBadge` component with dropdown, grouped by Custom Profiles / Built-in, click-outside-to-close
- `handleChangeParser` — re-parses file with the selected parser, preserves `rawBuffer` for PDFs
- `expandedAccounts` resets when parser changes (stale account keys)
- `rawBuffer` saved in PDF error paths (avoids redundant file re-read on retry)
- Removed label-comparison skip guard (caused collision when custom profile shared a name with a built-in parser)

### Review fixes applied
- Label collision guard removed
- `buffer` hoisted out of try block for catch access
- `document.body.click` replaced with badge toggle in test