### PR TITLE
feat: holding metrics, Tiger pipeline fixes, and full-clear sync

### DIFF
--- a/.agents/skills/lokfi-db-query/SKILL.md
+++ b/.agents/skills/lokfi-db-query/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: lokfi-db-query
+description: |
+  Query the Lokfi IndexedDB database using the Chrome DevTools MCP in-browser.
+  Provides the full schema, store/index listing, and reusable query patterns for
+  transactions, rules, categories, brokerage data, and more.
+  Auto-activate when user mentions: query database, check data, lokfi db,
+  IndexedDB, what's in the database, show me records, how many transactions,
+  find transactions, lokfi database, indexeddb lokfi, inspect db, peek at db
+license: MIT
+metadata:
+  author: lokfi
+  version: "0.1.0"
+  language: en_US
+---
+
+# Lokfi DB Query — IndexedDB via Chrome DevTools MCP
+
+Query the Lokfi Dexie.js IndexedDB database using `chrome-devtools_evaluate_script`
+in the running app at `http://localhost:5173/`.
+
+## Schema Overview
+
+**Database:** `lokfi` (Dexie.js)
+
+### Store: `transactions`
+| Index | Key |
+|-------|-----|
+| Primary | `id` (UUID) |
+| `hash` | dedup key |
+| `source` | e.g. `"hsbc"` |
+| `accountNo` | account number |
+| `date` | ISO `YYYY-MM-DD` |
+| `category` | category id (set by rules) |
+| `manualCategory` | category id (set by user, overrides rules) |
+| `importedAt` | ISO timestamp |
+
+Fields: `id`, `hash`, `source`, `accountNo`, `date`, `description`, `transactionValue`, `balance?`, `category?`, `manualCategory?`, `importedAt`
+
+### Store: `rules`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+| `priority` | lower = applied first |
+| `category` | category id |
+
+Fields: `id`, `name`, `priority`, `conditions[]`, `category`, `createdAt`
+
+### Store: `categories`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+| `name` | category name |
+
+Fields: `id`, `name`
+
+### Store: `settings`
+| Index | Key |
+|-------|-----|
+| Primary | `key` |
+
+Fields: `key`, `value`
+
+### Store: `budgets`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+| `categoryId` | |
+
+Fields: `id`, `categoryId`, `monthlyLimit`, `updatedAt`
+
+### Store: `customParsers`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+| `headerFingerprint` | |
+| `name` | |
+| `createdAt` | |
+
+### Store: `fxRates`
+| Index | Key |
+|-------|-----|
+| Primary | `[date+base]` |
+
+Fields: `date`, `base`, `rates`
+
+### Store: `brokeragePositions`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+
+### Store: `brokeragePositionExtensions`
+| Index | Key |
+|-------|-----|
+| Primary | `[positionId+key]` |
+| `positionId` | |
+
+### Store: `brokerageTransactions`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+| `orderId` | |
+| `source` | |
+| `symbol` | |
+| `executedAt` | |
+
+### Store: `brokerageFundDetails`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+| `source` | |
+| `classifiedType` | |
+| `symbol` | |
+| `businessDate` | |
+
+### Store: `brokerageAccounts`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+| `source` | |
+| `currency` | |
+
+### Store: `brokerageSyncLog`
+| Index | Key |
+|-------|-----|
+| Primary | `++id` (auto-increment) |
+| `source` | |
+| `category` | |
+| `lastSyncAt` | |
+| `status` | |
+
+### Store: `brokerageCredentials`
+| Index | Key |
+|-------|-----|
+| Primary | `id` |
+
+## Query Method
+
+Use `chrome-devtools_evaluate_script` with an `async () => { ... }` function.
+
+**Pattern:**
+
+```
+async () => {
+  const db = await new Promise((resolve, reject) => {
+    const req = indexedDB.open('lokfi', <version>);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+  const tx = db.transaction('<storeName>', 'readonly');
+  const store = tx.objectStore('<storeName>');
+  const index = store.index('<indexName>'); // optional
+
+  // ... query logic ...
+
+  const results = await new Promise((resolve, reject) => {
+    const req = <request>;
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+  db.close();
+  return results;
+}
+```
+
+## When to Use Reference
+
+| Task | Reference |
+|------|-----------|
+| Count/store summaries | [queries.md](references/queries.md) |
+| Transactions by date range | [queries.md](references/queries.md) |
+| Uncategorized transactions | [queries.md](references/queries.md) |
+| Rules and their categories | [queries.md](references/queries.md) |
+| Brokerage positions/accounts | [queries.md](references/queries.md) |
+| Custom queries on any store | [queries.md](references/queries.md) |

--- a/.agents/skills/lokfi-db-query/references/queries.md
+++ b/.agents/skills/lokfi-db-query/references/queries.md
@@ -1,0 +1,382 @@
+# Lokfi DB Query Reference — Common Query Patterns
+
+All queries use `chrome-devtools_evaluate_script`. Just copy the function body
+into the `function` parameter.
+
+## Getting the Current DB Version
+
+```javascript
+async () => {
+  const dbs = await window.indexedDB.databases();
+  return dbs;
+}
+```
+
+## Record Counts for All Stores
+
+```javascript
+async () => {
+  const dbs = await window.indexedDB.databases();
+  const results = [];
+  for (const info of dbs) {
+    const db = await new Promise((r, x) => {
+      const q = indexedDB.open(info.name, info.version);
+      q.onsuccess = () => r(q.result);
+      q.onerror = () => x(q.error);
+    });
+    const stores = [];
+    for (const name of db.objectStoreNames) {
+      const tx = db.transaction(name, 'readonly');
+      const count = await new Promise((r, x) => {
+        const q = tx.objectStore(name).count();
+        q.onsuccess = () => r(q.result);
+        q.onerror = () => x(q.error);
+      });
+      stores.push({ name, count });
+    }
+    results.push({ name: info.name, stores });
+    db.close();
+  }
+  return results;
+}
+```
+
+## All Transactions (with date ordering)
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('transactions', 'readonly');
+  const store = tx.objectStore('transactions');
+  const all = await new Promise((r, x) => {
+    const q = store.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return all.sort((a, b) => a.date.localeCompare(b.date));
+}
+```
+
+## Transactions by Date Range
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('transactions', 'readonly');
+  const index = tx.objectStore('transactions').index('date');
+  const range = IDBKeyRange.bound('2025-01-01', '2025-12-31');
+  const results = await new Promise((r, x) => {
+    const q = index.getAll(range);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return results;
+}
+```
+
+## Uncategorized Transactions (no category set)
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('transactions', 'readonly');
+  const store = tx.objectStore('transactions');
+  const all = await new Promise((r, x) => {
+    const q = store.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return all.filter(t => !t.category && !t.manualCategory);
+}
+```
+
+## Manually Categorized Transactions
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('transactions', 'readonly');
+  const index = tx.objectStore('transactions').index('manualCategory');
+  const result = await new Promise((r, x) => {
+    const q = index.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return result;
+}
+```
+
+## Transactions by Source (e.g. `"hsbc"`)
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('transactions', 'readonly');
+  const index = tx.objectStore('transactions').index('source');
+  const results = await new Promise((r, x) => {
+    const q = index.getAll('hsbc');
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return results;
+}
+```
+
+## All Rules Ordered by Priority
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('rules', 'readonly');
+  const index = tx.objectStore('rules').index('priority');
+  const rules = await new Promise((r, x) => {
+    const q = index.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return rules;
+}
+```
+
+## Rules for a Specific Category
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('rules', 'readonly');
+  const index = tx.objectStore('rules').index('category');
+  const rules = await new Promise((r, x) => {
+    const q = index.getAll('<category-id>');
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return rules;
+}
+```
+
+## All Categories
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('categories', 'readonly');
+  const store = tx.objectStore('categories');
+  const all = await new Promise((r, x) => {
+    const q = store.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return all;
+}
+```
+
+## Budgets with Category Details (cross-store lookup)
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const budgets = await new Promise((r, x) => {
+    const q = db.transaction('budgets', 'readonly').objectStore('budgets').getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const categories = await new Promise((r, x) => {
+    const q = db.transaction('categories', 'readonly').objectStore('categories').getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  const catMap = Object.fromEntries(categories.map(c => [c.id, c.name]));
+  return budgets.map(b => ({ ...b, categoryName: catMap[b.categoryId] || 'Unknown' }));
+}
+```
+
+## All Brokerage Accounts
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('brokerageAccounts', 'readonly');
+  const store = tx.objectStore('brokerageAccounts');
+  const all = await new Promise((r, x) => {
+    const q = store.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return all;
+}
+```
+
+## Brokerage Positions by Account
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('brokeragePositions', 'readonly');
+  const store = tx.objectStore('brokeragePositions');
+  const all = await new Promise((r, x) => {
+    const q = store.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return all;
+}
+```
+
+## Brokerage Fund Details by Source
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('brokerageFundDetails', 'readonly');
+  const index = tx.objectStore('brokerageFundDetails').index('source');
+  const results = await new Promise((r, x) => {
+    const q = index.getAll('tiger');
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return results;
+}
+```
+
+## Brokerage Sync Log (recent entries)
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('brokerageSyncLog', 'readonly');
+  const store = tx.objectStore('brokerageSyncLog');
+  const all = await new Promise((r, x) => {
+    const q = store.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return all.sort((a, b) => (b.lastSyncAt || '').localeCompare(a.lastSyncAt || ''));
+}
+```
+
+## Custom Query — Any Store, Any Index
+
+Generic pattern to query any store with any index:
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('<storeName>', 'readonly');
+  const src = '<indexName>'
+    ? tx.objectStore('<storeName>').index('<indexName>')
+    : tx.objectStore('<storeName>');
+  const range = '<keyValue>'
+    ? IDBKeyRange.only('<keyValue>')
+    : null;
+  const results = await new Promise((r, x) => {
+    const q = range ? src.getAll(range) : src.getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  return results;
+}
+```
+
+## Transaction Summary by Category (aggregation)
+
+```javascript
+async () => {
+  const db = await new Promise((r, x) => {
+    const q = indexedDB.open('lokfi', 70);
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const tx = db.transaction('transactions', 'readonly');
+  const all = await new Promise((r, x) => {
+    const q = tx.objectStore('transactions').getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  const cats = await new Promise((r, x) => {
+    const q = db.transaction('categories', 'readonly').objectStore('categories').getAll();
+    q.onsuccess = () => r(q.result);
+    q.onerror = () => x(q.error);
+  });
+  db.close();
+  const catMap = Object.fromEntries(cats.map(c => [c.id, c.name]));
+  const summary = {};
+  for (const t of all) {
+    const catId = t.manualCategory || t.category || '__uncategorized__';
+    const catName = catMap[catId] || 'Uncategorized';
+    if (!summary[catName]) summary[catName] = { count: 0, total: 0 };
+    summary[catName].count++;
+    summary[catName].total += t.transactionValue;
+  }
+  return summary;
+}
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,10 @@ Test file pattern: `*.test.ts`. Run single package: `pnpm --filter <pkg> test`.
 
 ## Architecture Notes
 
-- **Data**: Dexie.js (IndexedDB) — not localStorage. `lokfi-db` v2 schema. `manualCategory` on transactions overrides rule engine; never auto-updated by rules.
+- **Data**: 
+  - Dexie.js (IndexedDB) — not localStorage 
+  - `manualCategory` on transactions overrides rule engine; never auto-updated by rules
+  - ensure database schema changes are compatible with importing and exporting backups
 - **PDF parsing**: runs in a Web Worker via `pdfjs-dist`. Worker path set with `new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url)`.
 - **Parser auto-detection**: `detectParser(text)` in `parser-core` tries each bank's `detect()` in order, returns first match.
 - **Rule engine**: Manual Override → General Rules (ascending priority) → Uncategorized. No hash-pinned rules.

--- a/apps/web/bin/test-tiger.ts
+++ b/apps/web/bin/test-tiger.ts
@@ -345,9 +345,111 @@ async function main(): Promise<void> {
     console.log(fail(`Failed to fetch orders: ${err instanceof Error ? err.message : String(err)}`))
   }
 
-  // ── Step 5: Fund Details ───────────────────────────────────────────
+  // ── Step 5: Historical Filled Orders (batched 90-day windows) ──────
 
-  section('5. Fund Details (last 90 days)')
+  section('5. Historical Filled Orders (batched 90d windows)')
+
+  const allIds = new Map<string, string>() // orderId -> window tag to detect overlap
+  const windowFiles: string[] = []
+
+  try {
+    const today = new Date()
+    const windows = [90, 180, 270, 360, 720, 1095, 1825, 3650]
+
+    for (const daysAgo of windows) {
+      const end = new Date(today)
+      end.setDate(end.getDate() - daysAgo + 90) // window end = daysAgo - 90 + 1
+      const start = new Date(today)
+      start.setDate(start.getDate() - daysAgo)
+
+      // Clamp to today
+      if (end > today) end.setTime(today.getTime())
+
+      const startStr = start.toISOString().slice(0, 10)
+      const endStr = end.toISOString().slice(0, 10)
+
+      try {
+        const rawResponse = await client.execute<unknown>({
+          method: 'filled_orders',
+          bizContent: biz({
+            start_date: startStr,
+            end_date: endStr,
+          }),
+        })
+
+        const filename = `filled-orders-${startStr}--${endStr}.json`
+        fs.writeFileSync(filename, JSON.stringify(rawResponse, null, 2))
+        windowFiles.push(filename)
+
+        const orders = unwrapItems(rawResponse as ItemResponse<TigerOrder>)
+
+        // Track order IDs for overlap detection
+        let overlapCount = 0
+        for (const o of orders) {
+          const oid = String(o.id ?? o.orderId ?? '?')
+          const tag = `${startStr}→${endStr}`
+          if (allIds.has(oid)) {
+            overlapCount++
+          }
+          allIds.set(oid, tag)
+        }
+
+        // Date range of returned orders
+        const timestamps = orders
+          .map((o) => (o.latestTime ? new Date(o.latestTime) : null))
+          .filter((d): d is Date => d !== null)
+        const minDate =
+          timestamps.length > 0
+            ? timestamps
+                .reduce((a, b) => (a < b ? a : b))
+                .toISOString()
+                .slice(0, 10)
+            : 'N/A'
+        const maxDate =
+          timestamps.length > 0
+            ? timestamps
+                .reduce((a, b) => (a > b ? a : b))
+                .toISOString()
+                .slice(0, 10)
+            : 'N/A'
+
+        if (orders.length > 0) {
+          console.log(
+            check(`${startStr} → ${endStr}  (${String(daysAgo)}d ago)  → ${bold(String(orders.length))} orders`),
+            dim(` | date range: ${minDate} → ${maxDate}`),
+            overlapCount > 0 ? yellow(` | ⚠ ${overlapCount} IDs already seen in earlier window(s)`) : ''
+          )
+          // Show first & last 2 orders as a spot check
+          const samples = [...orders.slice(0, 2), ...orders.slice(-2)]
+          for (const o of samples) {
+            const t = o.latestTime ? new Date(o.latestTime).toISOString().slice(0, 10) : 'N/A'
+            console.log(
+              dim(
+                `     ${t}  id=${o.id ?? '?'}  ${(o.action ?? '').padEnd(5)} ${(o.symbol ?? '').padEnd(8)} ${(o.secType ?? '').padEnd(4)} qty=${o.totalQuantity}`
+              )
+            )
+          }
+        } else {
+          console.log(dim(`   ${startStr} → ${endStr}  (${String(daysAgo)}d ago)  → 0 orders (API accepted the range)`))
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.log(fail(`${startStr} → ${endStr}  (${String(daysAgo)}d ago)  → ${red(msg)}`))
+      }
+    }
+
+    // ── Overlap summary ─────────────────────────────────────────────
+    const totalUnique = allIds.size
+    console.log(`\n  ${bold('ID overlap summary:')}`)
+    console.log(dim(`   Total unique order IDs across all windows: ${totalUnique}`))
+    console.log(dim(`   Raw JSON saved: ${windowFiles.join(', ')}`))
+  } catch (err) {
+    console.log(fail(`Batched orders test failed: ${err instanceof Error ? err.message : String(err)}`))
+  }
+
+  // ── Step 6: Fund Details ───────────────────────────────────────────
+
+  section('6. Fund Details (last 90 days)')
 
   try {
     const since = new Date()
@@ -388,7 +490,7 @@ async function main(): Promise<void> {
 
   // ── Summary ───────────────────────────────────────────────────────────
 
-  section('Result')
+  section('7. Result')
 
   console.log(`\n  ${green('✓ Connection working')}  — Tiger OpenAPI is accessible with your credentials.\n`)
   console.log(dim('  The lokfi sync pipeline uses these same API calls through the'))

--- a/apps/web/src/lib/brokerage/dexie-sync-adapter.ts
+++ b/apps/web/src/lib/brokerage/dexie-sync-adapter.ts
@@ -45,16 +45,74 @@ export class DexieSyncAdapter implements SyncDatabase {
 
   async appendTransactions(transactions: BrokerageTransaction[]): Promise<void> {
     if (transactions.length === 0) return
-    // Use bulkPut with natural ID — if an orderId already exists, it won't
-    // overwrite because the ID is based on orderId which is unique per fill.
-    // New order fills (same orderId but different execution) would need
-    // a separate mechanism — but the SDK's order transactions use unique IDs.
-    await this.db.brokerageTransactions.bulkPut(transactions)
+
+    // Content-based dedup: defend against the provider returning the same order
+    // with different IDs across sync runs (e.g. from API pagination changes or
+    // chunk-boundary straddling). Uses symbol + action + qty + price + date as
+    // the natural business key for a trade fill.
+    const contentKey = (t: BrokerageTransaction) =>
+      `${t.source}|${t.symbol}|${t.secType ?? 'STK'}|${t.action}|${t.quantity}|${t.price}|${t.executedAt}`
+
+    // Deduplicate within the incoming batch first
+    const seen = new Set<string>()
+    const deduped = transactions.filter((t) => {
+      const key = contentKey(t)
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+    // Cross-check against existing records in the DB (streamed to avoid
+    // loading the entire table into memory for large histories).
+    const existingKeys = new Set<string>()
+    await this.db.brokerageTransactions.each((t) => {
+      existingKeys.add(contentKey(t))
+    })
+    const toInsert = deduped.filter((t) => !existingKeys.has(contentKey(t)))
+
+    if (toInsert.length > 0) {
+      await this.db.brokerageTransactions.bulkPut(toInsert)
+    }
   }
 
   async appendFundDetails(actions: BrokerageFundDetail[]): Promise<void> {
     if (actions.length === 0) return
-    await this.db.brokerageFundDetails.bulkPut(actions)
+
+    const contentKey = (fd: BrokerageFundDetail) =>
+      `${fd.source}|${fd.symbol ?? ''}|${fd.businessDate}|${fd.amount}|${fd.classifiedType}`
+
+    // Deduplicate within the incoming batch (Tiger returns same trade per linked account)
+    const seen = new Set<string>()
+    const deduped = actions.filter((fd) => {
+      const key = contentKey(fd)
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+    // Load existing records in the covered date range to detect cross-sync duplicates
+    const dates = deduped.map((fd) => fd.businessDate).filter(Boolean) as string[]
+    if (dates.length === 0) {
+      await this.db.brokerageFundDetails.bulkPut(deduped)
+      return
+    }
+
+    const minDate = dates.reduce((a, b) => (a < b ? a : b))
+    const maxDate = dates.reduce((a, b) => (a > b ? a : b))
+    const sourceSet = new Set(deduped.map((fd) => fd.source))
+
+    const existing = await this.db.brokerageFundDetails
+      .where('businessDate')
+      .between(minDate, maxDate, true, true)
+      .filter((fd) => sourceSet.has(fd.source))
+      .toArray()
+
+    const existingKeys = new Set(existing.map(contentKey))
+    const toInsert = deduped.filter((fd) => !existingKeys.has(contentKey(fd)))
+
+    if (toInsert.length > 0) {
+      await this.db.brokerageFundDetails.bulkPut(toInsert)
+    }
   }
 
   async upsertAccounts(accounts: BrokerageAccount[]): Promise<void> {

--- a/apps/web/src/lib/brokerage/tiger/tiger-adapter.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-adapter.ts
@@ -57,12 +57,20 @@ export function adaptPosition(raw: TigerPosition): BrokeragePosition {
 
 /**
  * Convert a Tiger Order (which includes fills) to a BrokerageTransaction.
- * Only orders with status 'Filled' or 'PartiallyFilled' produce transactions.
- * Partially filled orders produce one transaction per fill quantity.
+ *
+ * Uses `order.id` as the unique identifier because Tiger's `orderId` field
+ * is always 0 for certain account types (notably global/prime accounts),
+ * causing all orders to collide on key `tiger_0` in the DB.
+ *
+ * Only orders with filledQuantity > 0 produce transactions.
  */
 export function adaptOrder(order: TigerOrder): BrokerageTransaction | null {
-  const orderId = String(order.orderId ?? order.id ?? '')
-  if (!orderId) return null
+  // Use the unique record ID (order.id) as the primary identifier.
+  // order.orderId may be 0 for some account types — skip it as unique key.
+  const rawId = order.id ?? order.orderId
+  if (rawId === undefined || rawId === null) return null
+  const id = String(rawId)
+  if (!id || id === '0') return null
 
   // Only emit transactions for executed order states
   const filledQty = order.filledQuantity ?? 0
@@ -71,15 +79,16 @@ export function adaptOrder(order: TigerOrder): BrokerageTransaction | null {
   const action = normalizeAction(order.action)
 
   return {
-    id: `${SOURCE}_${orderId}`,
+    id: `${SOURCE}_${id}`,
     source: SOURCE,
-    orderId,
+    orderId: id,
     symbol: order.symbol,
     action,
     quantity: filledQty,
     price: order.avgFillPrice ?? 0,
     currency: order.currency || 'USD',
     commission: order.commission,
+    secType: order.secType as BrokerageTransaction['secType'],
     executedAt: order.latestTime ? new Date(order.latestTime).toISOString() : new Date().toISOString(),
   }
 }
@@ -87,19 +96,23 @@ export function adaptOrder(order: TigerOrder): BrokerageTransaction | null {
 // ── Order Transaction Detail → Transaction ────────────────────────────────
 
 export function adaptOrderTransaction(raw: TigerOrderTransaction): BrokerageTransaction | null {
-  const orderId = String(raw.orderId ?? raw.id ?? '')
-  if (!orderId) return null
+  // Use the unique record ID first; orderId may be 0 for some account types.
+  const rawId = raw.id ?? raw.orderId
+  if (rawId === undefined || rawId === null) return null
+  const id = String(rawId)
+  if (!id || id === '0') return null
 
   return {
-    id: `${SOURCE}_txn_${orderId}`,
+    id: `${SOURCE}_txn_${id}`,
     source: SOURCE,
-    orderId,
+    orderId: id,
     symbol: raw.symbol ?? '',
     action: normalizeAction(raw.action ?? ''),
     quantity: raw.quantity ?? 0,
     price: raw.price ?? 0,
     currency: raw.currency || 'USD',
     commission: raw.commission,
+    secType: raw.secType as BrokerageTransaction['secType'],
     executedAt: raw.tradeTime ? new Date(raw.tradeTime).toISOString() : new Date().toISOString(),
   }
 }

--- a/apps/web/src/lib/brokerage/tiger/tiger-provider.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-provider.ts
@@ -94,50 +94,76 @@ export class TigerProvider implements BrokerageProvider {
     return tigerPositions.map(adaptPosition)
   }
 
-  async fetchTransactions(since: Date, _onProgress?: ProviderProgress): Promise<BrokerageTransaction[]> {
-    // Strategy:
-    // 1. Chunk the date range into ≤90-day windows (Tiger API limit)
-    // 2. Fetch completed orders (status = Filled) for each chunk
-    // 3. Adapt each to normalized transaction
-    // 4. Deduplicate across chunks (safety net)
-    // 5. Cache filled orders for enrichment use in fetchFundDetails
-
+  /**
+   * Fetch filled orders in 90-day chunks with pagination.
+   *
+   * The Tiger `filled_orders` API:
+   *   - Requires start_date/end_date (≤90 day window per call)
+   *   - Supports page_token-based pagination (default limit ~100, max 300)
+   *   - Returns { items: TigerOrder[], nextPageToken?: string }
+   *
+   * Strategy:
+   *   1. Split the full date range into ≤90-day windows
+   *   2. For each window, paginate via page_token until exhausted
+   *   3. Adapt each TigerOrder → BrokerageTransaction
+   *   4. Deduplicate across chunks (safety net for boundary-straddling orders)
+   *   5. Cache filled orders for fund_detail enrichment
+   */
+  async fetchTransactions(since: Date, onProgress?: ProviderProgress): Promise<BrokerageTransaction[]> {
     const endDate = new Date()
     const chunks = this.getDateChunks(since, endDate, TRANSACTIONS_CHUNK_DAYS)
 
     const allTransactions: BrokerageTransaction[] = []
 
-    for (const { start, end } of chunks) {
-      const filledOrdersRaw = await this.client.execute<{ items?: TigerOrder[] }>({
-        method: 'filled_orders',
-        bizContent: this.bizContent({
+    for (let chunkIdx = 0; chunkIdx < chunks.length; chunkIdx++) {
+      const { start, end } = chunks[chunkIdx]
+      const label = `${start.toISOString().slice(0, 10)} → ${end.toISOString().slice(0, 10)}`
+      onProgress?.(`Fetching transactions chunk ${chunkIdx + 1}/${chunks.length} (${label})`)
+
+      let pageToken: string | undefined
+      let hasMore = true
+
+      while (hasMore) {
+        const bizContent: Record<string, unknown> = {
           start_date: start.toISOString().slice(0, 10),
           end_date: end.toISOString().slice(0, 10),
-        }),
-      })
-
-      const filledOrders = filledOrdersRaw?.items ?? []
-
-      for (const order of filledOrders) {
-        const txn = adaptOrder(order)
-        if (txn && new Date(txn.executedAt) >= since) {
-          allTransactions.push(txn)
+          limit: 300, // Max allowed per page to minimize round trips
+        }
+        if (pageToken) {
+          bizContent.page_token = pageToken
         }
 
-        // Also fetch detailed transaction records per order
-        if (order.orderId) {
-          try {
-            const detail = await this.client.execute<{ items?: unknown[] }>({
-              method: 'order_transactions',
-              bizContent: this.bizContent({ id: order.orderId }),
-            })
-            const txnItems = detail?.items ?? []
-            if (txnItems.length > 0) {
-              // Per-fill transaction records — extends the order-level data
-            }
-          } catch {
-            // Non-critical — order-level data is sufficient
+        // Response shape: { items: TigerOrder[], nextPageToken?: string }
+        // or in rare cases a direct TigerOrder[] (be defensive)
+        type FilledOrdersResponse = {
+          items?: TigerOrder[]
+          nextPageToken?: string
+        }
+
+        const response = await this.client.execute<FilledOrdersResponse | TigerOrder[]>({
+          method: 'filled_orders',
+          bizContent: this.bizContent(bizContent),
+        })
+
+        const orders = Array.isArray(response) ? response : (response?.items ?? [])
+
+        for (const order of orders) {
+          const txn = adaptOrder(order)
+          if (txn && new Date(txn.executedAt) >= since) {
+            allTransactions.push(txn)
           }
+        }
+
+        // Check for next page (only in object responses, not raw arrays)
+        if (!Array.isArray(response)) {
+          const nextToken = response?.nextPageToken
+          if (nextToken && nextToken.length > 0) {
+            pageToken = nextToken
+          } else {
+            hasMore = false
+          }
+        } else {
+          hasMore = false
         }
       }
     }

--- a/apps/web/src/lib/brokerage/unifiedTransactions.ts
+++ b/apps/web/src/lib/brokerage/unifiedTransactions.ts
@@ -92,6 +92,23 @@ export function mapBankTransaction(t: DbTransaction): UnifiedTransactionRow {
   }
 }
 
+/** Label quantity with the correct unit name based on security type */
+function labelQty(qty: number, secType?: string): string {
+  if (secType === 'OPT' || secType === 'FUT' || secType === 'FOP') {
+    return `${qty} ${qty === 1 ? 'contract' : 'contracts'}`
+  }
+  return `${qty} ${qty === 1 ? 'share' : 'shares'}`
+}
+
+/**
+ * Return a secType suffix for non-stock trades so the instrument type is
+ * always visible in the description (e.g. "(OPT)" for option trades).
+ * Omitted for STK / undefined since those are the common default.
+ */
+function secTypeTag(secType?: string): string {
+  return secType && secType !== 'STK' ? ` (${secType})` : ''
+}
+
 /** Map a BrokerageTransaction to one or more UnifiedTransactionRows */
 export function mapBrokerageTransaction(t: BrokerageTransaction): UnifiedTransactionRow[] {
   const rows: UnifiedTransactionRow[] = []
@@ -101,14 +118,16 @@ export function mapBrokerageTransaction(t: BrokerageTransaction): UnifiedTransac
   const commission = t.commission ?? 0
   const total = t.action === 'BUY' ? -(gross + commission) : gross - commission
 
+  const qtyLabel = labelQty(t.quantity, t.secType)
+
   rows.push({
     id: `bt-${t.id}`,
     source: t.source,
     date,
-    description: `${t.action} ${t.symbol} — ${t.quantity} shares @ ${fmtCurrency(t.price, t.currency)}`,
+    description: `${t.action} ${t.symbol} — ${qtyLabel} @ ${fmtCurrency(t.price, t.currency)}${secTypeTag(t.secType)}`,
     amount: total,
     currency: t.currency,
-    type: t.action,
+    type: t.action as UnifiedTransactionRow['type'],
     symbol: t.symbol,
     quantity: t.quantity,
     price: t.price,
@@ -177,15 +196,18 @@ export function mapFundDetail(d: BrokerageFundDetail): UnifiedTransactionRow[] {
 
     case 'TRADE': {
       if (d.quantity !== undefined && d.price !== undefined && d.action) {
-        // Enriched trade — show as BUY/SELL row with per-share detail
+        // Enriched trade — show as BUY/SELL row with per-share detail.
+        // Fund details lack secType so we always say "shares" here.
         const gross = d.quantity * d.price
         const comm = d.commission ?? 0
         const total = d.action === 'BUY' ? -(gross + comm) : gross - comm
+        const qtyLabel = `${d.quantity} ${d.quantity === 1 ? 'share' : 'shares'}`
+
         rows.push({
           id: `fd-${d.id}`,
           source: d.source,
           date,
-          description: `${d.action} ${d.symbol || ''} — ${d.quantity} shares @ ${fmtCurrency(d.price, d.currency)}`,
+          description: `${d.action} ${d.symbol || ''} — ${qtyLabel} @ ${fmtCurrency(d.price, d.currency)}`,
           amount: total,
           currency: d.currency,
           type: d.action,
@@ -439,7 +461,16 @@ export async function fetchUnifiedRows(filters: Filters): Promise<{ rows: Unifie
 
     // Fund details
     const fundDetails = await db.brokerageFundDetails.toArray()
+    // Only skip enriched TRADEs when we actually have transactions for the
+    // same symbol. If the transaction sync failed (or is empty), enriched
+    // TRADEs are the only representation of those trades and must be shown.
+    const txnSymbols = new Set(txns.map((t) => t.symbol))
     for (const fd of fundDetails) {
+      if (fd.classifiedType === 'TRADE' && fd.quantity !== undefined && fd.price !== undefined && fd.action) {
+        if (txnSymbols.has(fd.symbol ?? '')) {
+          continue
+        }
+      }
       for (const row of mapFundDetail(fd)) {
         if (filterBrokerageRow(row, filters)) {
           brokerageRows.push(row)

--- a/apps/web/src/lib/brokerage/unifiedTransactions.ts
+++ b/apps/web/src/lib/brokerage/unifiedTransactions.ts
@@ -21,6 +21,25 @@ export type BrokerageRowType =
   | 'UNKNOWN'
   | 'REBATE'
 
+/** Display labels for brokerage row types, used in filters and table badges */
+export const BROKERAGE_TYPE_LABELS: Record<string, string> = {
+  BUY: 'Buy',
+  SELL: 'Sell',
+  DIVIDEND: 'Dividend',
+  FEE: 'Fee',
+  SPLIT: 'Split',
+  RIGHTS: 'Rights',
+  OTHER: 'Other',
+  DIVIDEND_TAX: 'Div. Tax',
+  TRANSFER_IN: 'Transfer In',
+  TRANSFER_OUT: 'Transfer Out',
+  DEPOSIT: 'Deposit',
+  WITHDRAWAL: 'Withdrawal',
+  CURRENCY_EXCHANGE: 'Currency Exchange',
+  UNKNOWN: 'Unknown',
+  REBATE: 'Rebate',
+}
+
 /** Common row shape for both bank and brokerage transactions in the UI */
 export interface UnifiedTransactionRow {
   id: string

--- a/apps/web/src/lib/db/db.ts
+++ b/apps/web/src/lib/db/db.ts
@@ -125,6 +125,31 @@ export class LokfiDatabase extends Dexie {
       brokerageFundDetails: 'id, source, classifiedType, symbol, businessDate',
     })
 
+    // v8 migration: deduplicate brokerageFundDetails by content key
+    // Tiger returns the same trade once per linked account; overlapping sync
+    // ranges also produce duplicate records. Clean up any that snuck in.
+    this.version(8).upgrade(async (trans) => {
+      const allRecords: BrokerageFundDetail[] = await trans.table('brokerageFundDetails').toArray()
+      const contentKey = (fd: BrokerageFundDetail) =>
+        `${fd.source}|${fd.symbol ?? ''}|${fd.businessDate}|${fd.amount}|${fd.classifiedType}`
+
+      const seen = new Map<string, string>()
+      const toDelete: string[] = []
+
+      for (const fd of allRecords) {
+        const key = contentKey(fd)
+        if (seen.has(key)) {
+          toDelete.push(fd.id)
+        } else {
+          seen.set(key, fd.id)
+        }
+      }
+
+      if (toDelete.length > 0) {
+        await trans.table('brokerageFundDetails').bulkDelete(toDelete)
+      }
+    })
+
     // Seed default categories on initial DB creation
     this.on('populate', () => {
       this.categories.bulkAdd(defaultCategories)

--- a/apps/web/src/pages/investments/ClosedPositionsTab.tsx
+++ b/apps/web/src/pages/investments/ClosedPositionsTab.tsx
@@ -1,0 +1,434 @@
+import type { BrokerageFundDetail, BrokerageTransaction } from '@lokfi/brokerage-core'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { useMemo, useState } from 'react'
+import { db } from '../../lib/db/db'
+import { convertAmount } from '../../lib/fx/convert'
+import type { CurrencyOption } from './currencyPreference'
+import { getDividends } from './holdingCalculations'
+
+interface ClosedPositionsTabProps {
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+  fxLastUpdated: string | null
+  fxError: string | null
+}
+
+interface ClosedPosition {
+  symbol: string
+  totalBuyQty: number
+  totalSellQty: number
+  totalCost: number
+  totalProceeds: number
+  totalCommission: number
+  realizedPnl: number
+  dividends: number
+  totalReturnPct: number | null
+  firstBuyDate: string
+  lastSellDate: string
+  currency: string
+}
+
+const fmtCache = new Map<string, Intl.NumberFormat>()
+function getFormatter(currency: string): Intl.NumberFormat {
+  if (!fmtCache.has(currency)) {
+    fmtCache.set(
+      currency,
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })
+    )
+  }
+  return fmtCache.get(currency)!
+}
+
+function formatCurrency(amount: number, currency: string): string {
+  return getFormatter(currency).format(amount)
+}
+
+function pnClass(pnl: number) {
+  if (pnl > 0) return 'text-emerald-600 dark:text-emerald-400'
+  if (pnl < 0) return 'text-red-600 dark:text-red-400'
+  return 'text-gray-500 dark:text-gray-400'
+}
+
+function formatDate(dateStr: string): string {
+  try {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  } catch {
+    return '—'
+  }
+}
+
+export function ClosedPositionsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError }: ClosedPositionsTabProps) {
+  const [sortKey, setSortKey] = useState<'symbol' | 'cost' | 'proceeds' | 'pnl' | 'dividends' | 'return' | 'date'>(
+    'pnl'
+  )
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
+
+  const allTransactions = useLiveQuery(() => db.brokerageTransactions.toArray(), []) ?? []
+  const allPositions = useLiveQuery(() => db.brokeragePositions.toArray(), []) ?? []
+
+  // Fund details for TRADE (closed position P&L) and DIVIDEND/DIVIDEND_TAX
+  const allFundDetails =
+    useLiveQuery(
+      () => db.brokerageFundDetails.where('classifiedType').anyOf(['TRADE', 'DIVIDEND', 'DIVIDEND_TAX']).toArray(),
+      []
+    ) ?? []
+
+  // Symbols that have current open positions — exclude from closed list
+  const openSymbols = useMemo(() => new Set(allPositions.map((p) => p.symbol)), [allPositions])
+
+  const closedPositions = useMemo(() => {
+    // Use fund detail TRADE records as primary data source (full history).
+    // BrokerageTransaction only covers the lookback window (default 90 days),
+    // while fund details go back to account inception.
+    const tradeFds = allFundDetails.filter((fd) => fd.classifiedType === 'TRADE' && !openSymbols.has(fd.symbol ?? ''))
+
+    // Supplement with brokerage transactions for quantity and date data
+    const txnsBySymbol = new Map<string, BrokerageTransaction[]>()
+    for (const t of allTransactions) {
+      if (openSymbols.has(t.symbol)) continue
+      if (!txnsBySymbol.has(t.symbol)) txnsBySymbol.set(t.symbol, [])
+      txnsBySymbol.get(t.symbol)!.push(t)
+    }
+
+    // Group fund detail TRADE records by symbol
+    const bySymbol = new Map<string, BrokerageFundDetail[]>()
+    for (const fd of tradeFds) {
+      const sym = fd.symbol ?? ''
+      if (!bySymbol.has(sym)) bySymbol.set(sym, [])
+      bySymbol.get(sym)!.push(fd)
+    }
+
+    // Also include symbols that only appear in transactions (with secType='STK')
+    for (const t of allTransactions) {
+      if (openSymbols.has(t.symbol)) continue
+      if (t.secType !== 'STK' && t.secType != null) continue
+      if (!bySymbol.has(t.symbol)) bySymbol.set(t.symbol, [])
+    }
+
+    const results: ClosedPosition[] = []
+    for (const [symbol, fds] of bySymbol) {
+      let totalCost = 0
+      let totalProceeds = 0
+      let firstBuyDate = ''
+      let lastSellDate = ''
+      let currency = 'USD'
+
+      // Fund detail TRADE amounts: negative = BUY (cost), positive = SELL (proceeds)
+      for (const fd of fds) {
+        if (fd.classifiedType !== 'TRADE') continue
+        currency = fd.currency
+        if (fd.amount < 0) {
+          totalCost += Math.abs(fd.amount)
+          const d = fd.businessDate
+          if (!firstBuyDate || d < firstBuyDate) firstBuyDate = d
+        } else {
+          totalProceeds += fd.amount
+          const d = fd.businessDate
+          if (!lastSellDate || d > lastSellDate) lastSellDate = d
+        }
+      }
+
+      // Also consider transaction data for better date range
+      const txns = txnsBySymbol.get(symbol) ?? []
+      let totalBuyQty = 0
+      let totalSellQty = 0
+      let totalCommission = 0
+      for (const t of txns) {
+        if (t.secType !== 'STK' && t.secType != null) continue
+        totalCommission += t.commission ?? 0
+        if (t.action === 'BUY') {
+          totalBuyQty += t.quantity
+          const d = t.executedAt
+          if (!firstBuyDate || d < firstBuyDate) firstBuyDate = d
+        } else {
+          totalSellQty += Math.abs(t.quantity)
+          const d = t.executedAt
+          if (!lastSellDate || d > lastSellDate) lastSellDate = d
+        }
+      }
+
+      // Skip symbols that have transaction records but no fund detail TRADEs
+      // (indicates missing data rather than a real closed position)
+      if (totalCost === 0 && totalProceeds === 0) continue
+
+      // Net dividends for this symbol (lifetime) — use getDividends to ensure
+      // tax reversals are capped so they never inflate net beyond gross.
+      const dividends = getDividends(symbol, allFundDetails)
+
+      const realizedPnl = totalProceeds - totalCost
+      const totalReturnPct = totalCost > 0 ? ((realizedPnl + dividends) / totalCost) * 100 : null
+
+      results.push({
+        symbol,
+        totalBuyQty,
+        totalSellQty,
+        totalCost,
+        totalProceeds,
+        totalCommission,
+        realizedPnl,
+        dividends,
+        totalReturnPct,
+        firstBuyDate,
+        lastSellDate,
+        currency,
+      })
+    }
+
+    return results
+  }, [allFundDetails, allTransactions, openSymbols])
+
+  // Sort
+  const sorted = useMemo(() => {
+    const arr = [...closedPositions]
+    function getCmp(a: ClosedPosition, b: ClosedPosition): number {
+      switch (sortKey) {
+        case 'symbol':
+          return a.symbol.localeCompare(b.symbol)
+        case 'cost':
+          return a.totalCost - b.totalCost
+        case 'proceeds':
+          return a.totalProceeds - b.totalProceeds
+        case 'pnl':
+          return a.realizedPnl - b.realizedPnl
+        case 'dividends':
+          return a.dividends - b.dividends
+        case 'return':
+          return (a.totalReturnPct ?? 0) - (b.totalReturnPct ?? 0)
+        case 'date':
+          return a.lastSellDate.localeCompare(b.lastSellDate)
+      }
+    }
+    arr.sort((a, b) => (sortDir === 'asc' ? 1 : -1) * getCmp(a, b))
+    return arr
+  }, [closedPositions, sortKey, sortDir])
+
+  function handleSort(key: typeof sortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir(key === 'pnl' || key === 'return' || key === 'date' ? 'desc' : 'asc')
+    }
+    setPage(0)
+  }
+
+  // Pagination
+  const [page, setPage] = useState(0)
+  const perPage = 50
+  const totalPages = Math.max(1, Math.ceil(sorted.length / perPage))
+  const safePage = Math.min(page, totalPages - 1)
+  const paginated = sorted.slice(safePage * perPage, (safePage + 1) * perPage)
+
+  // Summary KPIs
+  const showConverted = preferredCurrency !== 'Original' && fxRates != null
+  const displayCurrency = showConverted ? preferredCurrency : 'USD'
+
+  const totalRealizedPnl = sorted.reduce((s, p) => {
+    const v = showConverted ? convertAmount(p.realizedPnl, p.currency, preferredCurrency, fxRates!) : p.realizedPnl
+    return s + v
+  }, 0)
+  const totalDividends = sorted.reduce((s, p) => {
+    const v = showConverted ? convertAmount(p.dividends, p.currency, preferredCurrency, fxRates!) : p.dividends
+    return s + v
+  }, 0)
+  const totalCost = sorted.reduce((s, p) => {
+    const v = showConverted ? convertAmount(p.totalCost, p.currency, preferredCurrency, fxRates!) : p.totalCost
+    return s + v
+  }, 0)
+  const totalReturnPct = totalCost > 0 ? ((totalRealizedPnl + totalDividends) / totalCost) * 100 : null
+
+  // ── Empty state ─────────────────────────────────────────────────────────
+
+  if (closedPositions.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+        <p className="text-lg font-medium mb-2">No closed positions yet</p>
+        <p className="text-sm">Sync your brokerage account to see realized P&L for positions you've fully exited.</p>
+      </div>
+    )
+  }
+
+  // ── Main render ────────────────────────────────────────────────────────
+
+  const kpiCardClass = 'rounded-xl border p-5'
+  const monoClass = 'font-mono tabular-nums'
+  const headerCellClass =
+    'px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200'
+  const cellClass = 'px-3 py-2.5 text-right font-mono tabular-nums text-gray-900 dark:text-white'
+
+  return (
+    <div className="space-y-6">
+      {/* FX status */}
+      {showConverted && fxLastUpdated && (
+        <div className="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500 px-1">
+          <span>
+            FX rates as of {new Date(fxLastUpdated).toLocaleString()} · displaying in{' '}
+            <span className="font-medium text-gray-600 dark:text-gray-300">{preferredCurrency}</span>
+          </span>
+          {fxError && <span className="text-amber-600 dark:text-amber-400">· FX error: {fxError}</span>}
+        </div>
+      )}
+
+      {/* Summary KPIs */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className={kpiCardClass} style={{ backgroundColor: 'var(--bg-sidebar)', borderColor: 'var(--border)' }}>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">Positions Closed</p>
+          <p className={`text-xl font-semibold ${monoClass}`} style={{ color: 'var(--text-primary)' }}>
+            {closedPositions.length}
+          </p>
+        </div>
+        <div className={kpiCardClass} style={{ backgroundColor: 'var(--bg-sidebar)', borderColor: 'var(--border)' }}>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">Realized P&L</p>
+          <p className={`text-xl font-semibold ${monoClass} ${pnClass(totalRealizedPnl)}`}>
+            {formatCurrency(totalRealizedPnl, displayCurrency)}
+          </p>
+        </div>
+        <div className={kpiCardClass} style={{ backgroundColor: 'var(--bg-sidebar)', borderColor: 'var(--border)' }}>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">Total Dividends</p>
+          <p className={`text-xl font-semibold ${monoClass}`} style={{ color: 'var(--text-primary)' }}>
+            {formatCurrency(totalDividends, displayCurrency)}
+          </p>
+        </div>
+        <div className={kpiCardClass} style={{ backgroundColor: 'var(--bg-sidebar)', borderColor: 'var(--border)' }}>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">Total Return</p>
+          <p className={`text-xl font-semibold ${monoClass} ${pnClass(totalReturnPct ?? 0)}`}>
+            {totalReturnPct != null ? `${totalReturnPct >= 0 ? '+' : ''}${totalReturnPct.toFixed(2)}%` : '—'}
+          </p>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-xl border overflow-hidden" style={{ borderColor: 'var(--border)' }}>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b" style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}>
+                <th
+                  className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+                  onClick={() => handleSort('symbol')}
+                >
+                  <span className="inline-flex items-center gap-1">
+                    Symbol{sortKey === 'symbol' && (sortDir === 'asc' ? ' ▲' : ' ▼')}
+                  </span>
+                </th>
+                <th className={headerCellClass}>Shares (B/S)</th>
+                <th className={headerCellClass} onClick={() => handleSort('cost')}>
+                  <span className="inline-flex items-center gap-1">
+                    Total Cost{sortKey === 'cost' && (sortDir === 'asc' ? ' ▲' : ' ▼')}
+                  </span>
+                </th>
+                <th className={headerCellClass} onClick={() => handleSort('proceeds')}>
+                  <span className="inline-flex items-center gap-1">
+                    Proceeds{sortKey === 'proceeds' && (sortDir === 'asc' ? ' ▲' : ' ▼')}
+                  </span>
+                </th>
+                <th className={headerCellClass} onClick={() => handleSort('pnl')}>
+                  <span className="inline-flex items-center gap-1">
+                    Realized P&L{sortKey === 'pnl' && (sortDir === 'asc' ? ' ▲' : ' ▼')}
+                  </span>
+                </th>
+                <th className={headerCellClass} onClick={() => handleSort('dividends')}>
+                  <span className="inline-flex items-center gap-1">
+                    Dividends{sortKey === 'dividends' && (sortDir === 'asc' ? ' ▲' : ' ▼')}
+                  </span>
+                </th>
+                <th className={headerCellClass} onClick={() => handleSort('return')}>
+                  <span className="inline-flex items-center gap-1">
+                    Total Return{sortKey === 'return' && (sortDir === 'asc' ? ' ▲' : ' ▼')}
+                  </span>
+                </th>
+                <th className={headerCellClass} onClick={() => handleSort('date')}>
+                  <span className="inline-flex items-center gap-1">
+                    Held{sortKey === 'date' && (sortDir === 'asc' ? ' ▲' : ' ▼')}
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginated.map((pos, i) => {
+                const isEven = i % 2 === 0
+                return (
+                  <tr
+                    key={pos.symbol}
+                    className="border-b last:border-0"
+                    style={{
+                      borderColor: 'var(--border)',
+                      backgroundColor: isEven ? 'var(--bg)' : 'var(--bg-sidebar)',
+                    }}
+                  >
+                    <td className="px-3 py-2.5 font-medium text-gray-900 dark:text-white">{pos.symbol}</td>
+                    <td className={cellClass}>
+                      {pos.totalBuyQty} / {pos.totalSellQty}
+                    </td>
+                    <td className={`${cellClass} text-red-600 dark:text-red-400`}>
+                      {formatCurrency(pos.totalCost, pos.currency)}
+                    </td>
+                    <td className={`${cellClass} text-emerald-600 dark:text-emerald-400`}>
+                      {formatCurrency(pos.totalProceeds, pos.currency)}
+                    </td>
+                    <td className={`${cellClass} font-medium ${pnClass(pos.realizedPnl)}`}>
+                      {formatCurrency(pos.realizedPnl, pos.currency)}
+                    </td>
+                    <td className={cellClass}>
+                      {pos.dividends !== 0 ? formatCurrency(pos.dividends, pos.currency) : '—'}
+                    </td>
+                    <td className={`${cellClass} font-medium ${pnClass(pos.totalReturnPct ?? 0)}`}>
+                      {pos.totalReturnPct != null
+                        ? `${pos.totalReturnPct >= 0 ? '+' : ''}${pos.totalReturnPct.toFixed(2)}%`
+                        : '—'}
+                    </td>
+                    <td className="px-3 py-2.5 text-right text-xs text-gray-500 dark:text-gray-400">
+                      {pos.firstBuyDate ? formatDate(pos.firstBuyDate) : '—'}
+                      {pos.lastSellDate ? ` – ${formatDate(pos.lastSellDate)}` : ''}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+        {sorted.length > perPage && (
+          <div
+            className="flex items-center justify-between px-4 py-2.5 border-t text-xs text-gray-400 dark:text-gray-500"
+            style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+          >
+            <span>
+              Showing {safePage * perPage + 1}–{Math.min((safePage + 1) * perPage, sorted.length)} of {sorted.length}{' '}
+              {sorted.length === 1 ? 'position' : 'positions'}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={safePage === 0}
+                className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
+                style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+              >
+                ← Prev
+              </button>
+              <span className="text-gray-500">
+                {safePage + 1} / {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={safePage === totalPages - 1}
+                className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
+                style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+              >
+                Next →
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/investments/HoldingsTab.tsx
+++ b/apps/web/src/pages/investments/HoldingsTab.tsx
@@ -2,10 +2,12 @@ import type { BrokeragePosition } from '@lokfi/brokerage-core'
 import { Link } from '@tanstack/react-router'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { ChevronDown, ChevronRight, Info } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { db } from '../../lib/db/db'
 import { convertAmount } from '../../lib/fx/convert'
 import type { CurrencyOption } from './currencyPreference'
+import { getAdjustedMetrics } from './holdingCalculations'
+import type { HoldingMetrics } from './holdingCalculations'
 
 interface HoldingsTabProps {
   preferredCurrency: CurrencyOption
@@ -20,10 +22,20 @@ interface PositionRow {
   mktValue: number
   pnl: number
   isEstimated: boolean
+  totalOptionPremiums: number
+  totalDividends: number
+  adjCostBasisPerShare: number | null
+  totalReturnPct: number | null
+  realisedPnl: number
+  unrealisedPnl: number
+  totalPnl: number
+  isIncomplete: boolean
+  diagnostics: string[]
 }
 
 interface HoldingDetailRowProps {
   row: PositionRow
+  variant?: 'stock' | 'derivative'
 }
 
 const fmtCache = new Map<string, Intl.NumberFormat>()
@@ -46,7 +58,7 @@ function formatCurrency(amount: number, currency: string): string {
   return getFormatter(currency).format(amount)
 }
 
-function HoldingDetailRow({ row }: HoldingDetailRowProps) {
+function HoldingDetailRow({ row, variant = 'stock' }: HoldingDetailRowProps) {
   const { position } = row
   const isDerivative = position.secType != null && DERIVATIVE_TYPES.has(position.secType)
   const costBasis = position.quantity * position.avgCost
@@ -72,7 +84,7 @@ function HoldingDetailRow({ row }: HoldingDetailRowProps) {
 
   return (
     <tr className="border-b" style={{ borderColor: 'var(--border)' }}>
-      <td colSpan={7} className="px-4 py-3">
+      <td colSpan={variant === 'stock' ? 13 : 7} className="px-4 py-3">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
           {/* Left column */}
           <div className="space-y-2">
@@ -102,8 +114,14 @@ function HoldingDetailRow({ row }: HoldingDetailRowProps) {
             )}
             <div className="flex gap-2">
               <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Adjusted Cost</span>
-              <span className="text-gray-900 dark:text-white">
-                Adjusted cost basis (including options) is coming in a future update.
+              <span className="text-gray-900 dark:text-white font-mono tabular-nums">
+                {(() => {
+                  const rawCostBasis = position.quantity * position.avgCost
+                  const adjTotal = rawCostBasis - row.totalOptionPremiums - row.totalDividends
+                  return row.adjCostBasisPerShare != null
+                    ? `${formatCurrency(adjTotal, position.currency)} (${formatCurrency(row.adjCostBasisPerShare, position.currency)}/sh)`
+                    : '—'
+                })()}
               </span>
             </div>
           </div>
@@ -155,6 +173,20 @@ function HoldingDetailRow({ row }: HoldingDetailRowProps) {
             </div>
           </div>
         </div>
+
+        {/* Diagnostics: surface data quality concerns */}
+        {row.diagnostics.length > 0 && (
+          <div className="mt-3 pt-3 border-t space-y-1" style={{ borderColor: 'var(--border)' }}>
+            <div className="text-amber-600 dark:text-amber-400 text-xs uppercase tracking-wider font-semibold mb-1">
+              Diagnostics
+            </div>
+            {row.diagnostics.map((msg, i) => (
+              <div key={i} className="text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
+                {msg}
+              </div>
+            ))}
+          </div>
+        )}
       </td>
     </tr>
   )
@@ -187,7 +219,19 @@ function HoldingsTable({
   const perPage = 100
 
   // Sorting
-  type HoldSortKey = 'symbol' | 'qty' | 'avgCost' | 'mktPrice' | 'mktValue' | 'pnl'
+  type HoldSortKey =
+    | 'symbol'
+    | 'qty'
+    | 'avgCost'
+    | 'mktPrice'
+    | 'mktValue'
+    | 'pnl'
+    | 'premium'
+    | 'dividend'
+    | 'adjCost'
+    | 'totalReturn'
+    | 'realised'
+    | 'totalPnl'
   const [sortKey, setSortKey] = useState<HoldSortKey | null>(null)
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
 
@@ -225,6 +269,24 @@ function HoldingsTable({
         case 'pnl':
           cmp = a.pnl - b.pnl
           break
+        case 'premium':
+          cmp = a.totalOptionPremiums - b.totalOptionPremiums
+          break
+        case 'dividend':
+          cmp = a.totalDividends - b.totalDividends
+          break
+        case 'adjCost':
+          cmp = (a.adjCostBasisPerShare ?? 0) - (b.adjCostBasisPerShare ?? 0)
+          break
+        case 'totalReturn':
+          cmp = (a.totalReturnPct ?? 0) - (b.totalReturnPct ?? 0)
+          break
+        case 'realised':
+          cmp = a.realisedPnl - b.realisedPnl
+          break
+        case 'totalPnl':
+          cmp = a.totalPnl - b.totalPnl
+          break
       }
       return sortDir === 'asc' ? cmp : -cmp
     })
@@ -254,6 +316,7 @@ function HoldingsTable({
             <th
               className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
               onClick={() => handleSort('symbol')}
+              title="Ticker symbol"
             >
               <span className="inline-flex items-center gap-1">
                 {isDerivative ? 'Underlying' : 'Symbol'}
@@ -263,6 +326,7 @@ function HoldingsTable({
             <th
               className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
               onClick={() => handleSort('qty')}
+              title={isDerivative ? 'Number of contracts held' : 'Number of shares currently held'}
             >
               <span className="inline-flex items-center gap-1">
                 {isDerivative ? 'Contracts' : 'Qty'}
@@ -272,6 +336,11 @@ function HoldingsTable({
             <th
               className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
               onClick={() => handleSort('avgCost')}
+              title={
+                isDerivative
+                  ? 'Broker-reported average price per contract'
+                  : 'Broker-reported average cost per share (split-adjusted)'
+              }
             >
               <span className="inline-flex items-center gap-1">
                 {isDerivative ? 'Avg Price' : 'Avg Cost'}
@@ -281,6 +350,7 @@ function HoldingsTable({
             <th
               className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
               onClick={() => handleSort('mktPrice')}
+              title={isDerivative ? 'Last traded price per contract' : 'Last traded market price per share'}
             >
               <span className="inline-flex items-center gap-1">
                 {isDerivative ? 'Last Price' : 'Mkt Price'}
@@ -290,6 +360,11 @@ function HoldingsTable({
             <th
               className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
               onClick={() => handleSort('mktValue')}
+              title={
+                isDerivative
+                  ? 'Market value = contracts × last price × multiplier'
+                  : 'Market value = qty × market price'
+              }
             >
               <span className="inline-flex items-center gap-1">
                 Mkt Value
@@ -299,12 +374,77 @@ function HoldingsTable({
             <th
               className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
               onClick={() => handleSort('pnl')}
+               title="Unrealised P&L on current position"
             >
               <span className="inline-flex items-center gap-1">
-                P&L
+                Unreal. P&L
                 {sortKey === 'pnl' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
               </span>
             </th>
+            {!isDerivative && (
+              <>
+                <th
+                  className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+                  onClick={() => handleSort('realised')}
+                  title="Realised gain/loss from closed stock sales only (excl. dividends & premiums)"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    Realised P&L
+                    {sortKey === 'realised' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                  </span>
+                </th>
+                <th
+                  className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+                  onClick={() => handleSort('premium')}
+                   title="Net option premiums received = sold premiums − bought-back premiums (covers closed trades when transaction history is available)"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    Prem Recv'd
+                    {sortKey === 'premium' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                  </span>
+                </th>
+                <th
+                  className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+                  onClick={() => handleSort('dividend')}
+                  title="Net dividends received (lifetime) = gross dividends − withholding tax. Tax reversals are capped at prior withholding."
+                >
+                  <span className="inline-flex items-center gap-1">
+                    Div Recv'd
+                    {sortKey === 'dividend' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                  </span>
+                </th>
+                <th
+                  className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+                  onClick={() => handleSort('adjCost')}
+                  title="Adjusted cost per share = (raw cost basis − premiums − dividends) ÷ qty"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    Adj Cost/Sh
+                    {sortKey === 'adjCost' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                  </span>
+                </th>
+                <th
+                  className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+                  onClick={() => handleSort('totalPnl')}
+                  title="All-time total = stock sale P&L + premiums + dividends + unrealised P&L"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    Total P&L
+                    {sortKey === 'totalPnl' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                  </span>
+                </th>
+                <th
+                  className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+                  onClick={() => handleSort('totalReturn')}
+                   title="Total return % = (Mkt Value + Realised P&L + Prem Recv'd + Div Recv'd − cost basis) ÷ cost basis × 100, where cost basis = Avg Cost × Qty"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    Total Return
+                    {sortKey === 'totalReturn' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                  </span>
+                </th>
+              </>
+            )}
           </tr>
         </thead>
         {paginatedPositions.map((row, i) => {
@@ -400,45 +540,79 @@ function HoldingsTable({
                     )}
                   </div>
                 </td>
+                {!isDerivative && (
+                  <>
+                    <td
+                      className={`px-3 py-2.5 text-right font-mono tabular-nums font-medium ${pnClass(row.realisedPnl)}`}
+                    >
+                      {row.realisedPnl !== 0 || !row.isIncomplete
+                        ? formatCurrency(row.realisedPnl, position.currency)
+                        : '—'}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                      {row.totalOptionPremiums > 0 ? formatCurrency(row.totalOptionPremiums, position.currency) : '—'}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                      {row.totalDividends > 0 ? formatCurrency(row.totalDividends, position.currency) : '—'}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                      {row.adjCostBasisPerShare != null
+                        ? formatCurrency(row.adjCostBasisPerShare, position.currency)
+                        : '—'}
+                    </td>
+                    <td
+                      className={`px-3 py-2.5 text-right font-mono tabular-nums font-medium ${pnClass(row.totalPnl)}`}
+                    >
+                      {formatCurrency(row.totalPnl, position.currency)}
+                    </td>
+                    <td
+                      className={`px-3 py-2.5 text-right font-mono tabular-nums font-medium ${pnClass(row.totalReturnPct ?? 0)}`}
+                    >
+                      {row.totalReturnPct != null
+                        ? `${row.totalReturnPct >= 0 ? '+' : ''}${row.totalReturnPct.toFixed(2)}%`
+                        : '—'}
+                    </td>
+                  </>
+                )}
               </tr>
-              {isExpanded && <HoldingDetailRow row={row} />}
+              {isExpanded && <HoldingDetailRow row={row} variant={variant} />}
             </tbody>
           )
         })}
-       </table>
-       {sortedPositions.length > perPage && (
-         <div
-           className="flex items-center justify-between px-4 py-2.5 border-t text-xs text-gray-400 dark:text-gray-500"
-           style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
-         >
-           <span>
-             Showing {safePage * perPage + 1}–{Math.min((safePage + 1) * perPage, sortedPositions.length)} of{' '}
-             {sortedPositions.length} {sortedPositions.length === 1 ? 'position' : 'positions'}
-           </span>
-           <div className="flex items-center gap-2">
-             <button
-               onClick={() => setPage((p) => Math.max(0, p - 1))}
-               disabled={safePage === 0}
-               className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
-               style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
-             >
-               ← Prev
-             </button>
-             <span className="text-gray-500">
-               {safePage + 1} / {totalPages}
-             </span>
-             <button
-               onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-               disabled={safePage === totalPages - 1}
-               className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
-               style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
-             >
-               Next →
-             </button>
-           </div>
-         </div>
-       )}
-     </div>
+      </table>
+      {sortedPositions.length > perPage && (
+        <div
+          className="flex items-center justify-between px-4 py-2.5 border-t text-xs text-gray-400 dark:text-gray-500"
+          style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+        >
+          <span>
+            Showing {safePage * perPage + 1}–{Math.min((safePage + 1) * perPage, sortedPositions.length)} of{' '}
+            {sortedPositions.length} {sortedPositions.length === 1 ? 'position' : 'positions'}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={safePage === 0}
+              className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
+              style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+            >
+              ← Prev
+            </button>
+            <span className="text-gray-500">
+              {safePage + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={safePage === totalPages - 1}
+              className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
+              style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+            >
+              Next →
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -471,7 +645,7 @@ function isDerivative(p: BrokeragePosition): boolean {
   return DERIVATIVE_TYPES.has(p.secType)
 }
 
-function toRow(position: BrokeragePosition): PositionRow {
+function toRow(position: BrokeragePosition, metrics?: HoldingMetrics): PositionRow {
   const mktValue = position.marketValue ?? position.quantity * position.avgCost
   // For derivatives, divide by multiplier so Last Price is per-share (consistent
   // with avgCost). Tiger reports marketValue as total contract value, so for
@@ -481,7 +655,22 @@ function toRow(position: BrokeragePosition): PositionRow {
   // Use authoritative unrealizedPnl from the API when available.
   const pnl = position.unrealizedPnl ?? (mktPrice - position.avgCost) * position.quantity * mult
   const isEstimated = !position.marketValue
-  return { position, mktPrice, mktValue, pnl, isEstimated }
+  return {
+    position,
+    mktPrice,
+    mktValue,
+    pnl,
+    isEstimated,
+    totalOptionPremiums: metrics?.totalOptionPremiums ?? 0,
+    totalDividends: metrics?.totalDividends ?? 0,
+    adjCostBasisPerShare: metrics?.adjCostBasisPerShare ?? null,
+    totalReturnPct: metrics?.totalReturnPct ?? null,
+    realisedPnl: metrics?.realisedStockPnl ?? 0,
+    unrealisedPnl: metrics?.unrealisedPnl ?? pnl,
+    totalPnl: metrics?.totalPnl ?? pnl,
+    isIncomplete: metrics?.isIncomplete ?? false,
+    diagnostics: metrics?.diagnostics ?? [],
+  }
 }
 
 function CollapsibleCurrencyGroup({
@@ -584,12 +773,39 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
 
   const allPositions = useLiveQuery(() => db.brokeragePositions.toArray(), [])
 
+  // Fund detail records for dividends and TRADE (used as fallback when
+  // transaction buy history is incomplete — fund details accumulate across syncs)
+  const fundDetails =
+    useLiveQuery(
+      () => db.brokerageFundDetails.where('classifiedType').anyOf(['TRADE', 'DIVIDEND', 'DIVIDEND_TAX']).toArray(),
+      []
+    ) ?? []
+
+  // All brokerage transactions for option premium calculation (includes secType for
+  // filtering option vs. stock trades, covering both open and closed positions)
+  const allTransactions = useLiveQuery(() => db.brokerageTransactions.toArray(), []) ?? []
+
+  // Option positions for premium calculation (fallback when transactions lack secType)
+  const optionPositions = useMemo(() => (allPositions ?? []).filter((p) => p.secType === 'OPT'), [allPositions])
+
+  // Precompute holding metrics for each stock position
+  const metricsByPositionId = useMemo(() => {
+    const map = new Map<string, HoldingMetrics>()
+    for (const p of allPositions ?? []) {
+      if (isStockLike(p)) {
+        map.set(p.id, getAdjustedMetrics(p, optionPositions, fundDetails, allTransactions))
+      }
+    }
+    return map
+  }, [allPositions, optionPositions, fundDetails, allTransactions])
+
   // Split into stock-like and derivatives
   const stockRows: PositionRow[] = []
   const derivativeRows: PositionRow[] = []
 
   for (const p of allPositions ?? []) {
-    const row = toRow(p)
+    const metrics = metricsByPositionId.get(p.id)
+    const row = toRow(p, metrics)
     if (isStockLike(p)) {
       stockRows.push(row)
     } else if (isDerivative(p)) {

--- a/apps/web/src/pages/investments/HoldingsTab.tsx
+++ b/apps/web/src/pages/investments/HoldingsTab.tsx
@@ -182,6 +182,58 @@ function HoldingsTable({
     })
   }
 
+  // Pagination
+  const [page, setPage] = useState(0)
+  const perPage = 100
+
+  // Sorting
+  type HoldSortKey = 'symbol' | 'qty' | 'avgCost' | 'mktPrice' | 'mktValue' | 'pnl'
+  const [sortKey, setSortKey] = useState<HoldSortKey | null>(null)
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
+
+  function handleSort(key: HoldSortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir(key === 'symbol' ? 'asc' : 'desc')
+    }
+    setPage(0)
+  }
+
+  // Sorted data
+  const sortedPositions = (() => {
+    if (!sortKey) return positions
+    return [...positions].sort((a, b) => {
+      let cmp = 0
+      switch (sortKey) {
+        case 'symbol':
+          cmp = a.position.symbol.localeCompare(b.position.symbol)
+          break
+        case 'qty':
+          cmp = a.position.quantity - b.position.quantity
+          break
+        case 'avgCost':
+          cmp = a.position.avgCost - b.position.avgCost
+          break
+        case 'mktPrice':
+          cmp = a.mktPrice - b.mktPrice
+          break
+        case 'mktValue':
+          cmp = a.mktValue - b.mktValue
+          break
+        case 'pnl':
+          cmp = a.pnl - b.pnl
+          break
+      }
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+  })()
+
+  const totalPages = Math.max(1, Math.ceil(sortedPositions.length / perPage))
+  const safePage = Math.min(page, totalPages - 1)
+  const paginatedPositions = sortedPositions.slice(safePage * perPage, (safePage + 1) * perPage)
+
   const showConverted = preferredCurrency !== 'Original' && fxRates != null
   const prefCurrency = preferredCurrency === 'Original' ? (positions[0]?.position.currency ?? 'USD') : preferredCurrency
 
@@ -199,27 +251,63 @@ function HoldingsTable({
         <thead>
           <tr className="border-b" style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}>
             <th className="w-8 px-3 py-2.5" />
-            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              {isDerivative ? 'Underlying' : 'Symbol'}
+            <th
+              className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+              onClick={() => handleSort('symbol')}
+            >
+              <span className="inline-flex items-center gap-1">
+                {isDerivative ? 'Underlying' : 'Symbol'}
+                {sortKey === 'symbol' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+              </span>
             </th>
-            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              {isDerivative ? 'Contracts' : 'Qty'}
+            <th
+              className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+              onClick={() => handleSort('qty')}
+            >
+              <span className="inline-flex items-center gap-1">
+                {isDerivative ? 'Contracts' : 'Qty'}
+                {sortKey === 'qty' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+              </span>
             </th>
-            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              {isDerivative ? 'Avg Price' : 'Avg Cost'}
+            <th
+              className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+              onClick={() => handleSort('avgCost')}
+            >
+              <span className="inline-flex items-center gap-1">
+                {isDerivative ? 'Avg Price' : 'Avg Cost'}
+                {sortKey === 'avgCost' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+              </span>
             </th>
-            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              {isDerivative ? 'Last Price' : 'Mkt Price'}
+            <th
+              className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+              onClick={() => handleSort('mktPrice')}
+            >
+              <span className="inline-flex items-center gap-1">
+                {isDerivative ? 'Last Price' : 'Mkt Price'}
+                {sortKey === 'mktPrice' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+              </span>
             </th>
-            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Mkt Value
+            <th
+              className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+              onClick={() => handleSort('mktValue')}
+            >
+              <span className="inline-flex items-center gap-1">
+                Mkt Value
+                {sortKey === 'mktValue' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+              </span>
             </th>
-            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              P&L
+            <th
+              className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200"
+              onClick={() => handleSort('pnl')}
+            >
+              <span className="inline-flex items-center gap-1">
+                P&L
+                {sortKey === 'pnl' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+              </span>
             </th>
           </tr>
         </thead>
-        {positions.map((row, i) => {
+        {paginatedPositions.map((row, i) => {
           const { position } = row
           const isEven = i % 2 === 0
           const isExpanded = expandedIds.has(position.id)
@@ -317,8 +405,40 @@ function HoldingsTable({
             </tbody>
           )
         })}
-      </table>
-    </div>
+       </table>
+       {sortedPositions.length > perPage && (
+         <div
+           className="flex items-center justify-between px-4 py-2.5 border-t text-xs text-gray-400 dark:text-gray-500"
+           style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+         >
+           <span>
+             Showing {safePage * perPage + 1}–{Math.min((safePage + 1) * perPage, sortedPositions.length)} of{' '}
+             {sortedPositions.length} {sortedPositions.length === 1 ? 'position' : 'positions'}
+           </span>
+           <div className="flex items-center gap-2">
+             <button
+               onClick={() => setPage((p) => Math.max(0, p - 1))}
+               disabled={safePage === 0}
+               className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
+               style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+             >
+               ← Prev
+             </button>
+             <span className="text-gray-500">
+               {safePage + 1} / {totalPages}
+             </span>
+             <button
+               onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+               disabled={safePage === totalPages - 1}
+               className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
+               style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+             >
+               Next →
+             </button>
+           </div>
+         </div>
+       )}
+     </div>
   )
 }
 

--- a/apps/web/src/pages/investments/InvestmentsPage.tsx
+++ b/apps/web/src/pages/investments/InvestmentsPage.tsx
@@ -15,6 +15,7 @@ import { SyncProgressBar } from '../../lib/brokerage/SyncProgressBar'
 import type { SyncProgress } from '../../lib/brokerage/sync-orchestrator'
 import { db } from '../../lib/db/db'
 import { useFxRates } from '../../lib/fx/useFxRates'
+import { ClosedPositionsTab } from './ClosedPositionsTab'
 import { CurrencySelector } from './CurrencySelector'
 import { DividendsTab } from './DividendsTab'
 import { HoldingsTab } from './HoldingsTab'
@@ -30,7 +31,7 @@ export function InvestmentsPage() {
   const location = useLocation()
   const searchParams = new URLSearchParams(location.search)
   const tab = searchParams.get('tab') || 'overview'
-  const validTabs = ['overview', 'holdings', 'transactions', 'dividends']
+  const validTabs = ['overview', 'holdings', 'closed', 'transactions', 'dividends']
   const activeTab = validTabs.includes(tab) ? tab : 'overview'
 
   const [preferredCurrency, setPreferredCurrencyState] = useState<CurrencyOption>('SGD')
@@ -157,7 +158,7 @@ export function InvestmentsPage() {
   }
 
   return (
-    <div className="max-w-5xl mx-auto px-5 py-8">
+    <div className="max-w-7xl mx-auto px-3 py-8">
       {/* Page header */}
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-xl text-gray-900 dark:text-white">Investments</h1>
@@ -254,6 +255,14 @@ export function InvestmentsPage() {
         )}
         {activeTab === 'holdings' && (
           <HoldingsTab
+            preferredCurrency={preferredCurrency}
+            fxRates={fxRates}
+            fxLastUpdated={fxLastUpdated}
+            fxError={fxError}
+          />
+        )}
+        {activeTab === 'closed' && (
+          <ClosedPositionsTab
             preferredCurrency={preferredCurrency}
             fxRates={fxRates}
             fxLastUpdated={fxLastUpdated}

--- a/apps/web/src/pages/investments/InvestmentsTabs.tsx
+++ b/apps/web/src/pages/investments/InvestmentsTabs.tsx
@@ -1,6 +1,7 @@
 const TABS = [
   { id: 'overview', label: 'Overview' },
   { id: 'holdings', label: 'Holdings' },
+  { id: 'closed', label: 'Closed' },
   { id: 'transactions', label: 'Transactions' },
   { id: 'dividends', label: 'Dividends' },
 ] as const

--- a/apps/web/src/pages/investments/InvestmentsTransactionsTab.tsx
+++ b/apps/web/src/pages/investments/InvestmentsTransactionsTab.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from '@tanstack/react-router'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { Link as LinkIcon } from 'lucide-react'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { type UnifiedTransactionRow, fetchUnifiedRows } from '../../lib/brokerage/unifiedTransactions'
 import { db } from '../../lib/db/db'
 import { defaultFilters } from '../transactions/filterTypes'
@@ -138,6 +138,64 @@ export function InvestmentsTransactionsTab() {
   const dividendRows = useMemo(() => rows.filter((r) => r.type === 'DIVIDEND'), [rows])
   const dividendBankLinks = useDividendBankLinks(dividendRows)
 
+  // ── Sorting ──────────────────────────────────────────────────────────────────
+
+  type TxnSortKey = 'date' | 'description' | 'type' | 'symbol' | 'quantity' | 'price' | 'amount' | 'source'
+  const [sortKey, setSortKey] = useState<TxnSortKey | null>('date')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
+
+  function handleTxnSort(key: TxnSortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir(key === 'date' ? 'desc' : 'asc')
+    }
+    setPage(0)
+  }
+
+  const sortedRows = (() => {
+    if (!sortKey) return rows
+    return [...rows].sort((a, b) => {
+      let cmp = 0
+      switch (sortKey) {
+        case 'date':
+          cmp = a.date.localeCompare(b.date)
+          break
+        case 'description':
+          cmp = a.description.localeCompare(b.description)
+          break
+        case 'type':
+          cmp = a.type.localeCompare(b.type)
+          break
+        case 'symbol':
+          cmp = (a.symbol ?? '').localeCompare(b.symbol ?? '')
+          break
+        case 'quantity':
+          cmp = (a.quantity ?? 0) - (b.quantity ?? 0)
+          break
+        case 'price':
+          cmp = (a.price ?? 0) - (b.price ?? 0)
+          break
+        case 'amount':
+          cmp = a.amount - b.amount
+          break
+        case 'source':
+          cmp = a.source.localeCompare(b.source)
+          break
+      }
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+  })()
+
+  // ── Pagination ───────────────────────────────────────────────────────────────
+
+  const [page, setPage] = useState(0)
+  const perPage = 100
+  const totalPages = Math.max(1, Math.ceil(sortedRows.length / perPage))
+  const safePage = Math.min(page, totalPages - 1)
+  const paginatedRows = sortedRows.slice(safePage * perPage, (safePage + 1) * perPage)
+
   if (rows.length === 0) {
     return (
       <div className="text-center py-12">
@@ -157,37 +215,37 @@ export function InvestmentsTransactionsTab() {
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b" style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}>
-            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Date
-            </th>
-            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Description
-            </th>
-            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Type
-            </th>
-            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Symbol
-            </th>
-            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Quantity
-            </th>
-            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Price
-            </th>
-            <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Amount
-            </th>
-            <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Source
-            </th>
+            {(['date', 'description', 'type', 'symbol', 'quantity', 'price', 'amount', 'source'] as const).map(
+              (key) => {
+                const isActive = sortKey === key
+                const isRight = key === 'quantity' || key === 'price' || key === 'amount'
+                const label = key.charAt(0).toUpperCase() + key.slice(1)
+                // Skip category — not sortable (computed cell)
+                return (
+                  <th
+                    key={key}
+                    className={`px-3 py-2.5 ${
+                      isRight ? 'text-right' : 'text-left'
+                    } text-xs font-semibold uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 ${
+                      isActive ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'
+                    }`}
+                    onClick={() => handleTxnSort(key)}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {label}
+                      {isActive && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                    </span>
+                  </th>
+                )
+              }
+            )}
             <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
               Category
             </th>
           </tr>
         </thead>
         <tbody>
-          {rows.map((t, i) => {
+          {paginatedRows.map((t, i) => {
             const isEven = i % 2 === 0
             const linkedBankId = dividendBankLinks.get(t.id)
 
@@ -265,14 +323,36 @@ export function InvestmentsTransactionsTab() {
         </tbody>
       </table>
 
-      {/* Footer */}
+      {/* Footer / Pagination */}
       <div
         className="flex items-center justify-between px-4 py-2.5 border-t text-xs text-gray-400 dark:text-gray-500"
         style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
       >
         <span>
-          Showing {rows.length} of {total} transactions
+          Showing {safePage * perPage + 1}–{Math.min((safePage + 1) * perPage, sortedRows.length)} of {total}{' '}
+          transactions
         </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={safePage === 0}
+            className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
+            style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+          >
+            ← Prev
+          </button>
+          <span className="text-gray-500">
+            {safePage + 1} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={safePage === totalPages - 1}
+            className="px-2 py-1 rounded border transition-colors disabled:opacity-30 disabled:cursor-not-allowed hover:border-amber-500 hover:text-amber-600"
+            style={{ borderColor: 'var(--border)', color: 'var(--accent)' }}
+          >
+            Next →
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/pages/investments/holdingCalculations.test.ts
+++ b/apps/web/src/pages/investments/holdingCalculations.test.ts
@@ -1,0 +1,355 @@
+import type { BrokerageFundDetail, BrokerageTransaction } from '@lokfi/brokerage-core'
+import { describe, expect, it } from 'vitest'
+import { computeStockSalePnL, getDividends } from './holdingCalculations'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tx(
+  id: string,
+  symbol: string,
+  action: 'BUY' | 'SELL',
+  qty: number,
+  price: number,
+  commission = 0
+): BrokerageTransaction {
+  return {
+    id,
+    source: 'test',
+    orderId: id,
+    symbol,
+    action,
+    quantity: qty,
+    price,
+    currency: 'USD',
+    commission,
+    executedAt: '2025-01-15T00:00:00Z',
+  }
+}
+
+/** Negative amount = BUY, positive amount = SELL (mirrors real fund detail cash flow) */
+function fundDetail(id: string, symbol: string, amount: number): BrokerageFundDetail {
+  return {
+    id,
+    source: 'test',
+    rawType: 'Trade',
+    classifiedType: 'TRADE',
+    symbol,
+    amount,
+    currency: 'USD',
+    businessDate: '2025-01-15',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// computeStockSalePnL
+// ---------------------------------------------------------------------------
+
+describe('computeStockSalePnL', () => {
+  // ─── Scenario 1: Complete transaction history ──────────────────────────────
+  it('computes P&L when all buys are tracked (totalBuyCost >= brokerCostBasisRemaining)', () => {
+    // Position: 100 shares @ $50 → brokerCostBasisRemaining = $5,000
+    // Transactions: $6,000 in buys, 1 sell of 20 @ $60 = $1,200
+    const transactions: BrokerageTransaction[] = [
+      tx('b1', 'AAPL', 'BUY', 50, 40), // $2,000
+      tx('b2', 'AAPL', 'BUY', 50, 80), // $4,000
+      tx('s1', 'AAPL', 'SELL', 20, 60), // $1,200
+    ]
+
+    const result = computeStockSalePnL('AAPL', 100, 50, transactions)
+
+    expect(result.totalBuyCost).toBe(6000)
+    expect(result.totalSellQty).toBe(20)
+    expect(result.totalSellProceeds).toBe(1200)
+    expect(result.costOfSoldShares).toBe(1000) // 6000 - 5000
+    expect(result.realisedStockPnl).toBe(200) // 1200 - 1000
+    expect(result.isIncomplete).toBe(false)
+  })
+
+  // ─── Scenario 2: Incomplete transactions + fund details fallback ──────────
+  it('uses fund details as fallback when transaction history is incomplete', () => {
+    // Position: 100 shares @ $50 → brokerCostBasisRemaining = $5,000
+    // Transactions: $3,000 in buys (< $5,000 — incomplete)
+    // Fund details: $8,000 in buys, $2,000 in sells — covers gap
+    const transactions: BrokerageTransaction[] = [
+      tx('b1', 'AAPL', 'BUY', 20, 50), // $1,000
+      tx('b2', 'AAPL', 'BUY', 20, 100), // $2,000
+      tx('s1', 'AAPL', 'SELL', 10, 55), // $550
+    ]
+
+    const fundDetails: BrokerageFundDetail[] = [
+      fundDetail('fd1', 'AAPL', -5000), // buy $5,000
+      fundDetail('fd2', 'AAPL', -3000), // buy $3,000
+      fundDetail('fd3', 'AAPL', 2000), // sell $2,000
+    ]
+
+    const result = computeStockSalePnL('AAPL', 100, 50, transactions, fundDetails)
+
+    // Fund details used exclusively — replaces both buy cost and sell proceeds
+    expect(result.totalBuyCost).toBe(8000)
+    expect(result.totalSellProceeds).toBe(2000)
+    // totalSellQty still from transactions (not overwritten by fund details)
+    expect(result.totalSellQty).toBe(10)
+    expect(result.costOfSoldShares).toBe(3000) // 8000 - 5000
+    expect(result.realisedStockPnl).toBe(-1000) // 2000 - 3000
+    expect(result.isIncomplete).toBe(false)
+  })
+
+  // ─── Scenario 3: MSTY — no buy transactions, fund details cover everything ─
+  it('uses fund details when no buy transactions exist (MSTY scenario)', () => {
+    // Position: 200 shares @ $25 → brokerCostBasisRemaining = $5,000
+    // Transactions: empty (all trades outside the 90-day lookback window)
+    // Fund details: $8,000 in buys, $2,000 in sells — full history
+    const transactions: BrokerageTransaction[] = []
+
+    const fundDetails: BrokerageFundDetail[] = [
+      fundDetail('fd1', 'MSTY', -3000), // buy $3,000
+      fundDetail('fd2', 'MSTY', -5000), // buy $5,000
+      fundDetail('fd3', 'MSTY', 2000), // sell $2,000
+    ]
+
+    const result = computeStockSalePnL('MSTY', 200, 25, transactions, fundDetails)
+
+    expect(result.totalBuyCost).toBe(8000)
+    expect(result.totalSellQty).toBe(0)
+    expect(result.totalSellProceeds).toBe(2000)
+    expect(result.costOfSoldShares).toBe(3000) // 8000 - 5000
+    expect(result.realisedStockPnl).toBe(-1000) // 2000 - 3000
+    expect(result.isIncomplete).toBe(false)
+  })
+
+  // ─── Scenario 4: MSTY with recent sells, no buys in window ────────────────
+  it('uses fund details for both buys and sells when only sells are in transaction history', () => {
+    // Position: 200 shares @ $25 → brokerCostBasisRemaining = $5,000
+    // Transactions: 1 sell (recent), no buys (outside window)
+    // Fund details: $8,000 in buys, $2,500 in sells (full history including recent)
+    const transactions: BrokerageTransaction[] = [
+      tx('s1', 'MSTY', 'SELL', 50, 30), // $1,500
+    ]
+
+    const fundDetails: BrokerageFundDetail[] = [
+      fundDetail('fd1', 'MSTY', -3000), // buy $3,000
+      fundDetail('fd2', 'MSTY', -5000), // buy $5,000
+      fundDetail('fd3', 'MSTY', 2500), // sell $2,500
+    ]
+
+    const result = computeStockSalePnL('MSTY', 200, 25, transactions, fundDetails)
+
+    // totalSellQty comes from transactions (not overwritten)
+    expect(result.totalSellQty).toBe(50)
+    // totalBuyCost and totalSellProceeds are overwritten by fund details
+    expect(result.totalBuyCost).toBe(8000)
+    expect(result.totalSellProceeds).toBe(2500)
+    expect(result.costOfSoldShares).toBe(3000) // 8000 - 5000
+    expect(result.realisedStockPnl).toBe(-500) // 2500 - 3000
+    expect(result.isIncomplete).toBe(false)
+  })
+
+  // ─── Scenario 5: No fund details available ─────────────────────────────────
+  it('returns incomplete when no fund details are provided and no transactions exist', () => {
+    const transactions: BrokerageTransaction[] = []
+
+    const result = computeStockSalePnL('AAPL', 100, 50, transactions)
+
+    expect(result.totalBuyCost).toBe(0)
+    expect(result.totalSellQty).toBe(0)
+    expect(result.totalSellProceeds).toBe(0)
+    expect(result.costOfSoldShares).toBe(0)
+    expect(result.realisedStockPnl).toBe(0)
+    expect(result.isIncomplete).toBe(true)
+  })
+
+  it('returns incomplete when no fund details provided but sells exist in transaction history', () => {
+    // Sells exist but buys are missing (outside lookback)
+    const transactions: BrokerageTransaction[] = [
+      tx('s1', 'AAPL', 'SELL', 10, 60), // $600
+    ]
+
+    const result = computeStockSalePnL('AAPL', 100, 50, transactions)
+
+    expect(result.totalBuyCost).toBe(0)
+    expect(result.totalSellQty).toBe(10)
+    expect(result.totalSellProceeds).toBe(600)
+    expect(result.costOfSoldShares).toBe(0)
+    expect(result.realisedStockPnl).toBe(0)
+    expect(result.isIncomplete).toBe(true)
+  })
+
+  it('returns incomplete when fund details array is empty', () => {
+    // Empty array is truthy — enters fund details branch but finds no TRADE records
+    const transactions: BrokerageTransaction[] = []
+
+    const result = computeStockSalePnL('AAPL', 100, 50, transactions, [])
+
+    expect(result.totalBuyCost).toBe(0)
+    expect(result.totalSellQty).toBe(0)
+    expect(result.totalSellProceeds).toBe(0)
+    expect(result.costOfSoldShares).toBe(0)
+    expect(result.realisedStockPnl).toBe(0)
+    expect(result.isIncomplete).toBe(true)
+  })
+
+  // ─── Scenario 6: Has option positions (fund details blocked) ──────────────
+  it('returns incomplete when hasOptionPositions is true and transaction history is insufficient', () => {
+    // Position: 50 shares @ $100 → brokerCostBasisRemaining = $5,000
+    // Transactions: $3,000 in buys (< $5,000 — incomplete)
+    // hasOptionPositions: true — fund details cannot be used to supplement
+    const transactions: BrokerageTransaction[] = [
+      tx('b1', 'AAPL', 'BUY', 20, 150), // $3,000
+      tx('s1', 'AAPL', 'SELL', 10, 200), // $2,000
+    ]
+
+    const fundDetails: BrokerageFundDetail[] = [
+      fundDetail('fd1', 'AAPL', -8000), // buy $8,000
+    ]
+
+    const result = computeStockSalePnL('AAPL', 50, 100, transactions, fundDetails, true)
+
+    // Fund details blocked — falls to else branch
+    expect(result.totalBuyCost).toBe(3000) // still from transactions
+    expect(result.totalSellProceeds).toBe(2000) // still from transactions
+    expect(result.totalSellQty).toBe(10)
+    expect(result.costOfSoldShares).toBe(1000) // avgCost * totalSellQty = 100 * 10
+    expect(result.realisedStockPnl).toBe(0)
+    expect(result.isIncomplete).toBe(true)
+  })
+
+  // ─── Scenario 7: Fund details insufficient ─────────────────────────────────
+  it('returns incomplete when fund details cannot cover the cost basis', () => {
+    // Position: 100 shares @ $50 → brokerCostBasisRemaining = $5,000
+    // Transactions: $2,000 in buys (< $5,000)
+    // Fund details: $3,000 in buys (< $5,000)
+    const transactions: BrokerageTransaction[] = [
+      tx('b1', 'AAPL', 'BUY', 10, 200), // $2,000
+    ]
+
+    const fundDetails: BrokerageFundDetail[] = [
+      fundDetail('fd1', 'AAPL', -3000), // buy $3,000 (insufficient)
+    ]
+
+    const result = computeStockSalePnL('AAPL', 100, 50, transactions, fundDetails)
+
+    expect(result.totalBuyCost).toBe(2000)
+    expect(result.totalSellQty).toBe(0)
+    expect(result.totalSellProceeds).toBe(0)
+    expect(result.costOfSoldShares).toBe(0)
+    expect(result.realisedStockPnl).toBe(0)
+    expect(result.isIncomplete).toBe(true)
+  })
+
+  // ─── Scenario 8: Transferred position with no history ─────────────────────
+  it('handles transferred position with no history gracefully', () => {
+    // Position: 50 shares @ $100 → brokerCostBasisRemaining = $5,000
+    // No transactions, no fund details
+    const transactions: BrokerageTransaction[] = []
+
+    const result = computeStockSalePnL('AAPL', 50, 100, transactions)
+
+    expect(result.totalBuyCost).toBe(0)
+    expect(result.totalSellQty).toBe(0)
+    expect(result.totalSellProceeds).toBe(0)
+    expect(result.costOfSoldShares).toBe(0)
+    expect(result.realisedStockPnl).toBe(0)
+    expect(result.isIncomplete).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDividends
+// ---------------------------------------------------------------------------
+
+function dividendFd(
+  id: string,
+  symbol: string,
+  amount: number,
+  type: 'DIVIDEND' | 'DIVIDEND_TAX',
+  date = '2025-01-15'
+): BrokerageFundDetail {
+  return {
+    id,
+    source: 'test',
+    rawType: type === 'DIVIDEND' ? 'Dividend' : 'Dividend Tax',
+    classifiedType: type,
+    symbol,
+    amount,
+    currency: 'USD',
+    businessDate: date,
+  }
+}
+
+describe('getDividends', () => {
+  it('sums gross dividends and withholding tax correctly', () => {
+    const fundDetails: BrokerageFundDetail[] = [
+      dividendFd('d1', 'AAPL', 100, 'DIVIDEND'),
+      dividendFd('d2', 'AAPL', 50, 'DIVIDEND'),
+      dividendFd('d3', 'AAPL', -30, 'DIVIDEND_TAX'),
+      dividendFd('d4', 'AAPL', -15, 'DIVIDEND_TAX'),
+    ]
+
+    expect(getDividends('AAPL', fundDetails)).toBe(105) // 100 + 50 - 30 - 15
+  })
+
+  it('caps tax reversals so they only cancel prior withholding, never become income', () => {
+    // Simulates the MSTY scenario: $100 in gross dividends, $30 tax withheld,
+    // then a $50 tax reversal (ROC reclassification).
+    // Cumulative tax: -30 → +20 (capped at 0) → total = 100 + 0 = 100.
+    const fundDetails: BrokerageFundDetail[] = [
+      dividendFd('d1', 'MSTY', 100, 'DIVIDEND', '2025-01-15'),
+      dividendFd('d2', 'MSTY', -30, 'DIVIDEND_TAX', '2025-01-17'),
+      dividendFd('d3', 'MSTY', 50, 'DIVIDEND_TAX', '2025-03-15'), // reversal
+    ]
+
+    expect(getDividends('MSTY', fundDetails)).toBe(100) // capped, not 120
+  })
+
+  it('allows tax reversals to fully unwind prior tax but no more', () => {
+    // $200 gross, $80 tax withheld, then $80 reversal (exact match)
+    const fundDetails: BrokerageFundDetail[] = [
+      dividendFd('d1', 'AAPL', 200, 'DIVIDEND', '2025-01-15'),
+      dividendFd('d2', 'AAPL', -80, 'DIVIDEND_TAX', '2025-01-17'),
+      dividendFd('d3', 'AAPL', 80, 'DIVIDEND_TAX', '2025-03-15'),
+    ]
+
+    expect(getDividends('AAPL', fundDetails)).toBe(200) // gross only, tax fully unwound
+  })
+
+  it('handles multiple interleaved taxes and reversals chronologically', () => {
+    // Chronological: D1(+150), T1(-40), D2(+100), T2(-30), Rev(+60)
+    // Cumulative tax: -40 → -70 → -10. Reversal absorbed within the deficit, never goes positive.
+    // Total = gross(250) + cumTax(-10) = 240
+    const fundDetails: BrokerageFundDetail[] = [
+      dividendFd('d1', 'AAPL', 150, 'DIVIDEND', '2025-01-15'),
+      dividendFd('t1', 'AAPL', -40, 'DIVIDEND_TAX', '2025-01-17'),
+      dividendFd('d2', 'AAPL', 100, 'DIVIDEND', '2025-02-15'),
+      dividendFd('t2', 'AAPL', -30, 'DIVIDEND_TAX', '2025-02-17'),
+      dividendFd('rev1', 'AAPL', 60, 'DIVIDEND_TAX', '2025-03-15'),
+    ]
+
+    expect(getDividends('AAPL', fundDetails)).toBe(240) // 250 + (-10) = 240
+  })
+
+  it('returns only gross dividends when no tax records exist', () => {
+    const fundDetails: BrokerageFundDetail[] = [
+      dividendFd('d1', 'AAPL', 100, 'DIVIDEND'),
+      dividendFd('d2', 'AAPL', 50, 'DIVIDEND'),
+    ]
+
+    expect(getDividends('AAPL', fundDetails)).toBe(150)
+  })
+
+  it('returns 0 when no dividend records exist', () => {
+    expect(getDividends('AAPL', [])).toBe(0)
+  })
+
+  it('filters by symbol', () => {
+    const fundDetails: BrokerageFundDetail[] = [
+      dividendFd('d1', 'AAPL', 100, 'DIVIDEND'),
+      dividendFd('d2', 'MSFT', 50, 'DIVIDEND'),
+      dividendFd('d3', 'AAPL', -20, 'DIVIDEND_TAX'),
+    ]
+
+    expect(getDividends('AAPL', fundDetails)).toBe(80)
+    expect(getDividends('MSFT', fundDetails)).toBe(50)
+  })
+})

--- a/apps/web/src/pages/investments/holdingCalculations.ts
+++ b/apps/web/src/pages/investments/holdingCalculations.ts
@@ -1,0 +1,423 @@
+import type { BrokerageFundDetail, BrokeragePosition, BrokerageTransaction } from '@lokfi/brokerage-core'
+
+/**
+ * Extract the underlying stock ticker from an OCC option identifier.
+ *
+ * OCC format: "<SYMBOL>  <YYMMDD><C|P><strike>"
+ * Example: "CRWV  260508P00106000" → "CRWV"
+ */
+export function extractUnderlying(identifier: string): string {
+  const parts = identifier.split(/\s{2,}/)
+  return parts[0] || ''
+}
+
+export interface HoldingMetrics {
+  /** Total premium received from selling options on this underlying (lifetime) */
+  totalOptionPremiums: number
+  /** Net dividends received (gross - tax) for this stock (lifetime) */
+  totalDividends: number
+  /** Raw cost basis: quantity × avgCost */
+  rawCostBasis: number
+  /** Adjusted cost basis: rawCostBasis - premiums - dividends */
+  adjustedCostBasis: number
+  /** Adjusted cost basis per share, null if quantity ≤ 0 */
+  adjCostBasisPerShare: number | null
+  /** Market value of the position */
+  marketValue: number
+  /**
+   * Total return % incorporating price return, option premiums, dividends,
+   * and partial stock sale gains.
+   *
+   * Formula:
+   *   ((marketValue + realisedPnl - rawCostBasisWithSales) / rawCostBasisWithSales) × 100
+   *
+   * Returns null when denominator ≤ 0.
+   */
+  totalReturnPct: number | null
+  /** Realised gain/loss from partial stock sales only (excludes dividends and option premiums) */
+  realisedStockPnl: number
+  /** Total realised: stock sale gains + option premiums + dividends */
+  realisedPnl: number
+  /** Unrealised P&L on current position */
+  unrealisedPnl: number
+  /** Total P&L: realisedStockPnl + optionPremiums + dividends + unrealisedPnl */
+  totalPnl: number
+  /**
+   * True when neither transaction history nor fund detail TRADE records fully
+   * cover the broker's cost basis — the position may be incomplete due to
+   * limited API history, a transferred position, or option-trade contamination
+   * blocking the fund detail fallback.
+   */
+  isIncomplete: boolean
+  /**
+   * Diagnostic messages surfacing data quality concerns (e.g. transaction vs.
+   * fund detail discrepancies, tax reversal impact, incomplete data sources).
+   * Displayed in the expandable detail row.
+   */
+  diagnostics: string[]
+}
+
+/**
+ * Compute option premiums received for a given stock symbol.
+ *
+ * Uses open short option positions (quantity < 0) where the option's underlying
+ * matches the stock symbol. Tiger Broker uses the underlying ticker as the option
+ * `symbol` field, so matching is direct.
+ *
+ * Premium = abs(quantity) × avgCost × multiplier
+ *
+ * Prefer `getOptionPremiumsFromTransactions` when secType-tagged transactions
+ * are available — it captures closed/bought-back trades that positions miss.
+ */
+export function getOptionPremiums(stockSymbol: string, optionPositions: BrokeragePosition[]): number {
+  return optionPositions
+    .filter((p) => p.symbol === stockSymbol && p.secType === 'OPT' && p.quantity < 0)
+    .reduce((sum, p) => sum + Math.abs(p.quantity) * p.avgCost * (p.multiplier ?? 100), 0)
+}
+
+/**
+ * Compute option premiums from transaction records (order fills).
+ *
+ * Filters transactions by secType='OPT' for the given underlying symbol.
+ * Handles both open (SELL to open) and closed (BUY to close) trades:
+ *
+ *   Net premium = Σ SELL × price × qty × multiplier − Σ BUY × price × qty × multiplier
+ *
+ * The multiplier defaults to 100 (standard US equity options) when no
+ * matching open position exists to provide it.
+ */
+export function getOptionPremiumsFromTransactions(
+  stockSymbol: string,
+  transactions: BrokerageTransaction[],
+  optionPositions: BrokeragePosition[]
+): number {
+  // Build a lookup of multiplier by symbol from open option positions
+  const multiplierBySymbol = new Map<string, number>()
+  for (const p of optionPositions) {
+    if (p.secType === 'OPT' && p.multiplier) {
+      multiplierBySymbol.set(p.symbol, p.multiplier)
+    }
+  }
+
+  return transactions
+    .filter((t) => t.symbol === stockSymbol && t.secType === 'OPT')
+    .reduce((sum, t) => {
+      const multiplier = multiplierBySymbol.get(t.symbol) ?? 100
+      const premium = t.price * Math.abs(t.quantity) * multiplier
+      return t.action === 'SELL' ? sum + premium : sum - premium
+    }, 0)
+}
+
+/**
+ * Compute total option premiums — prefers transaction-based (covers closed trades)
+ * when secType-tagged data is available, falls back to open positions.
+ */
+export function getTotalOptionPremiums(
+  stockSymbol: string,
+  optionPositions: BrokeragePosition[],
+  transactions?: BrokerageTransaction[]
+): number {
+  if (transactions?.some((t) => t.symbol === stockSymbol && t.secType === 'OPT')) {
+    return getOptionPremiumsFromTransactions(stockSymbol, transactions, optionPositions)
+  }
+  return getOptionPremiums(stockSymbol, optionPositions)
+}
+
+/**
+ * Compute realised P&L from partial stock sales.
+ *
+ * Uses the broker's authoritative cost basis (position.avgCost × position.qty) as
+ * the anchor and reconciles via transaction cash flows. This is immune to
+ * corporate actions (splits, reverse splits, mergers) because it works with
+ * total dollar amounts, not per-share quantities that drift after adjustments.
+ *
+ *   costOfSoldShares   = totalBuyCost − brokerCostBasisRemaining
+ *   realisedStockPnl   = totalSellProceeds − costOfSoldShares
+ *
+ * where brokerCostBasisRemaining = position.avgCost × position.qty.
+ *
+ * Data source priority:
+ *   1. Transaction history (brokerageTransactions) — has per-share detail and
+ *      covers the full account history when available. The sync fetches up to
+ *      10 years of history (3650 days) in 90-day API-call chunks.
+ *   2. Fund detail TRADE records (brokerageFundDetails) — cash ledger entries
+ *      that accumulate across syncs. Used as the fallback when transaction
+ *      history is incomplete or not available from the broker API.
+ *
+ * For symbols with option positions, fund details can't separate stock from
+ * option trades — in that case only premiums + dividends are shown as realised.
+ *
+ * Known limitation: return-of-capital distributions (reported as dividend by
+ * the broker but reducing cost basis) are not tracked separately and can cause
+ * costOfSoldShares to be overstated.
+ */
+export function computeStockSalePnL(
+  symbol: string,
+  currentQty: number,
+  currentAvgCost: number,
+  transactions: BrokerageTransaction[],
+  fundDetails?: BrokerageFundDetail[],
+  hasOptionPositions?: boolean
+): {
+  totalBuyCost: number
+  totalSellQty: number
+  totalSellProceeds: number
+  costOfSoldShares: number
+  realisedStockPnl: number
+  isIncomplete: boolean
+} {
+  const stockTxns = transactions.filter((t) => t.symbol === symbol && (t.secType === 'STK' || t.secType == null))
+
+  let totalBuyCost = 0
+  let totalSellQty = 0
+  let totalSellProceeds = 0
+
+  for (const t of stockTxns) {
+    const amount = t.price * Math.abs(t.quantity)
+    const comm = t.commission ?? 0
+    if (t.action === 'BUY') {
+      totalBuyCost += amount + comm
+    } else {
+      totalSellQty += Math.abs(t.quantity)
+      totalSellProceeds += amount - comm
+    }
+  }
+
+  const brokerCostBasisRemaining = currentAvgCost * currentQty
+  let isIncomplete = false
+
+  let costOfSoldShares: number
+  if (totalBuyCost > 0 && totalBuyCost >= brokerCostBasisRemaining) {
+    // Complete: all buys are tracked in transaction history
+    costOfSoldShares = totalBuyCost - brokerCostBasisRemaining
+  } else if (fundDetails && !hasOptionPositions) {
+    // Transaction history is incomplete or missing — use fund detail TRADE
+    // records as the fallback source. Fund details accumulate across syncs
+    // and cover the full account history.
+    // Only safe for symbols without option positions (fund details can't
+    // separate stock from option trades).
+    let fdBuyCost = 0
+    let fdSellProceeds = 0
+    for (const fd of fundDetails) {
+      if (fd.classifiedType !== 'TRADE' || fd.symbol !== symbol) continue
+      // Fund detail amounts are total dollars: negative = BUY, positive = SELL
+      fdBuyCost += fd.amount < 0 ? Math.abs(fd.amount) : 0
+      fdSellProceeds += fd.amount > 0 ? fd.amount : 0
+    }
+
+    if (fdBuyCost >= brokerCostBasisRemaining) {
+      // Fund details cover the full buy history — use them exclusively to
+      // avoid double-counting with transaction data (same trades appear in both)
+      totalBuyCost = fdBuyCost
+      totalSellProceeds = fdSellProceeds
+      costOfSoldShares = totalBuyCost - brokerCostBasisRemaining
+    } else if (fdBuyCost > 0) {
+      // Fund details exist but can't cover current cost basis
+      // (position may have been transferred or cost basis adjusted by corp actions)
+      isIncomplete = true
+      costOfSoldShares = 0
+    } else {
+      // No fund detail TRADE records for this symbol at all
+      isIncomplete = true
+      costOfSoldShares = 0
+    }
+  } else if (totalBuyCost === 0 && totalSellProceeds > 0) {
+    // No buy transactions at all but sells exist — definitely incomplete
+    // (and no fund details available, or has option positions blocking fallback)
+    isIncomplete = true
+    costOfSoldShares = 0
+  } else {
+    // Incomplete: some tracked buys but not enough to cover the broker's
+    // cost basis, and option positions blocked the fund detail fallback.
+    isIncomplete = true
+    costOfSoldShares = currentAvgCost * totalSellQty
+  }
+
+  const realisedStockPnl = isIncomplete ? 0 : totalSellProceeds - costOfSoldShares
+
+  return { totalBuyCost, totalSellQty, totalSellProceeds, costOfSoldShares, realisedStockPnl, isIncomplete }
+}
+
+/**
+ * Compute net dividends received (gross dividend - withholding tax) for a stock.
+ *
+ * Sums across ALL time (lifetime cumulative), since cost basis adjustment is
+ * cumulative. Negative tax records are withholding; positive tax records are
+ * reversals (e.g. from return-of-capital reclassification).
+ *
+ * Tax reversals are capped so they only cancel prior withholding — they never
+ * inflate the net dividend beyond gross. Otherwise a ROC reclassification
+ * reversing $14k of tax would incorrectly appear as $14k of additional income.
+ */
+export function getDividends(stockSymbol: string, fundDetails: BrokerageFundDetail[]): number {
+  const grossDividends = fundDetails
+    .filter((fd) => fd.symbol === stockSymbol && fd.classifiedType === 'DIVIDEND')
+    .reduce((sum, fd) => sum + fd.amount, 0)
+
+  // Track cumulative tax paid (negative = tax withheld). Floor at 0 so that
+  // reversal entries (positive) can only unwind prior withholding, never
+  // create a net credit that would inflate the dividend total.
+  let cumulativeTax = 0
+  const taxEntries = fundDetails
+    .filter((fd) => fd.symbol === stockSymbol && fd.classifiedType === 'DIVIDEND_TAX')
+    .sort((a, b) => a.businessDate.localeCompare(b.businessDate))
+
+  for (const fd of taxEntries) {
+    cumulativeTax += fd.amount
+    // Cap at 0 — withholding tax can't become a net credit
+    if (cumulativeTax > 0) cumulativeTax = 0
+  }
+
+  return grossDividends + cumulativeTax
+}
+
+/**
+ * Compute all holding metrics for a single stock position.
+ *
+ * Incorporates:
+ *   - Partial stock sale gains (average cost accounting from transaction history)
+ *   - Option premiums (from transactions or open positions)
+ *   - Dividends (from fund details)
+ *   - Unrealised P&L (from broker or computed)
+ *
+ * Adjusted Cost Basis = Raw Cost Basis − Option Premiums Received − Net Dividends
+ *
+ * Total Return % = (Market Value + Realised P&L − RawCostBasisWithSales) / RawCostBasisWithSales × 100
+ *   where RawCostBasisWithSales accounts for the reduced cost basis after partial sales.
+ */
+export function getAdjustedMetrics(
+  position: BrokeragePosition,
+  optionPositions: BrokeragePosition[],
+  fundDetails: BrokerageFundDetail[],
+  transactions?: BrokerageTransaction[]
+): HoldingMetrics {
+  const rawCostBasis = position.quantity * position.avgCost
+  const marketValue = position.marketValue ?? position.quantity * position.avgCost
+  const totalOptionPremiums = getTotalOptionPremiums(position.symbol, optionPositions, transactions)
+  const totalDividends = getDividends(position.symbol, fundDetails)
+  const adjustedCostBasis = rawCostBasis - totalOptionPremiums - totalDividends
+
+  const adjCostBasisPerShare = position.quantity > 0 ? adjustedCostBasis / position.quantity : null
+
+  // Unrealised P&L: use broker's figure when available, otherwise compute
+  const unrealisedPnl = position.unrealizedPnl ?? marketValue - adjustedCostBasis
+
+  // Realised stock P&L via broker cost basis reconciliation.
+  // Fund details supplement transaction data for full buy/sell history.
+  const hasOptionPositions = optionPositions.some(
+    (p) => p.symbol === position.symbol && p.secType === 'OPT' && p.quantity < 0
+  )
+  const stockPnL = transactions
+    ? computeStockSalePnL(
+        position.symbol,
+        position.quantity,
+        position.avgCost,
+        transactions,
+        fundDetails,
+        hasOptionPositions
+      )
+    : {
+        totalBuyCost: 0,
+        totalSellQty: 0,
+        totalSellProceeds: 0,
+        costOfSoldShares: 0,
+        realisedStockPnl: 0,
+        isIncomplete: false,
+      }
+
+  const realisedPnl = stockPnL.realisedStockPnl + totalOptionPremiums + totalDividends
+
+  const totalPnl = realisedPnl + unrealisedPnl
+
+  // Total return denominator: cost basis of remaining shares (broker's figure,
+  // already adjusted for splits/mergers)
+  const investedCost = position.avgCost * position.quantity
+  const totalReturnPct = investedCost > 0 ? ((marketValue + realisedPnl - investedCost) / investedCost) * 100 : null
+
+  // ── Diagnostics ──────────────────────────────────────────────────────────
+  const diagnostics: string[] = []
+
+  // Tax reversal impact: detect positive DIVIDEND_TAX entries (reversals)
+  const taxReversals = fundDetails.filter(
+    (fd) => fd.symbol === position.symbol && fd.classifiedType === 'DIVIDEND_TAX' && fd.amount > 0
+  )
+  if (taxReversals.length > 0) {
+    const reversalSum = taxReversals.reduce((s, fd) => s + fd.amount, 0)
+    if (reversalSum > 0) {
+      diagnostics.push(
+        `${taxReversals.length} tax reversal entries (${formatCurrencyLocal(reversalSum, position.currency)}) detected — likely ROC reclassification. Net dividend capped at gross; excess reversals excluded.`
+      )
+    }
+  }
+
+  // Source discrepancy: when both transactions and fund details exist,
+  // check if they produce materially different stock sale P&L
+  if (transactions && transactions.length > 0 && !hasOptionPositions && !stockPnL.isIncomplete) {
+    const stockTxns = transactions.filter(
+      (t) => t.symbol === position.symbol && (t.secType === 'STK' || t.secType == null)
+    )
+    if (stockTxns.length > 0) {
+      let fdBuyCost = 0
+      let fdSellProceeds = 0
+      for (const fd of fundDetails) {
+        if (fd.classifiedType !== 'TRADE' || fd.symbol !== position.symbol) continue
+        fdBuyCost += fd.amount < 0 ? Math.abs(fd.amount) : 0
+        fdSellProceeds += fd.amount > 0 ? fd.amount : 0
+      }
+      if (fdBuyCost > 0) {
+        const fdCostOfSold = fdBuyCost - investedCost
+        const fdRealised = fdSellProceeds - fdCostOfSold
+        const diff = Math.abs(stockPnL.realisedStockPnl - fdRealised)
+        if (diff > 0.01 && fdBuyCost >= investedCost) {
+          diagnostics.push(
+            `Stock P&L source: transactions (${formatCurrencyLocal(stockPnL.realisedStockPnl, position.currency)}). Fund detail estimate would be ${formatCurrencyLocal(fdRealised, position.currency)} (diff: ${formatCurrencyLocal(diff, position.currency)}).`
+          )
+        }
+      }
+    }
+  } else if (stockPnL.isIncomplete && stockPnL.totalSellProceeds > 0) {
+    diagnostics.push(
+      'Realised stock P&L is incomplete — buy history does not cover sold shares. Extend sync lookback for full history.'
+    )
+  } else if (
+    stockPnL.isIncomplete &&
+    stockPnL.totalSellProceeds === 0 &&
+    transactions &&
+    stockTxns_count(transactions, position.symbol) > 0
+  ) {
+    diagnostics.push(
+      'Buy history is incomplete — tracked purchases do not cover current position quantity. May indicate a transferred position or missing historical data.'
+    )
+  } else if (!transactions || stockTxns_count(transactions, position.symbol) === 0) {
+    diagnostics.push('Stock P&L sourced from fund detail TRADE records (no transaction history available).')
+  }
+
+  return {
+    totalOptionPremiums,
+    totalDividends,
+    rawCostBasis,
+    adjustedCostBasis,
+    adjCostBasisPerShare,
+    marketValue,
+    totalReturnPct,
+    realisedStockPnl: stockPnL.realisedStockPnl,
+    realisedPnl,
+    unrealisedPnl,
+    totalPnl,
+    isIncomplete: stockPnL.isIncomplete,
+    diagnostics,
+  }
+}
+
+function formatCurrencyLocal(amount: number, currency: string): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount)
+}
+
+function stockTxns_count(transactions: BrokerageTransaction[], symbol: string): number {
+  return transactions.filter((t) => t.symbol === symbol && (t.secType === 'STK' || t.secType == null)).length
+}

--- a/apps/web/src/pages/settings/BrokerageSettingsPage.tsx
+++ b/apps/web/src/pages/settings/BrokerageSettingsPage.tsx
@@ -8,7 +8,6 @@ import {
   DexieSyncAdapter,
   SyncOrchestrator,
   TigerProvider,
-  computeIncrementalSince,
 } from '../../lib/brokerage'
 import type { TigerClientConfig } from '../../lib/brokerage'
 import { SyncProgressBar } from '../../lib/brokerage/SyncProgressBar'
@@ -139,13 +138,34 @@ export function BrokerageSettingsPage() {
       }
       const provider = new TigerProvider({ config })
       const adapter = new DexieSyncAdapter(db)
-      const since = await computeIncrementalSince(adapter, SOURCE)
+      const since = new Date(Date.now() - 3650 * 24 * 60 * 60 * 1000)
       const orchestrator = new SyncOrchestrator({
         provider,
         database: adapter,
         onProgress: (p) => setSyncProgress((prev) => [...prev, p]),
       })
-      await orchestrator.sync(undefined, since)
+
+      // Wrap clear + repopulate in a single Dexie transaction so that a
+      // partial failure (network error, API rate limit, etc.) rolls back the
+      // clear and leaves the previous data intact.
+      await db.transaction(
+        'rw',
+        [
+          db.brokerageTransactions,
+          db.brokerageFundDetails,
+          db.brokeragePositions,
+          db.brokeragePositionExtensions,
+          db.brokerageAccounts,
+        ],
+        async () => {
+          await db.brokerageTransactions.clear()
+          await db.brokerageFundDetails.clear()
+          await db.brokeragePositions.clear()
+          await db.brokeragePositionExtensions.clear()
+          await db.brokerageAccounts.clear()
+          await orchestrator.sync(undefined, since)
+        }
+      )
       showSuccess('Sync completed')
     } catch (err) {
       showError(err instanceof Error ? err.message : 'Sync failed')
@@ -262,7 +282,7 @@ export function BrokerageSettingsPage() {
           <div className="space-y-1">
             <p className="text-xs text-gray-400 dark:text-gray-500">
               Credentials are encrypted and stored locally. Auto-sync on the Investments page. Sync range is computed
-              automatically (incremental from last sync, or all-time on first sync).
+              automatically (incremental from last sync, or since 3650 days ago on first sync).
             </p>
           </div>
         )}
@@ -290,11 +310,11 @@ export function BrokerageSettingsPage() {
           <button
             onClick={handleSync}
             disabled={syncing || loading}
-            className="text-sm font-medium px-4 py-2 rounded-full border transition-colors disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 text-sm font-medium px-4 py-2 rounded-full border transition-colors disabled:opacity-50"
             style={{ borderColor: 'var(--border)' }}
           >
             {syncing ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
-            <span className="ml-1">Sync Now</span>
+            <span>Full Sync</span>
           </button>
           {hasCredentials && (
             <button

--- a/apps/web/src/pages/transactions/TransactionFilters.tsx
+++ b/apps/web/src/pages/transactions/TransactionFilters.tsx
@@ -1,6 +1,6 @@
 import { useLiveQuery } from 'dexie-react-hooks'
-import { db } from '../../lib/db/db'
 import { BROKERAGE_TYPE_LABELS } from '../../lib/brokerage/unifiedTransactions'
+import { db } from '../../lib/db/db'
 
 import { type Filters, defaultFilters } from './filterTypes'
 

--- a/apps/web/src/pages/transactions/TransactionFilters.tsx
+++ b/apps/web/src/pages/transactions/TransactionFilters.tsx
@@ -1,5 +1,6 @@
 import { useLiveQuery } from 'dexie-react-hooks'
 import { db } from '../../lib/db/db'
+import { BROKERAGE_TYPE_LABELS } from '../../lib/brokerage/unifiedTransactions'
 
 import { type Filters, defaultFilters } from './filterTypes'
 
@@ -193,11 +194,11 @@ export function TransactionFilters({ filters, onChange }: TransactionFiltersProp
               style={inputStyle}
             >
               <option value="">All</option>
-              <option value="BUY">Buy</option>
-              <option value="SELL">Sell</option>
-              <option value="DIVIDEND">Dividend</option>
-              <option value="FEE">Fee</option>
-              <option value="CORP ACTION">Corp Action</option>
+              {Object.entries(BROKERAGE_TYPE_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
             </select>
           </div>
         </>

--- a/apps/web/src/pages/transactions/TransactionTable.tsx
+++ b/apps/web/src/pages/transactions/TransactionTable.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react'
 import type { UnifiedTransactionRow } from '../../lib/brokerage/unifiedTransactions'
 import { BROKERAGE_TYPE_LABELS } from '../../lib/brokerage/unifiedTransactions'
 import type { DbTransaction } from '../../lib/db/db'
-import type { SourceType } from './filterTypes'
 import { CategoryBadge } from './CategoryBadge'
+import type { SourceType } from './filterTypes'
 
 const fmtCache = new Map<string, Intl.NumberFormat>()
 function getFormatter(currency: string): Intl.NumberFormat {

--- a/apps/web/src/pages/transactions/TransactionTable.tsx
+++ b/apps/web/src/pages/transactions/TransactionTable.tsx
@@ -1,7 +1,9 @@
 import { Check, Copy } from 'lucide-react'
 import { useState } from 'react'
 import type { UnifiedTransactionRow } from '../../lib/brokerage/unifiedTransactions'
+import { BROKERAGE_TYPE_LABELS } from '../../lib/brokerage/unifiedTransactions'
 import type { DbTransaction } from '../../lib/db/db'
+import type { SourceType } from './filterTypes'
 import { CategoryBadge } from './CategoryBadge'
 
 const fmtCache = new Map<string, Intl.NumberFormat>()
@@ -33,6 +35,35 @@ function amountColorClass(row: UnifiedTransactionRow): string {
   }
 }
 
+function typeBadgeClass(type: string): string {
+  switch (type) {
+    case 'BUY':
+      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+    case 'SELL':
+    case 'WITHDRAWAL':
+      return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+    case 'DIVIDEND':
+    case 'DIVIDEND_TAX':
+      return 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+    case 'FEE':
+      return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+    case 'TRANSFER_IN':
+      return 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+    case 'TRANSFER_OUT':
+      return 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300'
+    case 'DEPOSIT':
+    case 'REBATE':
+      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+    case 'SPLIT':
+    case 'RIGHTS':
+      return 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300'
+    case 'CURRENCY_EXCHANGE':
+      return 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300'
+    default:
+      return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+  }
+}
+
 function formatSource(row: UnifiedTransactionRow): string {
   const icon = row.isBank ? '🏦' : '📈'
   return `${icon} ${row.source}`
@@ -40,6 +71,7 @@ function formatSource(row: UnifiedTransactionRow): string {
 
 interface TransactionTableProps {
   rows: UnifiedTransactionRow[]
+  sourceType: SourceType
   selectedIds: Set<string>
   onToggleSelect: (id: string) => void
   onToggleAll: (ids: string[]) => void
@@ -52,6 +84,7 @@ interface TransactionTableProps {
 
 export function TransactionTable({
   rows,
+  sourceType,
   selectedIds,
   onToggleSelect,
   onToggleAll,
@@ -66,6 +99,7 @@ export function TransactionTable({
 
   const selectableIds = rows.filter((t) => t.isBank).map((t) => t.id)
   const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selectedIds.has(id))
+  const showTypeColumn = sourceType !== 'bank'
 
   return (
     <div className="overflow-x-auto relative">
@@ -90,6 +124,11 @@ export function TransactionTable({
             <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
               Date
             </th>
+            {showTypeColumn && (
+              <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                Type
+              </th>
+            )}
             <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
               Description
             </th>
@@ -144,6 +183,19 @@ export function TransactionTable({
                 <td className="px-3 py-2.5 text-gray-500 dark:text-gray-400 whitespace-nowrap font-mono text-xs">
                   {t.date.slice(0, 10)}
                 </td>
+                {showTypeColumn && (
+                  <td className="px-3 py-2.5">
+                    {!t.isBank ? (
+                      <span
+                        className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${typeBadgeClass(t.type)}`}
+                      >
+                        {BROKERAGE_TYPE_LABELS[t.type] ?? t.type}
+                      </span>
+                    ) : (
+                      <span className="text-gray-300 dark:text-gray-600 text-xs">—</span>
+                    )}
+                  </td>
+                )}
                 <td
                   className={`px-3 py-2.5 text-gray-900 dark:text-white max-w-xs ${isEditing ? 'whitespace-normal break-words' : ''}`}
                 >

--- a/apps/web/src/pages/transactions/TransactionsPage.tsx
+++ b/apps/web/src/pages/transactions/TransactionsPage.tsx
@@ -249,6 +249,7 @@ export function TransactionsPage() {
         ) : (
           <TransactionTable
             rows={rows}
+            sourceType={filters.sourceType}
             selectedIds={selectedIds}
             onToggleSelect={handleToggleSelect}
             onToggleAll={handleToggleAll}

--- a/packages/brokerage-core/src/types.ts
+++ b/packages/brokerage-core/src/types.ts
@@ -82,6 +82,8 @@ export interface BrokerageTransaction {
   commission?: number
   /** ISO-8601 timestamp of execution */
   executedAt: string
+  /** Security type of the traded instrument (STK, OPT, etc.). Added for filtering option vs. stock trades. */
+  secType?: SecurityType
 }
 
 // ── Fund Detail ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Eight focused commits spanning the brokerage sync pipeline and investments UI:

### New Features
- **Holding metrics engine** — adjusted cost basis, total return %, premiums received, dividends received per stock position. New sortable columns on Holdings tab.
- **Closed positions tab** — new tab in Investments page showing closed stock positions.
- **Full-clear sync** — clears and repopulates brokerage data atomically in a single Dexie transaction (rolls back on failure), with 10-year lookback.

### Fixes
- **Tiger order ID collision** — uses `order.id` instead of `order.orderId` (which is always 0 for global/prime accounts, causing all orders to collide on key `tiger_0`).
- **Filled orders pagination** — added `page_token`-based pagination to retrieve large result sets fully.
- **Unified transaction display** — labels quantity as contracts/shares based on `secType`, adds `(OPT)`/`(FUT)` tags, fixes enriched TRADE dedup fallback.
- **Content-based dedup** — defends against the provider returning the same order with different IDs across sync runs. v8 migration cleans existing duplicates.

### Refactors
- **DexieSyncAdapter** — content-keyed dedup for both `appendTransactions` and `appendFundDetails`.
- **BrokerageSettingsPage** — replaced incremental `computeIncrementalSince` with full-clear transactional repopulate.

### Other
- Batched historical orders debug in test-tiger CLI (8 windows, 90–3650 days).
- Documentation updates (AGENTS.md, lokfi-db-query skill).