### PR TITLE
feat(investments): portfolio buckets and performance card

### DIFF
--- a/apps/docs/guide/investments.md
+++ b/apps/docs/guide/investments.md
@@ -7,10 +7,22 @@ Lokfi can track your brokerage portfolios alongside your finances, giving you a 
 The Investments page provides tabs for:
 
 ### Overview
-A summary of your portfolio's total value, cost basis, and unrealized gain/loss across all connected brokerages.
+A summary of your portfolio's total value, dividend income, and performance across all connected brokerages. The Overview features a **Portfolio by bucket** chart and a **Performance** chart.
+
+**KPIs:**
+- **Total Portfolio Value** — Sum of all positions (market value or cost basis) plus cash balances across all accounts
+- **Dividends (TTM)** — Total dividend income over the trailing 12 months, converted to your preferred currency
+
+**Performance card:**
+
+The Performance card plots your portfolio value over time as an area chart. Use the time-range pills to switch between **1M, 3M, 6M, 1Y, YTD**, and **All**. Above the chart, the card shows:
+- **Return %** — Percentage change from the first to the last snapshot in the selected range, colored green (gain) or red (loss)
+- **Absolute gain/loss** — The same change expressed in your preferred currency
+
+> **Note:** Performance history is built from daily snapshots captured automatically each time you sync. The card shows "Sync again to start building history" until at least two snapshots exist for the selected range. Changing your preferred currency restates historical snapshots using current FX rates.
 
 ### Holdings
-A detailed view of each position — ticker, quantity, current price, market value, and performance. Prices are fetched via broker API where available.
+A detailed view of each position — ticker, quantity, current price, market value, and bucket assignment. The holdings view supports filtering by portfolio bucket, searching by ticker or name, and expanding positions to see lot-level detail.
 
 ### Transactions
 Individual trade history — buys, sells, dividends, and corporate actions — synced from your brokerages and normalized into Lokfi's unified transaction format.
@@ -20,9 +32,73 @@ A dedicated view of dividend income across your portfolio. See payouts by period
 
 ### Currency
 
-Toggle between SGD and USD (or your portfolio's native currency) using the currency selector. All values are converted using current exchange rates.
+Toggle between your preferred currency (SGD, USD, etc.) or view values in their original currency using the currency selector. All values are converted using current exchange rates.
 
 > **Note:** Currency conversion uses live rates from the Frankfurter API. If you're offline, the last cached rates are used.
+
+---
+
+## Portfolio Buckets
+
+Portfolio buckets let you organize your holdings into custom groups (e.g., Growth, Income, Cash) and track how your portfolio allocation aligns with your targets.
+
+### Default Buckets
+
+Lokfi creates three default buckets on first use:
+- **Growth** — For equity and growth-oriented positions
+- **Income** — For dividend and income-generating holdings
+- **Cash** — For money market, cash equivalents, and fixed income
+
+Positions that aren't assigned to any bucket appear under **Unassigned**.
+
+### Managing Buckets
+
+Open **Settings → Portfolio buckets** to manage your buckets:
+
+- **Rename** — Click the bucket name to edit it
+- **Reorder** — Use the arrow buttons to change bucket display order
+- **Recolor** — Pick from a palette of swatches to color-code each bucket
+- **Add / Delete** — Create new buckets or delete existing ones (deleting a bucket unassigns its holdings)
+
+#### Target Allocation
+
+Each bucket can have a **target percentage** of your total portfolio:
+
+1. Enter a percentage (0–100) in the **% target** field next to each bucket
+2. A **Target total** summary bar shows your combined allocation
+   - **Under 100%** — Shows remaining unallocated percentage
+   - **Over 100%** — Highlighted red with the overage amount
+
+Targets are optional — buckets without a target simply track actual allocation without comparison.
+
+### Bucket Overview Chart
+
+On the Overview tab, the **Portfolio by bucket** widget shows:
+
+- **Pie chart** — Each holding appears as an individual slice, colored by its assigned bucket. Hover to see the holding name and value.
+- **Legend** — Buckets are listed by total value (descending), each with its color indicator.
+- **Bucket rows** — Each row shows:
+  - Bucket name and total value
+  - Actual allocation percentage
+  - Target percentage (if set), shown as `actual% / target%`
+  - **Delta indicator** — The difference between actual and target, color-coded:
+    - ≤2% deviation — Green (on track)
+    - ≤8% deviation — Amber (needs attention)
+    - >8% deviation — Red (significantly off-target)
+- **Expandable holdings** — Click a bucket row to expand it and see each holding's name, value, and proportional bar within that bucket
+
+### Assigning Holdings to Buckets
+
+From the **Holdings** tab, click the bucket icon on any position row to assign or reassign it to a bucket. Assignments are saved immediately to your local database.
+
+### Empty States
+
+The holdings view shows contextual messages depending on the situation:
+- **No search results** — "No results for &lt;query&gt;"
+- **Bucket filter with no holdings** — "No holdings in this bucket yet" with a button to show all holdings
+- **No recognizable holdings** — Fallback message when security types are unknown
+
+---
 
 ## Supported Brokerages
 

--- a/apps/web/src/lib/db/backup.test.ts
+++ b/apps/web/src/lib/db/backup.test.ts
@@ -18,9 +18,16 @@ const baseV3 = {
   brokerageCredentials: [],
 }
 
+const baseV4 = {
+  ...baseV3,
+  version: 4,
+  portfolioBuckets: [],
+  portfolioBucketAssignments: [],
+}
+
 describe('backup helpers', () => {
-  it('uses backup version 4 for portfolio buckets', () => {
-    expect(BACKUP_VERSION).toBe(4)
+  it('uses backup version 5 for portfolio snapshots', () => {
+    expect(BACKUP_VERSION).toBe(5)
   })
 
   it('requires portfolio bucket arrays for v4 backups', () => {
@@ -82,5 +89,42 @@ describe('backup helpers', () => {
 
     expect(summary).toContain('1 portfolio bucket(s)')
     expect(summary).toContain('1 portfolio bucket assignment(s)')
+  })
+
+  it('requires portfolioSnapshots array for v5 backups', () => {
+    expect(validateBackupShape({ ...baseV4, version: 5 }).valid).toBe(false)
+    expect(
+      validateBackupShape({ ...baseV4, version: 5, portfolioSnapshots: [] })
+    ).toEqual({ valid: true })
+  })
+
+  it('normalizes v4 and older backups with empty portfolioSnapshots', () => {
+    const normalizedV3 = normalizeBackupForImport(baseV3)
+    expect(normalizedV3.portfolioSnapshots).toEqual([])
+
+    const normalizedV4 = normalizeBackupForImport(baseV4)
+    expect(normalizedV4.portfolioSnapshots).toEqual([])
+  })
+
+  it('keeps portfolioSnapshots during v5 normalization', () => {
+    const snapshot = { date: '2026-05-01', totalValue: 10000, currency: 'SGD' }
+    const normalized = normalizeBackupForImport({
+      ...baseV4,
+      version: 5,
+      portfolioSnapshots: [snapshot],
+    })
+    expect(normalized.portfolioSnapshots).toHaveLength(1)
+    expect(normalized.portfolioSnapshots[0]).toEqual(snapshot)
+  })
+
+  it('includes snapshot count in import summary', () => {
+    const summary = buildImportSummary({
+      ...normalizeBackupForImport({ ...baseV4, version: 5, portfolioSnapshots: [] }),
+      portfolioSnapshots: [
+        { date: '2026-05-01', totalValue: 10000, currency: 'SGD' },
+        { date: '2026-05-02', totalValue: 10200, currency: 'SGD' },
+      ],
+    })
+    expect(summary).toContain('2 portfolio snapshot(s)')
   })
 })

--- a/apps/web/src/lib/db/backup.test.ts
+++ b/apps/web/src/lib/db/backup.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BACKUP_VERSION,
+  buildImportSummary,
+  normalizeBackupForImport,
+  validateBackupShape,
+} from './backup'
+
+const baseV3 = {
+  version: 3,
+  exportedAt: '2026-05-11T00:00:00.000Z',
+  transactions: [],
+  rules: [],
+  categories: [],
+  customParsers: [],
+  budgets: [],
+  brokeragePositions: [],
+  brokeragePositionExtensions: [],
+  brokerageTransactions: [],
+  brokerageFundDetails: [],
+  brokerageAccounts: [],
+  brokerageSyncLog: [],
+  brokerageCredentials: [],
+}
+
+describe('backup helpers', () => {
+  it('uses backup version 4 for portfolio buckets', () => {
+    expect(BACKUP_VERSION).toBe(4)
+  })
+
+  it('requires portfolio bucket arrays for v4 backups', () => {
+    expect(validateBackupShape({ ...baseV3, version: 4 }).valid).toBe(false)
+    expect(
+      validateBackupShape({ ...baseV3, version: 4, portfolioBuckets: [], portfolioBucketAssignments: [] })
+    ).toEqual({ valid: true })
+  })
+
+  it('normalizes older v1-v3 backups with empty bucket arrays', () => {
+    const normalized = normalizeBackupForImport(baseV3)
+
+    expect(normalized.portfolioBuckets).toEqual([])
+    expect(normalized.portfolioBucketAssignments).toEqual([])
+  })
+
+  it('keeps v4 bucket arrays during normalization', () => {
+    const normalized = normalizeBackupForImport({
+      ...baseV3,
+      version: 4,
+      portfolioBuckets: [
+        {
+          id: 'bucket_growth',
+          name: 'Growth',
+          color: '#3b82f6',
+          sortOrder: 0,
+          isDefault: true,
+          createdAt: 'now',
+          updatedAt: 'now',
+        },
+      ],
+      portfolioBucketAssignments: [
+        { securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' },
+      ],
+    })
+
+    expect(normalized.portfolioBuckets).toHaveLength(1)
+    expect(normalized.portfolioBucketAssignments).toHaveLength(1)
+  })
+
+  it('includes bucket counts in import summary', () => {
+    const summary = buildImportSummary({
+      ...normalizeBackupForImport(baseV3),
+      portfolioBuckets: [
+        {
+          id: 'bucket_growth',
+          name: 'Growth',
+          color: '#3b82f6',
+          sortOrder: 0,
+          isDefault: true,
+          createdAt: 'now',
+          updatedAt: 'now',
+        },
+      ],
+      portfolioBucketAssignments: [
+        { securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' },
+      ],
+    })
+
+    expect(summary).toContain('1 portfolio bucket(s)')
+    expect(summary).toContain('1 portfolio bucket assignment(s)')
+  })
+})

--- a/apps/web/src/lib/db/backup.test.ts
+++ b/apps/web/src/lib/db/backup.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  BACKUP_VERSION,
-  buildImportSummary,
-  normalizeBackupForImport,
-  validateBackupShape,
-} from './backup'
+import { BACKUP_VERSION, buildImportSummary, normalizeBackupForImport, validateBackupShape } from './backup'
 
 const baseV3 = {
   version: 3,

--- a/apps/web/src/lib/db/backup.ts
+++ b/apps/web/src/lib/db/backup.ts
@@ -1,0 +1,218 @@
+import { createDefaultPortfolioBuckets } from '../investments/portfolioBuckets'
+import type { LokfiDatabase } from './db'
+
+export const BACKUP_VERSION = 4
+
+export interface LokfiBackup {
+  version: 1 | 2 | 3 | 4
+  exportedAt?: string
+  transactions: unknown[]
+  rules: unknown[]
+  categories: unknown[]
+  customParsers: unknown[]
+  budgets: unknown[]
+  brokeragePositions: unknown[]
+  brokeragePositionExtensions: unknown[]
+  brokerageTransactions: unknown[]
+  brokerageFundDetails: unknown[]
+  brokerageAccounts: unknown[]
+  brokerageSyncLog: unknown[]
+  brokerageCredentials: unknown[]
+  portfolioBuckets: unknown[]
+  portfolioBucketAssignments: unknown[]
+}
+
+function isArray(value: unknown): value is unknown[] {
+  return Array.isArray(value)
+}
+
+export function validateBackupShape(data: unknown): { valid: true } | { valid: false; message: string } {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { valid: false, message: 'Invalid backup file: expected an object.' }
+  }
+  const candidate = data as Record<string, unknown>
+  const version = Number(candidate.version)
+  if (![1, 2, 3, 4].includes(version)) {
+    return { valid: false, message: 'Invalid backup file: unsupported backup version.' }
+  }
+  for (const key of ['transactions', 'rules', 'categories', 'customParsers', 'budgets']) {
+    if (!isArray(candidate[key])) {
+      return { valid: false, message: `Invalid backup file: missing ${key} array.` }
+    }
+  }
+  if (version >= 2) {
+    for (const key of [
+      'brokeragePositions',
+      'brokeragePositionExtensions',
+      'brokerageTransactions',
+      'brokerageAccounts',
+      'brokerageSyncLog',
+      'brokerageCredentials',
+    ]) {
+      if (!isArray(candidate[key])) {
+        return { valid: false, message: `Invalid brokerage backup file: missing ${key} array.` }
+      }
+    }
+  }
+  if (version >= 3 && !isArray(candidate.brokerageFundDetails)) {
+    return { valid: false, message: 'Invalid v3 backup file: missing brokerageFundDetails array.' }
+  }
+  if (version === 4) {
+    if (!isArray(candidate.portfolioBuckets) || !isArray(candidate.portfolioBucketAssignments)) {
+      return { valid: false, message: 'Invalid v4 backup file: missing portfolio bucket arrays.' }
+    }
+  }
+  return { valid: true }
+}
+
+export function normalizeBackupForImport(data: Record<string, unknown>): LokfiBackup {
+  const version = Number(data.version) as 1 | 2 | 3 | 4
+  return {
+    version,
+    exportedAt: typeof data.exportedAt === 'string' ? data.exportedAt : undefined,
+    transactions: data.transactions as unknown[],
+    rules: data.rules as unknown[],
+    categories: data.categories as unknown[],
+    customParsers: data.customParsers as unknown[],
+    budgets: data.budgets as unknown[],
+    brokeragePositions: version >= 2 ? (data.brokeragePositions as unknown[]) : [],
+    brokeragePositionExtensions: version >= 2 ? (data.brokeragePositionExtensions as unknown[]) : [],
+    brokerageTransactions: version >= 2 ? (data.brokerageTransactions as unknown[]) : [],
+    brokerageFundDetails: version >= 3 ? (data.brokerageFundDetails as unknown[]) : [],
+    brokerageAccounts: version >= 2 ? (data.brokerageAccounts as unknown[]) : [],
+    brokerageSyncLog: version >= 2 ? (data.brokerageSyncLog as unknown[]) : [],
+    brokerageCredentials: version >= 2 ? (data.brokerageCredentials as unknown[]) : [],
+    portfolioBuckets: version === 4 ? (data.portfolioBuckets as unknown[]) : [],
+    portfolioBucketAssignments: version === 4 ? (data.portfolioBucketAssignments as unknown[]) : [],
+  }
+}
+
+export function buildImportSummary(data: LokfiBackup): string {
+  return (
+    `This will replace all current data with the backup:\n` +
+    `• ${data.transactions.length} transaction(s)\n` +
+    `• ${data.rules.length} rule(s)\n` +
+    `• ${data.categories.length} categor(ies)\n` +
+    `• ${data.customParsers.length} parser profile(s)\n` +
+    `• ${data.budgets.length} budget(s)\n` +
+    `• ${data.brokeragePositions.length} brokerage position(s)\n` +
+    `• ${data.brokerageTransactions.length} brokerage trade(s)\n` +
+    `• ${data.brokerageFundDetails.length} fund detail(s)\n` +
+    `• ${data.brokerageAccounts.length} brokerage account(s)\n` +
+    `• ${data.brokerageCredentials.length} credential(s) (encrypted)\n` +
+    `• ${data.portfolioBuckets.length} portfolio bucket(s)\n` +
+    `• ${data.portfolioBucketAssignments.length} portfolio bucket assignment(s)\n` +
+    `Current data will be overwritten. Are you sure?`
+  )
+}
+
+export async function buildBackupPayload(db: LokfiDatabase): Promise<LokfiBackup & { exportedAt: string }> {
+  const [
+    transactions,
+    rules,
+    categories,
+    customParsers,
+    budgets,
+    brokeragePositions,
+    brokeragePositionExtensions,
+    brokerageTransactions,
+    brokerageFundDetails,
+    brokerageAccounts,
+    brokerageSyncLog,
+    brokerageCredentials,
+    portfolioBuckets,
+    portfolioBucketAssignments,
+  ] = await Promise.all([
+    db.transactions.toArray(),
+    db.rules.toArray(),
+    db.categories.toArray(),
+    db.customParsers.toArray(),
+    db.budgets.toArray(),
+    db.brokeragePositions.toArray(),
+    db.brokeragePositionExtensions.toArray(),
+    db.brokerageTransactions.toArray(),
+    db.brokerageFundDetails.toArray(),
+    db.brokerageAccounts.toArray(),
+    db.brokerageSyncLog.toArray(),
+    db.brokerageCredentials.toArray(),
+    db.portfolioBuckets.toArray(),
+    db.portfolioBucketAssignments.toArray(),
+  ])
+  return {
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    transactions,
+    rules,
+    categories,
+    customParsers,
+    budgets,
+    brokeragePositions,
+    brokeragePositionExtensions,
+    brokerageTransactions,
+    brokerageFundDetails,
+    brokerageAccounts,
+    brokerageSyncLog,
+    brokerageCredentials,
+    portfolioBuckets,
+    portfolioBucketAssignments,
+  }
+}
+
+export async function importBackupPayload(db: LokfiDatabase, data: LokfiBackup): Promise<void> {
+  await db.transaction(
+    'rw',
+    [
+      db.transactions,
+      db.rules,
+      db.categories,
+      db.customParsers,
+      db.budgets,
+      db.brokeragePositions,
+      db.brokeragePositionExtensions,
+      db.brokerageTransactions,
+      db.brokerageFundDetails,
+      db.brokerageAccounts,
+      db.brokerageSyncLog,
+      db.brokerageCredentials,
+      db.portfolioBuckets,
+      db.portfolioBucketAssignments,
+    ],
+    async () => {
+      await Promise.all([
+        db.transactions.clear(),
+        db.rules.clear(),
+        db.categories.clear(),
+        db.customParsers.clear(),
+        db.budgets.clear(),
+        db.brokeragePositions.clear(),
+        db.brokeragePositionExtensions.clear(),
+        db.brokerageTransactions.clear(),
+        db.brokerageFundDetails.clear(),
+        db.brokerageAccounts.clear(),
+        db.brokerageSyncLog.clear(),
+        db.brokerageCredentials.clear(),
+        db.portfolioBuckets.clear(),
+        db.portfolioBucketAssignments.clear(),
+      ])
+      if (data.transactions.length) await db.transactions.bulkAdd(data.transactions as never[])
+      if (data.rules.length) await db.rules.bulkAdd(data.rules as never[])
+      if (data.categories.length) await db.categories.bulkAdd(data.categories as never[])
+      if (data.customParsers.length) await db.customParsers.bulkAdd(data.customParsers as never[])
+      if (data.budgets.length) await db.budgets.bulkAdd(data.budgets as never[])
+      if (data.brokeragePositions.length) await db.brokeragePositions.bulkAdd(data.brokeragePositions as never[])
+      if (data.brokeragePositionExtensions.length) {
+        await db.brokeragePositionExtensions.bulkAdd(data.brokeragePositionExtensions as never[])
+      }
+      if (data.brokerageTransactions.length) await db.brokerageTransactions.bulkAdd(data.brokerageTransactions as never[])
+      if (data.brokerageFundDetails.length) await db.brokerageFundDetails.bulkAdd(data.brokerageFundDetails as never[])
+      if (data.brokerageAccounts.length) await db.brokerageAccounts.bulkAdd(data.brokerageAccounts as never[])
+      if (data.brokerageSyncLog.length) await db.brokerageSyncLog.bulkAdd(data.brokerageSyncLog as never[])
+      if (data.brokerageCredentials.length) await db.brokerageCredentials.bulkAdd(data.brokerageCredentials as never[])
+      const buckets = data.portfolioBuckets.length ? data.portfolioBuckets : createDefaultPortfolioBuckets()
+      if (buckets.length) await db.portfolioBuckets.bulkAdd(buckets as never[])
+      if (data.portfolioBucketAssignments.length) {
+        await db.portfolioBucketAssignments.bulkAdd(data.portfolioBucketAssignments as never[])
+      }
+    }
+  )
+}

--- a/apps/web/src/lib/db/backup.ts
+++ b/apps/web/src/lib/db/backup.ts
@@ -1,10 +1,10 @@
 import { createDefaultPortfolioBuckets } from '../investments/portfolioBuckets'
 import type { LokfiDatabase } from './db'
 
-export const BACKUP_VERSION = 4
+export const BACKUP_VERSION = 5
 
 export interface LokfiBackup {
-  version: 1 | 2 | 3 | 4
+  version: 1 | 2 | 3 | 4 | 5
   exportedAt?: string
   transactions: unknown[]
   rules: unknown[]
@@ -20,6 +20,7 @@ export interface LokfiBackup {
   brokerageCredentials: unknown[]
   portfolioBuckets: unknown[]
   portfolioBucketAssignments: unknown[]
+  portfolioSnapshots: unknown[]
 }
 
 function isArray(value: unknown): value is unknown[] {
@@ -32,7 +33,7 @@ export function validateBackupShape(data: unknown): { valid: true } | { valid: f
   }
   const candidate = data as Record<string, unknown>
   const version = Number(candidate.version)
-  if (![1, 2, 3, 4].includes(version)) {
+  if (![1, 2, 3, 4, 5].includes(version)) {
     return { valid: false, message: 'Invalid backup file: unsupported backup version.' }
   }
   for (const key of ['transactions', 'rules', 'categories', 'customParsers', 'budgets']) {
@@ -57,16 +58,19 @@ export function validateBackupShape(data: unknown): { valid: true } | { valid: f
   if (version >= 3 && !isArray(candidate.brokerageFundDetails)) {
     return { valid: false, message: 'Invalid v3 backup file: missing brokerageFundDetails array.' }
   }
-  if (version === 4) {
+  if (version >= 4) {
     if (!isArray(candidate.portfolioBuckets) || !isArray(candidate.portfolioBucketAssignments)) {
       return { valid: false, message: 'Invalid v4 backup file: missing portfolio bucket arrays.' }
     }
+  }
+  if (version >= 5 && !isArray(candidate.portfolioSnapshots)) {
+    return { valid: false, message: 'Invalid v5 backup file: missing portfolioSnapshots array.' }
   }
   return { valid: true }
 }
 
 export function normalizeBackupForImport(data: Record<string, unknown>): LokfiBackup {
-  const version = Number(data.version) as 1 | 2 | 3 | 4
+  const version = Number(data.version) as 1 | 2 | 3 | 4 | 5
   return {
     version,
     exportedAt: typeof data.exportedAt === 'string' ? data.exportedAt : undefined,
@@ -82,8 +86,9 @@ export function normalizeBackupForImport(data: Record<string, unknown>): LokfiBa
     brokerageAccounts: version >= 2 ? (data.brokerageAccounts as unknown[]) : [],
     brokerageSyncLog: version >= 2 ? (data.brokerageSyncLog as unknown[]) : [],
     brokerageCredentials: version >= 2 ? (data.brokerageCredentials as unknown[]) : [],
-    portfolioBuckets: version === 4 ? (data.portfolioBuckets as unknown[]) : [],
-    portfolioBucketAssignments: version === 4 ? (data.portfolioBucketAssignments as unknown[]) : [],
+    portfolioBuckets: version >= 4 ? (data.portfolioBuckets as unknown[]) : [],
+    portfolioBucketAssignments: version >= 4 ? (data.portfolioBucketAssignments as unknown[]) : [],
+    portfolioSnapshots: version >= 5 ? (data.portfolioSnapshots as unknown[]) : [],
   }
 }
 
@@ -102,6 +107,7 @@ export function buildImportSummary(data: LokfiBackup): string {
     `• ${data.brokerageCredentials.length} credential(s) (encrypted)\n` +
     `• ${data.portfolioBuckets.length} portfolio bucket(s)\n` +
     `• ${data.portfolioBucketAssignments.length} portfolio bucket assignment(s)\n` +
+    `• ${data.portfolioSnapshots.length} portfolio snapshot(s)\n` +
     `Current data will be overwritten. Are you sure?`
   )
 }
@@ -122,6 +128,7 @@ export async function buildBackupPayload(db: LokfiDatabase): Promise<LokfiBackup
     brokerageCredentials,
     portfolioBuckets,
     portfolioBucketAssignments,
+    portfolioSnapshots,
   ] = await Promise.all([
     db.transactions.toArray(),
     db.rules.toArray(),
@@ -137,6 +144,7 @@ export async function buildBackupPayload(db: LokfiDatabase): Promise<LokfiBackup
     db.brokerageCredentials.toArray(),
     db.portfolioBuckets.toArray(),
     db.portfolioBucketAssignments.toArray(),
+    db.portfolioSnapshots.toArray(),
   ])
   return {
     version: BACKUP_VERSION,
@@ -155,6 +163,7 @@ export async function buildBackupPayload(db: LokfiDatabase): Promise<LokfiBackup
     brokerageCredentials,
     portfolioBuckets,
     portfolioBucketAssignments,
+    portfolioSnapshots,
   }
 }
 
@@ -176,6 +185,7 @@ export async function importBackupPayload(db: LokfiDatabase, data: LokfiBackup):
       db.brokerageCredentials,
       db.portfolioBuckets,
       db.portfolioBucketAssignments,
+      db.portfolioSnapshots,
     ],
     async () => {
       await Promise.all([
@@ -193,6 +203,7 @@ export async function importBackupPayload(db: LokfiDatabase, data: LokfiBackup):
         db.brokerageCredentials.clear(),
         db.portfolioBuckets.clear(),
         db.portfolioBucketAssignments.clear(),
+        db.portfolioSnapshots.clear(),
       ])
       if (data.transactions.length) await db.transactions.bulkAdd(data.transactions as never[])
       if (data.rules.length) await db.rules.bulkAdd(data.rules as never[])
@@ -214,6 +225,7 @@ export async function importBackupPayload(db: LokfiDatabase, data: LokfiBackup):
       if (data.portfolioBucketAssignments.length) {
         await db.portfolioBucketAssignments.bulkAdd(data.portfolioBucketAssignments as never[])
       }
+      if (data.portfolioSnapshots.length) await db.portfolioSnapshots.bulkAdd(data.portfolioSnapshots as never[])
     }
   )
 }

--- a/apps/web/src/lib/db/backup.ts
+++ b/apps/web/src/lib/db/backup.ts
@@ -203,7 +203,8 @@ export async function importBackupPayload(db: LokfiDatabase, data: LokfiBackup):
       if (data.brokeragePositionExtensions.length) {
         await db.brokeragePositionExtensions.bulkAdd(data.brokeragePositionExtensions as never[])
       }
-      if (data.brokerageTransactions.length) await db.brokerageTransactions.bulkAdd(data.brokerageTransactions as never[])
+      if (data.brokerageTransactions.length)
+        await db.brokerageTransactions.bulkAdd(data.brokerageTransactions as never[])
       if (data.brokerageFundDetails.length) await db.brokerageFundDetails.bulkAdd(data.brokerageFundDetails as never[])
       if (data.brokerageAccounts.length) await db.brokerageAccounts.bulkAdd(data.brokerageAccounts as never[])
       if (data.brokerageSyncLog.length) await db.brokerageSyncLog.bulkAdd(data.brokerageSyncLog as never[])

--- a/apps/web/src/lib/db/db.ts
+++ b/apps/web/src/lib/db/db.ts
@@ -65,6 +65,12 @@ export interface DbBudget {
   updatedAt: string
 }
 
+export interface DbPortfolioSnapshot {
+  date: string       // YYYY-MM-DD, primary key
+  totalValue: number
+  currency: string   // preferred currency used at snapshot time
+}
+
 export class LokfiDatabase extends Dexie {
   // Bank statement tables
   transactions!: Table<DbTransaction>
@@ -87,6 +93,9 @@ export class LokfiDatabase extends Dexie {
   // Investment portfolio bucket tables (v9)
   portfolioBuckets!: Table<DbPortfolioBucket>
   portfolioBucketAssignments!: Table<DbPortfolioBucketAssignment>
+
+  // Portfolio performance snapshots (v10)
+  portfolioSnapshots!: Table<DbPortfolioSnapshot>
 
   constructor() {
     super('lokfi')
@@ -172,6 +181,11 @@ export class LokfiDatabase extends Dexie {
           await table.bulkAdd(createDefaultPortfolioBuckets())
         }
       })
+
+    // v10 schema (adds daily portfolio value snapshots for performance chart)
+    this.version(10).stores({
+      portfolioSnapshots: 'date',
+    })
 
     // Seed default categories and portfolio buckets on initial DB creation
     this.on('populate', () => {

--- a/apps/web/src/lib/db/db.ts
+++ b/apps/web/src/lib/db/db.ts
@@ -10,9 +10,9 @@ import type {
 import type { CustomParserProfile, StatementSource } from '@lokfi/parser-core'
 import Dexie, { type Table } from 'dexie'
 import {
-  createDefaultPortfolioBuckets,
   type DbPortfolioBucket,
   type DbPortfolioBucketAssignment,
+  createDefaultPortfolioBuckets,
 } from '../investments/portfolioBuckets'
 import { type DbCategory, defaultCategories } from './seedCategories'
 

--- a/apps/web/src/lib/db/db.ts
+++ b/apps/web/src/lib/db/db.ts
@@ -9,6 +9,11 @@ import type {
 } from '@lokfi/brokerage-core'
 import type { CustomParserProfile, StatementSource } from '@lokfi/parser-core'
 import Dexie, { type Table } from 'dexie'
+import {
+  createDefaultPortfolioBuckets,
+  type DbPortfolioBucket,
+  type DbPortfolioBucketAssignment,
+} from '../investments/portfolioBuckets'
 import { type DbCategory, defaultCategories } from './seedCategories'
 
 export interface DbTransaction {
@@ -78,6 +83,10 @@ export class LokfiDatabase extends Dexie {
   brokerageSyncLog!: Table<BrokerageSyncLog>
   brokerageCredentials!: Table<BrokerageCredentials>
   fxRates!: Table<FxRateRecord>
+
+  // Investment portfolio bucket tables (v9)
+  portfolioBuckets!: Table<DbPortfolioBucket>
+  portfolioBucketAssignments!: Table<DbPortfolioBucketAssignment>
 
   constructor() {
     super('lokfi')
@@ -150,9 +159,24 @@ export class LokfiDatabase extends Dexie {
       }
     })
 
-    // Seed default categories on initial DB creation
+    // v9 schema (adds user-defined investment portfolio buckets)
+    this.version(9)
+      .stores({
+        portfolioBuckets: 'id, sortOrder, name',
+        portfolioBucketAssignments: 'securityKey, bucketId',
+      })
+      .upgrade(async (trans) => {
+        const table = trans.table('portfolioBuckets')
+        const count = await table.count()
+        if (count === 0) {
+          await table.bulkAdd(createDefaultPortfolioBuckets())
+        }
+      })
+
+    // Seed default categories and portfolio buckets on initial DB creation
     this.on('populate', () => {
       this.categories.bulkAdd(defaultCategories)
+      this.portfolioBuckets.bulkAdd(createDefaultPortfolioBuckets())
     })
   }
 }

--- a/apps/web/src/lib/investments/portfolioBuckets.test.ts
+++ b/apps/web/src/lib/investments/portfolioBuckets.test.ts
@@ -1,0 +1,163 @@
+import type { BrokeragePosition } from '@lokfi/brokerage-core'
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PORTFOLIO_BUCKETS,
+  buildBucketLookup,
+  buildBucketOptions,
+  createDefaultPortfolioBuckets,
+  filterPositionsByBucket,
+  getPortfolioBucketAggregation,
+  getSecurityKey,
+  isStockLikePosition,
+  removeAssignmentsForBucket,
+} from './portfolioBuckets'
+
+function position(overrides: Partial<BrokeragePosition> = {}): BrokeragePosition {
+  return {
+    id: overrides.id ?? 'pos-1',
+    source: overrides.source ?? 'test',
+    symbol: overrides.symbol ?? 'AAPL',
+    name: overrides.name ?? 'Apple Inc.',
+    quantity: overrides.quantity ?? 10,
+    avgCost: overrides.avgCost ?? 100,
+    currency: overrides.currency ?? 'USD',
+    secType: overrides.secType ?? 'STK',
+    marketValue: overrides.marketValue,
+    updatedAt: overrides.updatedAt ?? '2026-05-11T00:00:00.000Z',
+  }
+}
+
+describe('portfolioBuckets', () => {
+  it('defines sparse default portfolio buckets in display order', () => {
+    expect(DEFAULT_PORTFOLIO_BUCKETS.map((bucket) => bucket.name)).toEqual(['Growth', 'Income', 'Cash'])
+    expect(DEFAULT_PORTFOLIO_BUCKETS.map((bucket) => bucket.sortOrder)).toEqual([0, 1, 2])
+  })
+
+  it('builds a stock-like security key from secType and uppercased symbol', () => {
+    expect(getSecurityKey(position({ symbol: 'aapl', secType: 'STK' }))).toBe('STK:AAPL')
+    expect(getSecurityKey(position({ symbol: 'sgov', secType: undefined }))).toBe('STK:SGOV')
+    expect(getSecurityKey(position({ symbol: 'AAPL', secType: 'FUND' }))).toBe('FUND:AAPL')
+  })
+
+  it('identifies stock-like positions and excludes derivatives', () => {
+    expect(isStockLikePosition(position({ secType: 'STK' }))).toBe(true)
+    expect(isStockLikePosition(position({ secType: 'FUND' }))).toBe(true)
+    expect(isStockLikePosition(position({ secType: 'CASH' }))).toBe(true)
+    expect(isStockLikePosition(position({ secType: 'OPT' }))).toBe(false)
+    expect(isStockLikePosition(position({ secType: 'FUT' }))).toBe(false)
+  })
+
+  it('filters positions by assigned bucket and unassigned state', () => {
+    const apple = position({ id: 'p1', symbol: 'AAPL' })
+    const microsoft = position({ id: 'p2', symbol: 'MSFT' })
+    const appleOption = position({ id: 'p3', symbol: 'AAPL', secType: 'OPT' })
+    const assignments = [{ securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' }]
+
+    expect(filterPositionsByBucket([apple, microsoft, appleOption], assignments, 'all')).toEqual([
+      apple,
+      microsoft,
+      appleOption,
+    ])
+    expect(filterPositionsByBucket([apple, microsoft, appleOption], assignments, 'bucket_growth')).toEqual([apple])
+    expect(filterPositionsByBucket([apple, microsoft, appleOption], assignments, 'unassigned')).toEqual([microsoft])
+  })
+
+  it('removes assignments for a deleted bucket', () => {
+    const assignments = [
+      { securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' },
+      { securityKey: 'STK:MSFT', bucketId: 'bucket_income', createdAt: 'now', updatedAt: 'now' },
+    ]
+
+    expect(removeAssignmentsForBucket(assignments, 'bucket_growth')).toEqual([
+      { securityKey: 'STK:MSFT', bucketId: 'bucket_income', createdAt: 'now', updatedAt: 'now' },
+    ])
+  })
+
+  it('aggregates stock-like positions by bucket and excludes derivatives', () => {
+    const buckets = [
+      {
+        id: 'bucket_growth',
+        name: 'Growth',
+        color: '#3b82f6',
+        sortOrder: 0,
+        isDefault: true,
+        createdAt: 'now',
+        updatedAt: 'now',
+      },
+      {
+        id: 'bucket_income',
+        name: 'Income',
+        color: '#22c55e',
+        sortOrder: 1,
+        isDefault: true,
+        createdAt: 'now',
+        updatedAt: 'now',
+      },
+    ]
+    const positions = [
+      position({ id: 'p1', symbol: 'AAPL', marketValue: 1200 }),
+      position({ id: 'p2', symbol: 'AAPL', marketValue: 800 }),
+      position({ id: 'p3', symbol: 'SCHD', marketValue: 1000 }),
+      position({ id: 'p4', symbol: 'AAPL', secType: 'OPT', marketValue: 500 }),
+      position({ id: 'p5', symbol: 'MSFT', quantity: 2, avgCost: 300, marketValue: undefined }),
+    ]
+    const assignments = [
+      { securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' },
+      { securityKey: 'STK:SCHD', bucketId: 'bucket_income', createdAt: 'now', updatedAt: 'now' },
+    ]
+
+    expect(getPortfolioBucketAggregation({ positions, buckets, assignments, convertValue: (value) => value })).toEqual([
+      { bucketId: 'bucket_growth', name: 'Growth', color: '#3b82f6', value: 2000, pct: 55.55555555555556 },
+      { bucketId: 'bucket_income', name: 'Income', color: '#22c55e', value: 1000, pct: 27.77777777777778 },
+      { bucketId: 'unassigned', name: 'Unassigned', color: '#94a3b8', value: 600, pct: 16.666666666666664 },
+    ])
+  })
+
+  it('builds bucket options with Unassigned after user buckets', () => {
+    const lookup = buildBucketLookup(DEFAULT_PORTFOLIO_BUCKETS)
+    expect(lookup.get('bucket_growth')?.name).toBe('Growth')
+    expect(buildBucketOptions(DEFAULT_PORTFOLIO_BUCKETS).map((option) => option.label)).toEqual([
+      'All buckets',
+      'Growth',
+      'Income',
+      'Cash',
+      'Unassigned',
+    ])
+  })
+})
+
+describe('createDefaultPortfolioBuckets', () => {
+  it('stamps default buckets at migration time while keeping stable ids', () => {
+    const buckets = createDefaultPortfolioBuckets('2026-05-11T12:00:00.000Z')
+
+    expect(buckets).toEqual([
+      {
+        id: 'bucket_growth',
+        name: 'Growth',
+        color: '#3b82f6',
+        sortOrder: 0,
+        isDefault: true,
+        createdAt: '2026-05-11T12:00:00.000Z',
+        updatedAt: '2026-05-11T12:00:00.000Z',
+      },
+      {
+        id: 'bucket_income',
+        name: 'Income',
+        color: '#22c55e',
+        sortOrder: 1,
+        isDefault: true,
+        createdAt: '2026-05-11T12:00:00.000Z',
+        updatedAt: '2026-05-11T12:00:00.000Z',
+      },
+      {
+        id: 'bucket_cash',
+        name: 'Cash',
+        color: '#f59e0b',
+        sortOrder: 2,
+        isDefault: true,
+        createdAt: '2026-05-11T12:00:00.000Z',
+        updatedAt: '2026-05-11T12:00:00.000Z',
+      },
+    ])
+  })
+})

--- a/apps/web/src/lib/investments/portfolioBuckets.ts
+++ b/apps/web/src/lib/investments/portfolioBuckets.ts
@@ -122,9 +122,7 @@ export function filterPositionsByBucket(
 export function buildBucketOptions(buckets: DbPortfolioBucket[]): Array<{ id: string; label: string }> {
   return [
     { id: 'all', label: 'All buckets' },
-    ...[...buckets]
-      .sort((a, b) => a.sortOrder - b.sortOrder)
-      .map((bucket) => ({ id: bucket.id, label: bucket.name })),
+    ...[...buckets].sort((a, b) => a.sortOrder - b.sortOrder).map((bucket) => ({ id: bucket.id, label: bucket.name })),
     { id: UNASSIGNED_BUCKET_ID, label: 'Unassigned' },
   ]
 }

--- a/apps/web/src/lib/investments/portfolioBuckets.ts
+++ b/apps/web/src/lib/investments/portfolioBuckets.ts
@@ -8,6 +8,7 @@ export interface DbPortfolioBucket {
   color: string
   sortOrder: number
   isDefault: boolean
+  targetPct?: number | null
   createdAt: string
   updatedAt: string
 }

--- a/apps/web/src/lib/investments/portfolioBuckets.ts
+++ b/apps/web/src/lib/investments/portfolioBuckets.ts
@@ -1,0 +1,186 @@
+import type { BrokeragePosition } from '@lokfi/brokerage-core'
+
+export const UNASSIGNED_BUCKET_ID = 'unassigned'
+
+export interface DbPortfolioBucket {
+  id: string
+  name: string
+  color: string
+  sortOrder: number
+  isDefault: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface DbPortfolioBucketAssignment {
+  securityKey: string
+  bucketId: string
+  createdAt: string
+  updatedAt: string
+}
+
+export const DEFAULT_PORTFOLIO_BUCKETS: DbPortfolioBucket[] = [
+  {
+    id: 'bucket_growth',
+    name: 'Growth',
+    color: '#3b82f6',
+    sortOrder: 0,
+    isDefault: true,
+    createdAt: '2026-05-11T00:00:00.000Z',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+  },
+  {
+    id: 'bucket_income',
+    name: 'Income',
+    color: '#22c55e',
+    sortOrder: 1,
+    isDefault: true,
+    createdAt: '2026-05-11T00:00:00.000Z',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+  },
+  {
+    id: 'bucket_cash',
+    name: 'Cash',
+    color: '#f59e0b',
+    sortOrder: 2,
+    isDefault: true,
+    createdAt: '2026-05-11T00:00:00.000Z',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+  },
+]
+
+export function createDefaultPortfolioBuckets(timestamp = new Date().toISOString()): DbPortfolioBucket[] {
+  return DEFAULT_PORTFOLIO_BUCKETS.map((bucket) => ({
+    ...bucket,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }))
+}
+
+const STOCK_LIKE_TYPES = new Set(['STK', 'CASH', 'FUND', 'MLEG'])
+
+export interface BucketAggregationRow {
+  bucketId: string
+  name: string
+  color: string
+  value: number
+  pct: number
+}
+
+export type BucketFilterValue = 'all' | 'unassigned' | string
+
+export function isStockLikePosition(position: BrokeragePosition): boolean {
+  return position.secType == null || STOCK_LIKE_TYPES.has(position.secType)
+}
+
+export function getSecurityKey(position: BrokeragePosition): string {
+  const secType = position.secType ?? 'STK'
+  return `${secType}:${position.symbol.trim().toUpperCase()}`
+}
+
+export function buildBucketLookup(buckets: DbPortfolioBucket[]): Map<string, DbPortfolioBucket> {
+  return new Map(buckets.map((bucket) => [bucket.id, bucket]))
+}
+
+export function buildAssignmentLookup(assignments: DbPortfolioBucketAssignment[]): Map<string, string> {
+  return new Map(assignments.map((assignment) => [assignment.securityKey, assignment.bucketId]))
+}
+
+export function getAssignedBucketId(
+  position: BrokeragePosition,
+  assignments: DbPortfolioBucketAssignment[]
+): string | null {
+  return buildAssignmentLookup(assignments).get(getSecurityKey(position)) ?? null
+}
+
+export function removeAssignmentsForBucket(
+  assignments: DbPortfolioBucketAssignment[],
+  bucketId: string
+): DbPortfolioBucketAssignment[] {
+  return assignments.filter((assignment) => assignment.bucketId !== bucketId)
+}
+
+export function filterPositionsByBucket(
+  positions: BrokeragePosition[],
+  assignments: DbPortfolioBucketAssignment[],
+  filter: BucketFilterValue
+): BrokeragePosition[] {
+  if (filter === 'all') return positions
+
+  const assignmentBySecurity = buildAssignmentLookup(assignments)
+
+  return positions.filter((position) => {
+    if (!isStockLikePosition(position)) return false
+
+    const assignedBucketId = assignmentBySecurity.get(getSecurityKey(position)) ?? null
+    if (filter === UNASSIGNED_BUCKET_ID) return assignedBucketId == null
+
+    return assignedBucketId === filter
+  })
+}
+
+export function buildBucketOptions(buckets: DbPortfolioBucket[]): Array<{ id: string; label: string }> {
+  return [
+    { id: 'all', label: 'All buckets' },
+    ...[...buckets]
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((bucket) => ({ id: bucket.id, label: bucket.name })),
+    { id: UNASSIGNED_BUCKET_ID, label: 'Unassigned' },
+  ]
+}
+
+export function getPortfolioBucketAggregation({
+  positions,
+  buckets,
+  assignments,
+  convertValue,
+}: {
+  positions: BrokeragePosition[]
+  buckets: DbPortfolioBucket[]
+  assignments: DbPortfolioBucketAssignment[]
+  convertValue: (value: number, position: BrokeragePosition) => number
+}): BucketAggregationRow[] {
+  const bucketById = buildBucketLookup(buckets)
+  const assignmentBySecurity = buildAssignmentLookup(assignments)
+  const totals = new Map<string, number>()
+
+  for (const position of positions) {
+    if (!isStockLikePosition(position)) continue
+
+    const rawValue = position.marketValue ?? position.quantity * position.avgCost
+    if (rawValue <= 0) continue
+
+    const assignedBucketId = assignmentBySecurity.get(getSecurityKey(position))
+    const bucketId = assignedBucketId && bucketById.has(assignedBucketId) ? assignedBucketId : UNASSIGNED_BUCKET_ID
+    totals.set(bucketId, (totals.get(bucketId) ?? 0) + convertValue(rawValue, position))
+  }
+
+  const totalValue = [...totals.values()].reduce((sum, value) => sum + value, 0)
+  const rows: BucketAggregationRow[] = []
+
+  for (const bucket of [...buckets].sort((a, b) => a.sortOrder - b.sortOrder)) {
+    const value = totals.get(bucket.id) ?? 0
+    if (value <= 0) continue
+
+    rows.push({
+      bucketId: bucket.id,
+      name: bucket.name,
+      color: bucket.color,
+      value,
+      pct: totalValue > 0 ? (value / totalValue) * 100 : 0,
+    })
+  }
+
+  const unassignedValue = totals.get(UNASSIGNED_BUCKET_ID) ?? 0
+  if (unassignedValue > 0) {
+    rows.push({
+      bucketId: UNASSIGNED_BUCKET_ID,
+      name: 'Unassigned',
+      color: '#94a3b8',
+      value: unassignedValue,
+      pct: totalValue > 0 ? (unassignedValue / totalValue) * 100 : 0,
+    })
+  }
+
+  return rows
+}

--- a/apps/web/src/lib/investments/portfolioPerformance.test.ts
+++ b/apps/web/src/lib/investments/portfolioPerformance.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { computeReturn, filterSnapshotsByRange } from './portfolioPerformance'
+
+const snap = (date: string, value: number) => ({ date, value })
+
+describe('filterSnapshotsByRange', () => {
+  const snapshots = [
+    snap('2025-05-12', 10000),
+    snap('2025-08-12', 11000),
+    snap('2025-11-12', 11500),
+    snap('2026-02-12', 12000),
+    snap('2026-05-11', 12500),
+  ]
+  const now = new Date('2026-05-12T00:00:00Z')
+
+  it('returns all snapshots for All', () => {
+    expect(filterSnapshotsByRange(snapshots, 'All', now)).toHaveLength(5)
+  })
+
+  it('filters to last 1 month', () => {
+    const result = filterSnapshotsByRange(snapshots, '1M', now)
+    expect(result.every((s) => s.date >= '2026-04-12')).toBe(true)
+    expect(result).toHaveLength(1)
+  })
+
+  it('filters to last 3 months', () => {
+    const result = filterSnapshotsByRange(snapshots, '3M', now)
+    expect(result.every((s) => s.date >= '2026-02-12')).toBe(true)
+    expect(result).toHaveLength(2)
+  })
+
+  it('filters to last 6 months', () => {
+    const result = filterSnapshotsByRange(snapshots, '6M', now)
+    expect(result.every((s) => s.date >= '2025-11-12')).toBe(true)
+    expect(result).toHaveLength(3)
+  })
+
+  it('filters to last 12 months (1Y)', () => {
+    const result = filterSnapshotsByRange(snapshots, '1Y', now)
+    expect(result.every((s) => s.date >= '2025-05-12')).toBe(true)
+    expect(result).toHaveLength(5)
+  })
+
+  it('filters YTD from Jan 1 of current year', () => {
+    const result = filterSnapshotsByRange(snapshots, 'YTD', now)
+    expect(result.every((s) => s.date >= '2026-01-01')).toBe(true)
+    expect(result).toHaveLength(2)
+  })
+})
+
+describe('computeReturn', () => {
+  it('returns null for fewer than 2 points', () => {
+    expect(computeReturn([])).toBeNull()
+    expect(computeReturn([snap('2026-01-01', 10000)])).toBeNull()
+  })
+
+  it('returns null if first value is zero', () => {
+    expect(computeReturn([snap('2026-01-01', 0), snap('2026-01-02', 100)])).toBeNull()
+  })
+
+  it('computes positive return', () => {
+    const result = computeReturn([snap('2026-01-01', 10000), snap('2026-05-01', 11000)])
+    expect(result).not.toBeNull()
+    expect(result!.pct).toBeCloseTo(10, 5)
+    expect(result!.abs).toBeCloseTo(1000, 5)
+  })
+
+  it('computes negative return', () => {
+    const result = computeReturn([snap('2026-01-01', 10000), snap('2026-05-01', 9000)])
+    expect(result!.pct).toBeCloseTo(-10, 5)
+    expect(result!.abs).toBeCloseTo(-1000, 5)
+  })
+
+  it('uses first and last points only, ignoring middle values', () => {
+    const result = computeReturn([
+      snap('2026-01-01', 10000),
+      snap('2026-03-01', 999999),
+      snap('2026-05-01', 12000),
+    ])
+    expect(result!.pct).toBeCloseTo(20, 5)
+    expect(result!.abs).toBeCloseTo(2000, 5)
+  })
+})

--- a/apps/web/src/lib/investments/portfolioPerformance.ts
+++ b/apps/web/src/lib/investments/portfolioPerformance.ts
@@ -1,0 +1,34 @@
+export type RangeKey = '1M' | '3M' | '6M' | '1Y' | 'YTD' | 'All'
+
+export interface SnapshotPoint {
+  date: string  // YYYY-MM-DD
+  value: number
+}
+
+export function filterSnapshotsByRange(
+  snapshots: SnapshotPoint[],
+  range: RangeKey,
+  now: Date,
+): SnapshotPoint[] {
+  if (range === 'All') return [...snapshots]
+
+  let cutoff: Date
+  if (range === 'YTD') {
+    cutoff = new Date(now.getFullYear(), 0, 1)
+  } else {
+    const monthsBack = { '1M': 1, '3M': 3, '6M': 6, '1Y': 12 }[range]
+    cutoff = new Date(now)
+    cutoff.setMonth(cutoff.getMonth() - monthsBack)
+  }
+
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+  return snapshots.filter((s) => s.date >= cutoffStr)
+}
+
+export function computeReturn(points: SnapshotPoint[]): { pct: number; abs: number } | null {
+  if (points.length < 2) return null
+  const first = points[0].value
+  const last = points[points.length - 1].value
+  if (first === 0) return null
+  return { pct: ((last - first) / first) * 100, abs: last - first }
+}

--- a/apps/web/src/lib/investments/usePortfolioSnapshot.test.ts
+++ b/apps/web/src/lib/investments/usePortfolioSnapshot.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { computePortfolioTotalValue } from './usePortfolioSnapshot'
+import type { BrokerageAccount, BrokeragePosition } from '@lokfi/brokerage-core'
+
+const pos = (currency: string, marketValue: number): BrokeragePosition =>
+  ({ currency, marketValue, quantity: 0, avgCost: 0 } as unknown as BrokeragePosition)
+
+const acc = (currency: string, cashBalance: number): BrokerageAccount =>
+  ({ currency, cashBalance } as unknown as BrokerageAccount)
+
+const rates = { SGD: 1.35, USD: 1 }
+
+describe('computePortfolioTotalValue', () => {
+  it('sums position market values without conversion when Original', () => {
+    const result = computePortfolioTotalValue(
+      [pos('USD', 1000), pos('SGD', 500)],
+      [],
+      'Original',
+      rates,
+    )
+    expect(result).toBeCloseTo(1500, 5)
+  })
+
+  it('converts positions and accounts to preferred currency', () => {
+    // 1000 USD → 1350 SGD, 500 SGD stays 500 SGD, 200 USD cash → 270 SGD
+    const result = computePortfolioTotalValue(
+      [pos('USD', 1000), pos('SGD', 500)],
+      [acc('USD', 200)],
+      'SGD',
+      rates,
+    )
+    expect(result).toBeCloseTo(1000 * 1.35 + 500 + 200 * 1.35, 2)
+  })
+
+  it('falls back to quantity * avgCost when marketValue is null', () => {
+    const position = { currency: 'USD', marketValue: null, quantity: 10, avgCost: 50 } as unknown as BrokeragePosition
+    const result = computePortfolioTotalValue([position], [], 'Original', null)
+    expect(result).toBeCloseTo(500, 5)
+  })
+
+  it('returns 0 for empty positions and accounts', () => {
+    expect(computePortfolioTotalValue([], [], 'SGD', rates)).toBe(0)
+  })
+})

--- a/apps/web/src/lib/investments/usePortfolioSnapshot.ts
+++ b/apps/web/src/lib/investments/usePortfolioSnapshot.ts
@@ -1,0 +1,40 @@
+import type { BrokerageAccount, BrokeragePosition } from '@lokfi/brokerage-core'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { useEffect } from 'react'
+import { convertAmount } from '../fx/convert'
+import { db } from '../db/db'
+import type { CurrencyOption } from '../../pages/investments/currencyPreference'
+
+export function computePortfolioTotalValue(
+  positions: BrokeragePosition[],
+  accounts: BrokerageAccount[],
+  preferredCurrency: CurrencyOption,
+  fxRates: Record<string, number> | null,
+): number {
+  const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+  let sum = 0
+  for (const p of positions) {
+    const v = p.marketValue ?? p.quantity * p.avgCost
+    sum += shouldConvert ? convertAmount(v, p.currency, preferredCurrency, fxRates) : v
+  }
+  for (const a of accounts) {
+    sum += shouldConvert ? convertAmount(a.cashBalance, a.currency, preferredCurrency, fxRates) : a.cashBalance
+  }
+  return sum
+}
+
+export function usePortfolioSnapshot(
+  preferredCurrency: CurrencyOption,
+  fxRates: Record<string, number> | null,
+): void {
+  const positions = useLiveQuery(() => db.brokeragePositions.toArray(), [])
+  const accounts = useLiveQuery(() => db.brokerageAccounts.toArray(), [])
+
+  useEffect(() => {
+    // Skip if data not loaded or currency is mixed-original (not comparable across currencies)
+    if (!positions || !accounts || preferredCurrency === 'Original') return
+    const totalValue = computePortfolioTotalValue(positions, accounts, preferredCurrency, fxRates)
+    const date = new Date().toISOString().slice(0, 10)
+    db.portfolioSnapshots.put({ date, totalValue, currency: preferredCurrency })
+  }, [positions, accounts, preferredCurrency, fxRates])
+}

--- a/apps/web/src/pages/investments/HoldingsTab.tsx
+++ b/apps/web/src/pages/investments/HoldingsTab.tsx
@@ -5,9 +5,18 @@ import { ChevronDown, ChevronRight, Info } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { db } from '../../lib/db/db'
 import { convertAmount } from '../../lib/fx/convert'
+import {
+  buildAssignmentLookup,
+  buildBucketOptions,
+  filterPositionsByBucket,
+  getSecurityKey,
+  type DbPortfolioBucketAssignment,
+} from '../../lib/investments/portfolioBuckets'
 import type { CurrencyOption } from './currencyPreference'
 import { getAdjustedMetrics } from './holdingCalculations'
 import type { HoldingMetrics } from './holdingCalculations'
+import { PortfolioBucketCombobox } from './PortfolioBucketCombobox'
+import { PortfolioBucketManager } from './PortfolioBucketManager'
 
 interface HoldingsTabProps {
   preferredCurrency: CurrencyOption
@@ -84,7 +93,7 @@ function HoldingDetailRow({ row, variant = 'stock' }: HoldingDetailRowProps) {
 
   return (
     <tr className="border-b" style={{ borderColor: 'var(--border)' }}>
-      <td colSpan={variant === 'stock' ? 13 : 7} className="px-4 py-3">
+      <td colSpan={variant === 'stock' ? 14 : 7} className="px-4 py-3">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
           {/* Left column */}
           <div className="space-y-2">
@@ -197,12 +206,22 @@ function HoldingsTable({
   preferredCurrency,
   fxRates,
   variant = 'stock',
+  assignments,
+  onAssignBucket,
+  onManageBuckets,
 }: {
   positions: PositionRow[]
   preferredCurrency: CurrencyOption
   fxRates: Record<string, number> | null
   variant?: 'stock' | 'derivative'
+  assignments?: DbPortfolioBucketAssignment[]
+  onAssignBucket?: (position: BrokeragePosition, bucketId: string | null) => void
+  onManageBuckets?: () => void
 }) {
+  const assignmentBySecurity = useMemo(
+    () => buildAssignmentLookup(assignments ?? []),
+    [assignments]
+  )
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
 
   function toggleExpand(id: string) {
@@ -443,6 +462,12 @@ function HoldingsTable({
                     {sortKey === 'totalReturn' && <span className="text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>}
                   </span>
                 </th>
+                <th
+                  className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  title="Portfolio bucket assignment for this security"
+                >
+                  Bucket
+                </th>
               </>
             )}
           </tr>
@@ -572,6 +597,15 @@ function HoldingsTable({
                         ? `${row.totalReturnPct >= 0 ? '+' : ''}${row.totalReturnPct.toFixed(2)}%`
                         : '—'}
                     </td>
+                    <td className="px-3 py-2.5 text-left" onClick={(event) => event.stopPropagation()}>
+                      {onAssignBucket && onManageBuckets ? (
+                        <PortfolioBucketCombobox
+                          value={assignmentBySecurity.get(getSecurityKey(position)) ?? null}
+                          onChange={(bucketId) => onAssignBucket(position, bucketId)}
+                          onManage={onManageBuckets}
+                        />
+                      ) : null}
+                    </td>
                   </>
                 )}
               </tr>
@@ -681,6 +715,9 @@ function CollapsibleCurrencyGroup({
   fxRates,
   defaultExpanded,
   variant = 'stock',
+  assignments,
+  onAssignBucket,
+  onManageBuckets,
 }: {
   currency: string
   label: string
@@ -689,6 +726,9 @@ function CollapsibleCurrencyGroup({
   fxRates: Record<string, number> | null
   defaultExpanded: boolean
   variant?: 'stock' | 'derivative'
+  assignments?: DbPortfolioBucketAssignment[]
+  onAssignBucket?: (position: BrokeragePosition, bucketId: string | null) => void
+  onManageBuckets?: () => void
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded)
 
@@ -715,7 +755,15 @@ function CollapsibleCurrencyGroup({
         </span>
       </button>
       {expanded && (
-        <HoldingsTable positions={rows} preferredCurrency={preferredCurrency} fxRates={fxRates} variant={variant} />
+        <HoldingsTable
+          positions={rows}
+          preferredCurrency={preferredCurrency}
+          fxRates={fxRates}
+          variant={variant}
+          assignments={assignments}
+          onAssignBucket={onAssignBucket}
+          onManageBuckets={onManageBuckets}
+        />
       )}
     </div>
   )
@@ -729,6 +777,9 @@ function PositionSection({
   fxRates,
   defaultExpanded,
   variant = 'stock',
+  assignments,
+  onAssignBucket,
+  onManageBuckets,
 }: {
   title: string
   rows: PositionRow[]
@@ -737,6 +788,9 @@ function PositionSection({
   defaultExpanded: boolean
   variant?: 'stock' | 'derivative'
   emptyMessage?: string
+  assignments?: DbPortfolioBucketAssignment[]
+  onAssignBucket?: (position: BrokeragePosition, bucketId: string | null) => void
+  onManageBuckets?: () => void
 }) {
   if (rows.length === 0) return null
 
@@ -762,6 +816,9 @@ function PositionSection({
           fxRates={fxRates}
           defaultExpanded={defaultExpanded}
           variant={variant}
+          assignments={assignments}
+          onAssignBucket={onAssignBucket}
+          onManageBuckets={onManageBuckets}
         />
       ))}
     </div>
@@ -770,8 +827,28 @@ function PositionSection({
 
 export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError }: HoldingsTabProps) {
   const [search, setSearch] = useState('')
+  const [bucketFilter, setBucketFilter] = useState('all')
+  const [bucketManagerOpen, setBucketManagerOpen] = useState(false)
 
   const allPositions = useLiveQuery(() => db.brokeragePositions.toArray(), [])
+  const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), []) ?? []
+  const assignments = useLiveQuery(() => db.portfolioBucketAssignments.toArray(), []) ?? []
+
+  async function handleAssignBucket(position: BrokeragePosition, bucketId: string | null) {
+    const securityKey = getSecurityKey(position)
+    if (bucketId == null) {
+      await db.portfolioBucketAssignments.delete(securityKey)
+      return
+    }
+    const now = new Date().toISOString()
+    const existing = await db.portfolioBucketAssignments.get(securityKey)
+    await db.portfolioBucketAssignments.put({
+      securityKey,
+      bucketId,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    })
+  }
 
   // Fund detail records for dividends and TRADE (used as fallback when
   // transaction buy history is incomplete — fund details accumulate across syncs)
@@ -799,11 +876,15 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
     return map
   }, [allPositions, optionPositions, fundDetails, allTransactions])
 
+  // Apply bucket filter to stock-like positions (derivatives remain visible unless
+  // the user picks a bucket — bucket assignments are stock-only).
+  const bucketFilteredPositions = filterPositionsByBucket(allPositions ?? [], assignments, bucketFilter)
+
   // Split into stock-like and derivatives
   const stockRows: PositionRow[] = []
   const derivativeRows: PositionRow[] = []
 
-  for (const p of allPositions ?? []) {
+  for (const p of bucketFilteredPositions) {
     const metrics = metricsByPositionId.get(p.id)
     const row = toRow(p, metrics)
     if (isStockLike(p)) {
@@ -914,6 +995,37 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
         )}
       </div>
 
+      {/* Bucket filter */}
+      <div className="flex items-center gap-2 overflow-x-auto pb-1">
+        {buildBucketOptions(buckets).map((option) => {
+          const active = bucketFilter === option.id
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setBucketFilter(option.id)}
+              className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                active ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'
+              }`}
+              style={{
+                borderColor: active ? 'var(--accent)' : 'var(--border)',
+                backgroundColor: active ? 'var(--accent-subtle)' : 'transparent',
+              }}
+            >
+              {option.label}
+            </button>
+          )
+        })}
+        <button
+          type="button"
+          onClick={() => setBucketManagerOpen(true)}
+          className="ml-auto shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          Manage buckets
+        </button>
+      </div>
+
       {/* No search results */}
       {search.trim() && filteredStock.length === 0 && filteredDerivatives.length === 0 && (
         <div className="text-center py-8 text-gray-500 dark:text-gray-400 text-sm">
@@ -928,6 +1040,9 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
         preferredCurrency={preferredCurrency}
         fxRates={fxRates}
         defaultExpanded={true}
+        assignments={assignments}
+        onAssignBucket={handleAssignBucket}
+        onManageBuckets={() => setBucketManagerOpen(true)}
       />
 
       {/* Derivatives section (options, futures, etc.) */}
@@ -939,6 +1054,8 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
         defaultExpanded={false}
         variant="derivative"
       />
+
+      <PortfolioBucketManager open={bucketManagerOpen} onClose={() => setBucketManagerOpen(false)} />
     </div>
   )
 }

--- a/apps/web/src/pages/investments/HoldingsTab.tsx
+++ b/apps/web/src/pages/investments/HoldingsTab.tsx
@@ -6,17 +6,17 @@ import { useMemo, useState } from 'react'
 import { db } from '../../lib/db/db'
 import { convertAmount } from '../../lib/fx/convert'
 import {
+  type DbPortfolioBucketAssignment,
   buildAssignmentLookup,
   buildBucketOptions,
   filterPositionsByBucket,
   getSecurityKey,
-  type DbPortfolioBucketAssignment,
 } from '../../lib/investments/portfolioBuckets'
+import { PortfolioBucketCombobox } from './PortfolioBucketCombobox'
+import { PortfolioBucketManager } from './PortfolioBucketManager'
 import type { CurrencyOption } from './currencyPreference'
 import { getAdjustedMetrics } from './holdingCalculations'
 import type { HoldingMetrics } from './holdingCalculations'
-import { PortfolioBucketCombobox } from './PortfolioBucketCombobox'
-import { PortfolioBucketManager } from './PortfolioBucketManager'
 
 interface HoldingsTabProps {
   preferredCurrency: CurrencyOption
@@ -218,10 +218,7 @@ function HoldingsTable({
   onAssignBucket?: (position: BrokeragePosition, bucketId: string | null) => void
   onManageBuckets?: () => void
 }) {
-  const assignmentBySecurity = useMemo(
-    () => buildAssignmentLookup(assignments ?? []),
-    [assignments]
-  )
+  const assignmentBySecurity = useMemo(() => buildAssignmentLookup(assignments ?? []), [assignments])
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
 
   function toggleExpand(id: string) {

--- a/apps/web/src/pages/investments/HoldingsTab.tsx
+++ b/apps/web/src/pages/investments/HoldingsTab.tsx
@@ -929,28 +929,6 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
     )
   }
 
-  if (stockRows.length === 0 && derivativeRows.length === 0) {
-    // All positions have an unexpected secType (shouldn't happen)
-    return (
-      <div
-        className="text-center p-8 rounded-xl border"
-        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
-      >
-        <p className="text-gray-600 dark:text-gray-400 mb-2">No recognizable holdings found.</p>
-        <p className="text-sm text-gray-400 dark:text-gray-500 mb-4">
-          Your account has positions with unknown security types. Try syncing again.
-        </p>
-        <Link
-          to="/settings/brokerage"
-          className="inline-flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-full text-white transition-colors"
-          style={{ backgroundColor: 'var(--accent)' }}
-        >
-          <Info size={14} />
-          Brokerage Settings
-        </Link>
-      </div>
-    )
-  }
 
   // ── Main render ────────────────────────────────────────────────────────
 
@@ -1023,10 +1001,32 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
         </button>
       </div>
 
-      {/* No search results */}
-      {search.trim() && filteredStock.length === 0 && filteredDerivatives.length === 0 && (
-        <div className="text-center py-8 text-gray-500 dark:text-gray-400 text-sm">
-          No results for &quot;{search}&quot;
+      {/* Empty state when filters produce no results */}
+      {filteredStock.length === 0 && filteredDerivatives.length === 0 && (
+        <div
+          className="rounded-xl border px-6 py-8 text-center text-sm"
+          style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+        >
+          {search.trim() ? (
+            <p className="text-gray-500 dark:text-gray-400">No results for &quot;{search}&quot;</p>
+          ) : bucketFilter !== 'all' ? (
+            <>
+              <p className="text-gray-600 dark:text-gray-400">No holdings in this bucket yet.</p>
+              <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                Assign holdings to this bucket from the <strong>All buckets</strong> view.
+              </p>
+              <button
+                type="button"
+                onClick={() => setBucketFilter('all')}
+                className="mt-4 rounded-full border px-4 py-1.5 text-xs font-medium transition-colors hover:opacity-80"
+                style={{ borderColor: 'var(--accent)', color: 'var(--accent)', backgroundColor: 'var(--accent-subtle)' }}
+              >
+                Show all holdings
+              </button>
+            </>
+          ) : (
+            <p className="text-gray-500 dark:text-gray-400">No recognizable holdings found.</p>
+          )}
         </div>
       )}
 

--- a/apps/web/src/pages/investments/OverviewTab.tsx
+++ b/apps/web/src/pages/investments/OverviewTab.tsx
@@ -6,9 +6,9 @@ import { TOOLTIP_STYLE } from '../../lib/charts/chartTheme'
 import { db } from '../../lib/db/db'
 import { convertAmount } from '../../lib/fx/convert'
 import {
-  getPortfolioBucketAggregation,
   type DbPortfolioBucket,
   type DbPortfolioBucketAssignment,
+  getPortfolioBucketAggregation,
 } from '../../lib/investments/portfolioBuckets'
 import type { CurrencyOption } from './currencyPreference'
 
@@ -228,7 +228,8 @@ function PortfolioBucketBreakdown({
               <span className="truncate">{row.name}</span>
             </span>
             <span className="font-mono text-gray-500 dark:text-gray-400">
-              {row.value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ({row.pct.toFixed(1)}%)
+              {row.value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} (
+              {row.pct.toFixed(1)}%)
             </span>
           </div>
         ))}

--- a/apps/web/src/pages/investments/OverviewTab.tsx
+++ b/apps/web/src/pages/investments/OverviewTab.tsx
@@ -1,8 +1,8 @@
 import { useLiveQuery } from 'dexie-react-hooks'
 import { AlertCircle, Minus, TrendingDown, TrendingUp } from 'lucide-react'
 import { useState } from 'react'
-import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
-import { TOOLTIP_STYLE } from '../../lib/charts/chartTheme'
+import { Area, AreaChart, Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
+import { AXIS_TICK, TOOLTIP_STYLE } from '../../lib/charts/chartTheme'
 import { db } from '../../lib/db/db'
 import { convertAmount } from '../../lib/fx/convert'
 import {
@@ -14,6 +14,9 @@ import {
   isStockLikePosition,
 } from '../../lib/investments/portfolioBuckets'
 import type { CurrencyOption } from './currencyPreference'
+import type { DbPortfolioSnapshot } from '../../lib/db/db'
+import { type RangeKey, type SnapshotPoint, computeReturn, filterSnapshotsByRange } from '../../lib/investments/portfolioPerformance'
+import { usePortfolioSnapshot } from '../../lib/investments/usePortfolioSnapshot'
 
 export interface OverviewTabProps {
   /** User's preferred display currency */
@@ -255,10 +258,42 @@ function PortfolioBucketBreakdown({
 }
 
 
-function PerformanceSparkline() {
-  // TODO: Implement historical snapshots — store portfolio value snapshots in
-  // brokerageAccounts history or a dedicated snapshot table, then compute
-  // value over time for the sparkline. Currently no historical data is stored.
+const PERFORMANCE_RANGES: RangeKey[] = ['1M', '3M', '6M', '1Y', 'YTD', 'All']
+
+function PerformanceCard({
+  snapshots,
+  preferredCurrency,
+  fxRates,
+}: {
+  snapshots: DbPortfolioSnapshot[]
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+}) {
+  const [range, setRange] = useState<RangeKey>('1Y')
+
+  const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+
+  const points: SnapshotPoint[] = snapshots.map((s) => ({
+    date: s.date,
+    value:
+      shouldConvert && s.currency !== preferredCurrency
+        ? convertAmount(s.totalValue, s.currency, preferredCurrency, fxRates)
+        : s.totalValue,
+  }))
+
+  const filtered = filterSnapshotsByRange(points, range, new Date())
+  const ret = computeReturn(filtered)
+
+  const fmt = (v: number) => v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+  const currencyLabel = preferredCurrency === 'Original' ? '' : `${preferredCurrency} `
+
+  const returnColor =
+    ret === null || ret.pct === 0
+      ? 'text-gray-900 dark:text-white'
+      : ret.pct > 0
+        ? 'text-emerald-600 dark:text-emerald-400'
+        : 'text-red-600 dark:text-red-400'
+
   return (
     <div
       className="rounded-xl border p-5"
@@ -267,19 +302,67 @@ function PerformanceSparkline() {
       <div className="mb-4 flex items-center justify-between">
         <h3 className="font-serif text-sm font-medium text-gray-900 dark:text-white">Performance</h3>
         <div className="flex gap-1">
-          {['1M', '3M', '6M', '1Y', 'YTD', 'All'].map((range) => (
+          {PERFORMANCE_RANGES.map((r) => (
             <button
-              key={range}
-              className="rounded px-2 py-0.5 text-xs text-gray-500 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+              key={r}
+              type="button"
+              onClick={() => setRange(r)}
+              className={`rounded px-2 py-0.5 text-xs transition-colors ${
+                r === range
+                  ? 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100'
+                  : 'text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800'
+              }`}
             >
-              {range}
+              {r}
             </button>
           ))}
         </div>
       </div>
-      <div className="flex h-40 items-center justify-center text-sm text-gray-400">
-        Not enough data — sync again to build history
-      </div>
+
+      {ret !== null && (
+        <div className="mb-4">
+          <div className={`font-mono text-2xl font-semibold tabular-nums ${returnColor}`}>
+            {ret.pct >= 0 ? '+' : ''}
+            {ret.pct.toFixed(2)}%
+          </div>
+          <div className="text-xs text-gray-400">
+            {ret.abs >= 0 ? '+' : ''}
+            {currencyLabel}
+            {fmt(ret.abs)}
+          </div>
+        </div>
+      )}
+
+      {filtered.length < 2 ? (
+        <div className="flex h-40 items-center justify-center text-sm text-gray-400">
+          Sync again to start building history
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={160}>
+          <AreaChart data={filtered} margin={{ top: 4, right: 0, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id="perfGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--accent)" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="var(--accent)" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis dataKey="date" tick={AXIS_TICK} tickLine={false} axisLine={false} minTickGap={40} />
+            <Tooltip
+              contentStyle={TOOLTIP_STYLE}
+              formatter={(value: number) => [`${currencyLabel}${fmt(value)}`, 'Value']}
+            />
+            <Area
+              type="monotone"
+              dataKey="value"
+              stroke="var(--accent)"
+              strokeWidth={2}
+              fill="url(#perfGradient)"
+              dot={false}
+              activeDot={{ r: 4 }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      )}
     </div>
   )
 }
@@ -313,13 +396,17 @@ export function OverviewTab({
   const fundDetails = useLiveQuery(() => db.brokerageFundDetails.toArray(), [])
   const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), [])
   const assignments = useLiveQuery(() => db.portfolioBucketAssignments.toArray(), [])
+  const snapshots = useLiveQuery(() => db.portfolioSnapshots.orderBy('date').toArray(), [])
 
   const isLoading =
     positions === undefined ||
     accounts === undefined ||
     fundDetails === undefined ||
     buckets === undefined ||
-    assignments === undefined
+    assignments === undefined ||
+    snapshots === undefined
+
+  usePortfolioSnapshot(preferredCurrency, fxRates)
 
   // ── Derived values ─────────────────────────────────────────────────────────
 
@@ -392,10 +479,14 @@ export function OverviewTab({
         />
       )}
 
-      {/* Performance sparkline */}
-      {!isLoading && hasData && (
+      {/* Performance card */}
+      {!isLoading && (
         <div className="md:col-span-2 lg:col-span-3">
-          <PerformanceSparkline />
+          <PerformanceCard
+            snapshots={snapshots!}
+            preferredCurrency={preferredCurrency}
+            fxRates={fxRates}
+          />
         </div>
       )}
     </div>

--- a/apps/web/src/pages/investments/OverviewTab.tsx
+++ b/apps/web/src/pages/investments/OverviewTab.tsx
@@ -1,14 +1,17 @@
 import { useLiveQuery } from 'dexie-react-hooks'
 import { AlertCircle, Minus, TrendingDown, TrendingUp } from 'lucide-react'
+import { useState } from 'react'
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
-import { CATEGORY_PALETTE } from '../../lib/charts/chartPalette'
 import { TOOLTIP_STYLE } from '../../lib/charts/chartTheme'
 import { db } from '../../lib/db/db'
 import { convertAmount } from '../../lib/fx/convert'
 import {
   type DbPortfolioBucket,
   type DbPortfolioBucketAssignment,
+  buildAssignmentLookup,
   getPortfolioBucketAggregation,
+  getSecurityKey,
+  isStockLikePosition,
 } from '../../lib/investments/portfolioBuckets'
 import type { CurrencyOption } from './currencyPreference'
 
@@ -75,94 +78,6 @@ function KpiCard({ title, value, secondary, warning, trend, loading }: KpiCardPr
   )
 }
 
-function AllocationChart({
-  positions,
-  totalValue,
-  preferredCurrency,
-  fxRates,
-  loading,
-}: {
-  positions: import('@lokfi/brokerage-core').BrokeragePosition[]
-  totalValue: number
-  preferredCurrency: CurrencyOption
-  fxRates: Record<string, number> | null
-  loading?: boolean
-}) {
-  if (loading) {
-    return (
-      <div
-        className="animate-pulse rounded-xl border p-5"
-        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
-      >
-        <div className="mb-4 h-4 w-32 rounded bg-gray-200 dark:bg-gray-700" />
-        <div className="flex justify-center">
-          <div className="h-48 w-48 rounded-full bg-gray-200 dark:bg-gray-700" />
-        </div>
-      </div>
-    )
-  }
-
-  if (positions.length === 0) {
-    return null
-  }
-
-  // Group by secType
-  const grouped: Record<string, number> = {}
-  for (const p of positions) {
-    const secType = p.secType ?? 'OTHER'
-    const value = p.marketValue ?? p.quantity * p.avgCost
-    const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
-    const convertedValue = shouldConvert ? convertAmount(value, p.currency, preferredCurrency, fxRates) : value
-    grouped[secType] = (grouped[secType] ?? 0) + convertedValue
-  }
-
-  const data = Object.entries(grouped)
-    .filter(([, v]) => v > 0)
-    .map(([name, value]) => ({
-      name,
-      value,
-      pct: totalValue > 0 ? (value / totalValue) * 100 : 0,
-    }))
-
-  if (data.length === 0) return null
-
-  const renderLabel = ({ name, percent }: { name: string; percent: number }) => `${name} ${(percent * 100).toFixed(1)}%`
-
-  return (
-    <div
-      className="rounded-xl border p-5"
-      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
-    >
-      <h3 className="mb-4 font-serif text-sm font-medium text-gray-900 dark:text-white">Asset Allocation</h3>
-      <ResponsiveContainer width="100%" height={260}>
-        <PieChart>
-          <Pie
-            data={data}
-            cx="50%"
-            cy="50%"
-            innerRadius={55}
-            outerRadius={75}
-            dataKey="value"
-            labelLine={false}
-            label={renderLabel}
-          >
-            {data.map((_, index) => (
-              <Cell key={`cell-${index}`} fill={CATEGORY_PALETTE[index % CATEGORY_PALETTE.length]} />
-            ))}
-          </Pie>
-          <Tooltip
-            contentStyle={TOOLTIP_STYLE}
-            formatter={(value: number) => [
-              value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-              'Value',
-            ]}
-          />
-          <Legend formatter={(value: string) => value} />
-        </PieChart>
-      </ResponsiveContainer>
-    </div>
-  )
-}
 
 function PortfolioBucketBreakdown({
   positions,
@@ -178,6 +93,8 @@ function PortfolioBucketBreakdown({
   fxRates: Record<string, number> | null
 }) {
   const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+
+  // Bucket-level aggregation drives the legend + bottom list
   const rows = getPortfolioBucketAggregation({
     positions,
     buckets,
@@ -186,7 +103,51 @@ function PortfolioBucketBreakdown({
       shouldConvert ? convertAmount(value, position.currency, preferredCurrency, fxRates) : value,
   })
 
+  const [expandedBuckets, setExpandedBuckets] = useState<Set<string>>(new Set())
+  function toggleBucket(id: string) {
+    setExpandedBuckets((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
   if (rows.length === 0) return null
+
+  // Per-position slices: each stock-like holding is its own slice, colored by its bucket
+  const bucketColorById = new Map(rows.map((r) => [r.bucketId, r.color]))
+  const bucketOrderById = new Map(rows.map((r, i) => [r.bucketId, i]))
+  const assignmentBySecurity = buildAssignmentLookup(assignments)
+  const slices = positions
+    .filter(isStockLikePosition)
+    .map((pos) => {
+      const raw = pos.marketValue ?? pos.quantity * pos.avgCost
+      if (raw <= 0) return null
+      const value = shouldConvert ? convertAmount(raw, pos.currency, preferredCurrency, fxRates) : raw
+      const bucketId = assignmentBySecurity.get(getSecurityKey(pos)) ?? 'unassigned'
+      return { name: pos.symbol, value, color: bucketColorById.get(bucketId) ?? '#94a3b8', bucketId }
+    })
+    .filter((s): s is { name: string; value: number; color: string; bucketId: string } => s !== null)
+    .sort((a, b) => {
+      const orderDiff = (bucketOrderById.get(a.bucketId) ?? 999) - (bucketOrderById.get(b.bucketId) ?? 999)
+      return orderDiff !== 0 ? orderDiff : b.value - a.value
+    })
+
+  // Target % lookup from the buckets prop (includes Unassigned which has no target)
+  const targetPctById = new Map(buckets.map((b) => [b.id, b.targetPct ?? null]))
+
+  // Sort buckets by value desc — used for legend and bucket rows
+  const rowsByValue = [...rows].sort((a, b) => b.value - a.value)
+  const legendPayload = rowsByValue.map((r) => ({ value: r.name, color: r.color, type: 'circle' as const }))
+
+  // Group slices by bucket for the expanded holding rows
+  const slicesByBucket = new Map<string, typeof slices>()
+  for (const slice of slices) {
+    const group = slicesByBucket.get(slice.bucketId) ?? []
+    group.push(slice)
+    slicesByBucket.set(slice.bucketId, group)
+  }
 
   return (
     <div
@@ -196,147 +157,93 @@ function PortfolioBucketBreakdown({
       <h3 className="mb-4 font-serif text-sm font-medium text-gray-900 dark:text-white">Portfolio by bucket</h3>
       <ResponsiveContainer width="100%" height={260}>
         <PieChart>
-          <Pie
-            data={rows}
-            cx="50%"
-            cy="50%"
-            innerRadius={55}
-            outerRadius={75}
-            dataKey="value"
-            labelLine={false}
-            label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(1)}%`}
-          >
-            {rows.map((row) => (
-              <Cell key={row.bucketId} fill={row.color} />
+          <Pie data={slices} cx="50%" cy="50%" innerRadius={55} outerRadius={75} dataKey="value">
+            {slices.map((slice, i) => (
+              <Cell key={`${slice.name}-${i}`} fill={slice.color} />
             ))}
           </Pie>
           <Tooltip
             contentStyle={TOOLTIP_STYLE}
-            formatter={(value: number) => [
+            formatter={(value: number, _name: string, props: { payload?: { name: string } }) => [
               value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-              'Value',
+              props.payload?.name ?? '',
             ]}
           />
-          <Legend formatter={(value: string) => value} />
+          <Legend payload={legendPayload} wrapperStyle={{ fontSize: '12px' }} />
         </PieChart>
       </ResponsiveContainer>
-      <div className="mt-3 space-y-2">
-        {rows.map((row) => (
-          <div key={row.bucketId} className="flex items-center justify-between text-xs">
-            <span className="flex min-w-0 items-center gap-2 text-gray-700 dark:text-gray-300">
-              <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: row.color }} />
-              <span className="truncate">{row.name}</span>
-            </span>
-            <span className="font-mono text-gray-500 dark:text-gray-400">
-              {row.value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} (
-              {row.pct.toFixed(1)}%)
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
 
-function CurrencyBreakdown({
-  positions,
-  accounts,
-  totalValue,
-  preferredCurrency,
-  fxRates,
-  loading,
-}: {
-  positions: import('@lokfi/brokerage-core').BrokeragePosition[]
-  accounts: import('@lokfi/brokerage-core').BrokerageAccount[]
-  totalValue: number
-  preferredCurrency: CurrencyOption
-  fxRates: Record<string, number> | null
-  loading?: boolean
-}) {
-  if (loading) {
-    return (
-      <div
-        className="animate-pulse rounded-xl border p-5"
-        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
-      >
-        <div className="mb-4 h-4 w-32 rounded bg-gray-200 dark:bg-gray-700" />
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="mb-3 flex items-center gap-3">
-            <div className="h-4 w-12 rounded bg-gray-200 dark:bg-gray-700" />
-            <div className="h-2 flex-1 rounded bg-gray-200 dark:bg-gray-700" />
-          </div>
-        ))}
-      </div>
-    )
-  }
-
-  if (positions.length === 0 && accounts.length === 0) {
-    return null
-  }
-
-  // Aggregate by currency
-  const currencyTotals: Record<string, { converted: number; original: number }> = {}
-  const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
-
-  for (const p of positions) {
-    const value = p.marketValue ?? p.quantity * p.avgCost
-    const convertedValue = shouldConvert ? convertAmount(value, p.currency, preferredCurrency, fxRates) : value
-    if (!currencyTotals[p.currency]) currencyTotals[p.currency] = { converted: 0, original: 0 }
-    currencyTotals[p.currency].converted += convertedValue
-    currencyTotals[p.currency].original += value
-  }
-
-  for (const acc of accounts) {
-    const convertedValue = shouldConvert
-      ? convertAmount(acc.cashBalance, acc.currency, preferredCurrency, fxRates)
-      : acc.cashBalance
-    if (!currencyTotals[acc.currency]) currencyTotals[acc.currency] = { converted: 0, original: 0 }
-    currencyTotals[acc.currency].converted += convertedValue
-    currencyTotals[acc.currency].original += acc.cashBalance
-  }
-
-  const entries = Object.entries(currencyTotals).filter(([, c]) => c.converted > 0 || c.original > 0)
-
-  if (entries.length === 0) return null
-
-  return (
-    <div
-      className="rounded-xl border p-5"
-      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
-    >
-      <h3 className="mb-4 font-serif text-sm font-medium text-gray-900 dark:text-white">Currency Breakdown</h3>
-      <div className="space-y-3">
-        {entries.map(([currency, c]) => {
-          const pct = totalValue > 0 ? (c.converted / totalValue) * 100 : 0
-          const needsWarning = shouldConvert && currency !== preferredCurrency && !fxRates?.[currency]
+      <div className="mt-3 space-y-1">
+        {rowsByValue.map((row) => {
+          const holdings = slicesByBucket.get(row.bucketId) ?? []
+          const isExpanded = expandedBuckets.has(row.bucketId)
+          const targetPct = targetPctById.get(row.bucketId) ?? null
+          const delta = targetPct !== null ? row.pct - targetPct : null
+          const deltaColor =
+            delta === null
+              ? ''
+              : Math.abs(delta) <= 2
+                ? 'text-emerald-600 dark:text-emerald-400'
+                : Math.abs(delta) <= 8
+                  ? 'text-amber-500 dark:text-amber-400'
+                  : 'text-red-500 dark:text-red-400'
           return (
-            <div key={currency}>
-              <div className="mb-1 flex items-center justify-between text-xs">
-                <span className="font-medium text-gray-700 dark:text-gray-300">{currency}</span>
-                <span className="flex items-center gap-1 text-gray-500 dark:text-gray-400">
-                  {c.converted.toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  })}
-                  {needsWarning && <AlertCircle size={10} className="text-amber-500" />}
-                  <span className="text-gray-400">({pct.toFixed(1)}%)</span>
+            <div key={row.bucketId}>
+              {/* Bucket header row */}
+              <button
+                type="button"
+                onClick={() => toggleBucket(row.bucketId)}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+              >
+                <span className="text-gray-400 dark:text-gray-500">{isExpanded ? '▾' : '▸'}</span>
+                <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: row.color }} />
+                <span className="font-medium text-gray-700 dark:text-gray-300">{row.name}</span>
+                <span className="ml-auto font-mono text-gray-500 dark:text-gray-400">
+                  {row.value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                 </span>
-              </div>
-              <div className="h-1.5 w-full rounded-full bg-gray-100 dark:bg-gray-800">
-                <div
-                  className="h-1.5 rounded-full transition-all"
-                  style={{
-                    width: `${Math.min(pct, 100)}%`,
-                    backgroundColor:
-                      CATEGORY_PALETTE[entries.findIndex(([k]) => k === currency) % CATEGORY_PALETTE.length],
-                  }}
-                />
-              </div>
-              {shouldConvert && currency !== preferredCurrency && (
-                <div className="mt-0.5 text-xs text-gray-400">
-                  Original:{' '}
-                  {c.original.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}{' '}
-                  {currency}
+                <span className="font-mono text-gray-400 dark:text-gray-500">
+                  {row.pct.toFixed(1)}%
+                  {targetPct !== null && <span className="text-gray-300 dark:text-gray-600"> / {targetPct}%</span>}
+                </span>
+                {delta !== null && (
+                  <span className={`w-12 shrink-0 text-right font-mono font-medium ${deltaColor}`}>
+                    {delta >= 0 ? '+' : ''}
+                    {delta.toFixed(1)}%
+                  </span>
+                )}
+              </button>
+
+              {/* Expanded holdings */}
+              {isExpanded && (
+                <div className="mb-1 ml-6 space-y-1.5 pt-1">
+                  {holdings.map((holding) => {
+                    const withinBucketPct = row.value > 0 ? (holding.value / row.value) * 100 : 0
+                    return (
+                      <div key={holding.name} className="flex items-center gap-2 text-xs">
+                        <span className="w-12 shrink-0 font-mono font-medium text-gray-700 dark:text-gray-300">
+                          {holding.name}
+                        </span>
+                        <div
+                          className="min-w-0 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800"
+                          style={{ height: 6 }}
+                        >
+                          <div
+                            className="h-full rounded-full transition-all"
+                            style={{ width: `${withinBucketPct}%`, backgroundColor: row.color }}
+                          />
+                        </div>
+                        <span className="w-10 shrink-0 text-right font-mono text-gray-500 dark:text-gray-400">
+                          {withinBucketPct.toFixed(1)}%
+                        </span>
+                        <span className="w-28 shrink-0 text-right font-mono text-gray-400 dark:text-gray-500">
+                          {holding.value.toLocaleString(undefined, {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                          })}
+                        </span>
+                      </div>
+                    )
+                  })}
                 </div>
               )}
             </div>
@@ -346,6 +253,7 @@ function CurrencyBreakdown({
     </div>
   )
 }
+
 
 function PerformanceSparkline() {
   // TODO: Implement historical snapshots — store portfolio value snapshots in
@@ -431,33 +339,17 @@ export function OverviewTab({
     return sum
   })()
 
-  // Day change: sum of unrealizedPnl as proxy (historical snapshots not available)
-  const dayChange = (() => {
-    if (!positions) return null
-    let sum = 0
-    for (const p of positions) {
-      if (p.unrealizedPnl != null) {
-        const v = shouldConvert
-          ? convertAmount(p.unrealizedPnl, p.currency, preferredCurrency, fxRates)
-          : p.unrealizedPnl
-        sum += v
-      }
-    }
-    return sum
-  })()
-
-  // Dividends YTD
-  const dividendsYtd = (() => {
+  // Dividends TTM (trailing 12 months)
+  const dividendsTtm = (() => {
     if (!fundDetails) return null
-    const year = new Date().getFullYear()
+    const cutoff = new Date()
+    cutoff.setFullYear(cutoff.getFullYear() - 1)
+    const cutoffStr = cutoff.toISOString().slice(0, 10)
     let sum = 0
     for (const fd of fundDetails) {
       if (fd.classifiedType !== 'DIVIDEND' && fd.classifiedType !== 'DIVIDEND_TAX') continue
-      if (!fd.businessDate) continue
-      const yearMatch = fd.businessDate.startsWith(String(year))
-      if (!yearMatch) continue
-      const amt = fd.amount
-      const v = shouldConvert ? convertAmount(amt, fd.currency, preferredCurrency, fxRates) : amt
+      if (!fd.businessDate || fd.businessDate < cutoffStr) continue
+      const v = shouldConvert ? convertAmount(fd.amount, fd.currency, preferredCurrency, fxRates) : fd.amount
       sum += v
     }
     return sum
@@ -479,14 +371,8 @@ export function OverviewTab({
       {/* KPI Row */}
       <KpiCard title="Total Portfolio Value" value={fmtWithSymbol(totalValue)} loading={isLoading} />
       <KpiCard
-        title="Day Change"
-        value={dayChange !== null ? fmtWithSymbol(dayChange) : '—'}
-        trend={dayChange !== null ? (dayChange > 0 ? 'positive' : dayChange < 0 ? 'negative' : 'neutral') : undefined}
-        loading={isLoading}
-      />
-      <KpiCard
-        title="Dividends YTD"
-        value={dividendsYtd !== null ? fmtWithSymbol(dividendsYtd) : '—'}
+        title="Dividends (TTM)"
+        value={dividendsTtm !== null ? fmtWithSymbol(dividendsTtm) : '—'}
         secondary={fxLastUpdated ? `Rates updated ${new Date(fxLastUpdated).toLocaleDateString()}` : undefined}
         warning={fxWarning ?? undefined}
         loading={isLoading}
@@ -495,33 +381,12 @@ export function OverviewTab({
       {/* Empty state */}
       {!isLoading && !hasData && <EmptyState />}
 
-      {/* Allocation chart */}
-      {!isLoading && hasData && (
-        <AllocationChart
-          positions={positions!}
-          totalValue={totalValue}
-          preferredCurrency={preferredCurrency}
-          fxRates={fxRates}
-        />
-      )}
-
       {/* Portfolio by bucket */}
       {!isLoading && hasData && (
         <PortfolioBucketBreakdown
           positions={positions!}
           buckets={buckets!}
           assignments={assignments!}
-          preferredCurrency={preferredCurrency}
-          fxRates={fxRates}
-        />
-      )}
-
-      {/* Currency breakdown */}
-      {!isLoading && hasData && (
-        <CurrencyBreakdown
-          positions={positions!}
-          accounts={accounts!}
-          totalValue={totalValue}
           preferredCurrency={preferredCurrency}
           fxRates={fxRates}
         />

--- a/apps/web/src/pages/investments/OverviewTab.tsx
+++ b/apps/web/src/pages/investments/OverviewTab.tsx
@@ -5,6 +5,11 @@ import { CATEGORY_PALETTE } from '../../lib/charts/chartPalette'
 import { TOOLTIP_STYLE } from '../../lib/charts/chartTheme'
 import { db } from '../../lib/db/db'
 import { convertAmount } from '../../lib/fx/convert'
+import {
+  getPortfolioBucketAggregation,
+  type DbPortfolioBucket,
+  type DbPortfolioBucketAssignment,
+} from '../../lib/investments/portfolioBuckets'
 import type { CurrencyOption } from './currencyPreference'
 
 export interface OverviewTabProps {
@@ -155,6 +160,79 @@ function AllocationChart({
           <Legend formatter={(value: string) => value} />
         </PieChart>
       </ResponsiveContainer>
+    </div>
+  )
+}
+
+function PortfolioBucketBreakdown({
+  positions,
+  buckets,
+  assignments,
+  preferredCurrency,
+  fxRates,
+}: {
+  positions: import('@lokfi/brokerage-core').BrokeragePosition[]
+  buckets: DbPortfolioBucket[]
+  assignments: DbPortfolioBucketAssignment[]
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+}) {
+  const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+  const rows = getPortfolioBucketAggregation({
+    positions,
+    buckets,
+    assignments,
+    convertValue: (value, position) =>
+      shouldConvert ? convertAmount(value, position.currency, preferredCurrency, fxRates) : value,
+  })
+
+  if (rows.length === 0) return null
+
+  return (
+    <div
+      className="rounded-xl border p-5"
+      style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+    >
+      <h3 className="mb-4 font-serif text-sm font-medium text-gray-900 dark:text-white">Portfolio by bucket</h3>
+      <ResponsiveContainer width="100%" height={260}>
+        <PieChart>
+          <Pie
+            data={rows}
+            cx="50%"
+            cy="50%"
+            innerRadius={55}
+            outerRadius={75}
+            dataKey="value"
+            labelLine={false}
+            label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(1)}%`}
+          >
+            {rows.map((row) => (
+              <Cell key={row.bucketId} fill={row.color} />
+            ))}
+          </Pie>
+          <Tooltip
+            contentStyle={TOOLTIP_STYLE}
+            formatter={(value: number) => [
+              value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+              'Value',
+            ]}
+          />
+          <Legend formatter={(value: string) => value} />
+        </PieChart>
+      </ResponsiveContainer>
+      <div className="mt-3 space-y-2">
+        {rows.map((row) => (
+          <div key={row.bucketId} className="flex items-center justify-between text-xs">
+            <span className="flex min-w-0 items-center gap-2 text-gray-700 dark:text-gray-300">
+              <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: row.color }} />
+              <span className="truncate">{row.name}</span>
+            </span>
+            <span className="font-mono text-gray-500 dark:text-gray-400">
+              {row.value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ({row.pct.toFixed(1)}%)
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }
@@ -324,8 +402,15 @@ export function OverviewTab({
   const positions = useLiveQuery(() => db.brokeragePositions.toArray(), [])
   const accounts = useLiveQuery(() => db.brokerageAccounts.toArray(), [])
   const fundDetails = useLiveQuery(() => db.brokerageFundDetails.toArray(), [])
+  const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), [])
+  const assignments = useLiveQuery(() => db.portfolioBucketAssignments.toArray(), [])
 
-  const isLoading = positions === undefined || accounts === undefined || fundDetails === undefined
+  const isLoading =
+    positions === undefined ||
+    accounts === undefined ||
+    fundDetails === undefined ||
+    buckets === undefined ||
+    assignments === undefined
 
   // ── Derived values ─────────────────────────────────────────────────────────
 
@@ -414,6 +499,17 @@ export function OverviewTab({
         <AllocationChart
           positions={positions!}
           totalValue={totalValue}
+          preferredCurrency={preferredCurrency}
+          fxRates={fxRates}
+        />
+      )}
+
+      {/* Portfolio by bucket */}
+      {!isLoading && hasData && (
+        <PortfolioBucketBreakdown
+          positions={positions!}
+          buckets={buckets!}
+          assignments={assignments!}
           preferredCurrency={preferredCurrency}
           fxRates={fxRates}
         />

--- a/apps/web/src/pages/investments/PortfolioBucketCombobox.tsx
+++ b/apps/web/src/pages/investments/PortfolioBucketCombobox.tsx
@@ -1,0 +1,239 @@
+import { useLiveQuery } from 'dexie-react-hooks'
+import { Settings } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { db } from '../../lib/db/db'
+import type { DbPortfolioBucket } from '../../lib/investments/portfolioBuckets'
+
+const CUSTOM_COLORS = ['#3b82f6', '#22c55e', '#f59e0b', '#06b6d4', '#8b5cf6', '#ec4899', '#64748b', '#ef4444']
+
+interface PortfolioBucketComboboxProps {
+  value: string | null
+  onChange: (id: string | null) => void
+  onManage: () => void
+  placeholder?: string
+}
+
+type ComboboxOption =
+  | { type: 'clear'; id: 'clear' }
+  | { type: 'bucket'; id: string; bucket: DbPortfolioBucket }
+  | { type: 'create'; id: 'create'; name: string }
+  | { type: 'manage'; id: 'manage' }
+
+export function PortfolioBucketCombobox({
+  value,
+  onChange,
+  onManage,
+  placeholder = 'Unassigned',
+}: PortfolioBucketComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const [inputText, setInputText] = useState('')
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), []) ?? []
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const creatingRef = useRef(false)
+
+  const selectedBucket = buckets.find((bucket) => bucket.id === value) ?? null
+  const filtered = buckets.filter((bucket) => bucket.name.toLowerCase().includes(inputText.toLowerCase()))
+  const showCreate =
+    inputText.trim().length > 0 &&
+    !buckets.some((bucket) => bucket.name.toLowerCase() === inputText.trim().toLowerCase())
+
+  const options = useMemo<ComboboxOption[]>(() => {
+    const opts: ComboboxOption[] = [{ type: 'clear', id: 'clear' }]
+    filtered.forEach((bucket) => opts.push({ type: 'bucket', id: bucket.id, bucket }))
+    if (showCreate) opts.push({ type: 'create', id: 'create', name: inputText.trim() })
+    opts.push({ type: 'manage', id: 'manage' })
+    return opts
+  }, [filtered, showCreate, inputText])
+
+  useEffect(() => {
+    if (open) setTimeout(() => inputRef.current?.focus(), 0)
+  }, [open])
+
+  useEffect(() => {
+    function handleMouseDown(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleMouseDown)
+      return () => document.removeEventListener('mousedown', handleMouseDown)
+    }
+  }, [open])
+
+  async function handleCreateBucket() {
+    const name = inputText.trim()
+    if (!name || creatingRef.current) return
+    creatingRef.current = true
+    try {
+      const now = new Date().toISOString()
+      const id = 'bucket_' + crypto.randomUUID()
+      const color = CUSTOM_COLORS[buckets.length % CUSTOM_COLORS.length]
+      const sortOrder = buckets.length
+      await db.portfolioBuckets.put({
+        id,
+        name,
+        color,
+        sortOrder,
+        isDefault: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      onChange(id)
+      setOpen(false)
+    } finally {
+      creatingRef.current = false
+    }
+  }
+
+  function selectBucket(id: string | null) {
+    onChange(id)
+    setOpen(false)
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open) return
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setHighlightedIndex((index) => (index + 1) % Math.max(1, options.length))
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setHighlightedIndex((index) => (index - 1 + options.length) % Math.max(1, options.length))
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      const option = options[highlightedIndex]
+      if (!option) return
+      if (option.type === 'clear') selectBucket(null)
+      if (option.type === 'bucket') selectBucket(option.id)
+      if (option.type === 'create') handleCreateBucket()
+      if (option.type === 'manage') {
+        setOpen(false)
+        onManage()
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative inline-block text-left">
+      <button
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation()
+          setInputText('')
+          setHighlightedIndex(0)
+          setOpen((current) => !current)
+        }}
+        className="inline-flex min-w-[8rem] max-w-[12rem] items-center gap-1.5 rounded-full border bg-white px-3 py-1.5 text-xs text-gray-900 focus:outline-none dark:bg-gray-900 dark:text-white"
+        style={{ borderColor: 'var(--border)' }}
+      >
+        {selectedBucket ? (
+          <>
+            <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: selectedBucket.color }} />
+            <span className="truncate">{selectedBucket.name}</span>
+          </>
+        ) : (
+          <span className="truncate text-gray-400 dark:text-gray-500">{placeholder}</span>
+        )}
+        <span className="ml-auto text-xs text-gray-400">⌄</span>
+      </button>
+
+      {open && (
+        <div
+          className="absolute left-0 top-full z-[1000] mt-1 w-60 rounded-lg border bg-white py-1 shadow-lg dark:bg-gray-900"
+          style={{ borderColor: 'var(--border)' }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="px-2 pb-1">
+            <input
+              ref={inputRef}
+              value={inputText}
+              onChange={(event) => {
+                setInputText(event.target.value)
+                setHighlightedIndex(0)
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Search or create bucket..."
+              className="w-full rounded-md border bg-white px-2 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 dark:bg-gray-800 dark:text-white"
+              style={{ borderColor: 'var(--border)', '--tw-ring-color': 'var(--accent)' } as React.CSSProperties}
+            />
+          </div>
+
+          <div className="max-h-40 overflow-y-auto">
+            {options.map((option, index) => {
+              const highlighted = index === highlightedIndex
+              const baseClass = 'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors '
+              const activeClass = highlighted
+                ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                : 'text-gray-800 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800'
+
+              if (option.type === 'clear') {
+                return (
+                  <button
+                    key="clear"
+                    type="button"
+                    data-highlighted={highlighted}
+                    onClick={() => selectBucket(null)}
+                    className={baseClass + activeClass}
+                  >
+                    Unassigned
+                  </button>
+                )
+              }
+              if (option.type === 'bucket') {
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    data-highlighted={highlighted}
+                    onClick={() => selectBucket(option.id)}
+                    className={baseClass + activeClass}
+                  >
+                    <span
+                      className="h-2 w-2 shrink-0 rounded-full"
+                      style={{ backgroundColor: option.bucket.color }}
+                    />
+                    <span className="truncate">{option.bucket.name}</span>
+                  </button>
+                )
+              }
+              if (option.type === 'create') {
+                return (
+                  <button
+                    key="create"
+                    type="button"
+                    data-highlighted={highlighted}
+                    onClick={handleCreateBucket}
+                    className={baseClass + activeClass}
+                    style={{ color: 'var(--accent)' }}
+                  >
+                    + Create &quot;{option.name}&quot;
+                  </button>
+                )
+              }
+              return (
+                <button
+                  key="manage"
+                  type="button"
+                  data-highlighted={highlighted}
+                  onClick={() => {
+                    setOpen(false)
+                    onManage()
+                  }}
+                  className={baseClass + activeClass}
+                >
+                  <Settings size={14} />
+                  Manage buckets...
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/investments/PortfolioBucketCombobox.tsx
+++ b/apps/web/src/pages/investments/PortfolioBucketCombobox.tsx
@@ -193,10 +193,7 @@ export function PortfolioBucketCombobox({
                     onClick={() => selectBucket(option.id)}
                     className={baseClass + activeClass}
                   >
-                    <span
-                      className="h-2 w-2 shrink-0 rounded-full"
-                      style={{ backgroundColor: option.bucket.color }}
-                    />
+                    <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: option.bucket.color }} />
                     <span className="truncate">{option.bucket.name}</span>
                   </button>
                 )

--- a/apps/web/src/pages/investments/PortfolioBucketManager.tsx
+++ b/apps/web/src/pages/investments/PortfolioBucketManager.tsx
@@ -1,0 +1,137 @@
+import { useLiveQuery } from 'dexie-react-hooks'
+import { ArrowDown, ArrowUp, Trash2, X } from 'lucide-react'
+import { db } from '../../lib/db/db'
+
+interface PortfolioBucketManagerProps {
+  open: boolean
+  onClose: () => void
+}
+
+const COLOR_SWATCHES = ['#3b82f6', '#22c55e', '#f59e0b', '#06b6d4', '#8b5cf6', '#ec4899', '#64748b', '#ef4444']
+
+export function PortfolioBucketManager({ open, onClose }: PortfolioBucketManagerProps) {
+  const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), []) ?? []
+
+  if (!open) return null
+
+  async function renameBucket(id: string, name: string) {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    await db.portfolioBuckets.update(id, { name: trimmed, updatedAt: new Date().toISOString() })
+  }
+
+  async function recolorBucket(id: string, color: string) {
+    await db.portfolioBuckets.update(id, { color, updatedAt: new Date().toISOString() })
+  }
+
+  async function moveBucket(id: string, direction: -1 | 1) {
+    const index = buckets.findIndex((bucket) => bucket.id === id)
+    const swap = buckets[index + direction]
+    const current = buckets[index]
+    if (!current || !swap) return
+    await db.transaction('rw', [db.portfolioBuckets], async () => {
+      await db.portfolioBuckets.update(current.id, {
+        sortOrder: swap.sortOrder,
+        updatedAt: new Date().toISOString(),
+      })
+      await db.portfolioBuckets.update(swap.id, {
+        sortOrder: current.sortOrder,
+        updatedAt: new Date().toISOString(),
+      })
+    })
+  }
+
+  async function deleteBucket(id: string) {
+    const confirmed = window.confirm('Delete this portfolio bucket? Affected holdings will become Unassigned.')
+    if (!confirmed) return
+    await db.transaction('rw', [db.portfolioBuckets, db.portfolioBucketAssignments], async () => {
+      await db.portfolioBuckets.delete(id)
+      await db.portfolioBucketAssignments.where('bucketId').equals(id).delete()
+    })
+  }
+
+  return (
+    <div className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/40 p-4">
+      <div
+        className="w-full max-w-lg rounded-xl border bg-white shadow-xl dark:bg-gray-950"
+        style={{ borderColor: 'var(--border)' }}
+      >
+        <div
+          className="flex items-center justify-between border-b px-5 py-4"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          <h2 className="font-serif text-lg text-gray-900 dark:text-white">Portfolio buckets</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+        <div className="max-h-[65vh] space-y-3 overflow-y-auto p-5">
+          {buckets.map((bucket, index) => (
+            <div
+              key={bucket.id}
+              className="rounded-lg border p-3"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  defaultValue={bucket.name}
+                  onBlur={(event) => renameBucket(bucket.id, event.target.value)}
+                  className="min-w-0 flex-1 rounded-md border bg-white px-2 py-1.5 text-sm text-gray-900 dark:bg-gray-900 dark:text-white"
+                  style={{ borderColor: 'var(--border)' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => moveBucket(bucket.id, -1)}
+                  disabled={index === 0}
+                  className="rounded border p-1 disabled:opacity-30"
+                  style={{ borderColor: 'var(--border)' }}
+                  aria-label="Move up"
+                >
+                  <ArrowUp size={14} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => moveBucket(bucket.id, 1)}
+                  disabled={index === buckets.length - 1}
+                  className="rounded border p-1 disabled:opacity-30"
+                  style={{ borderColor: 'var(--border)' }}
+                  aria-label="Move down"
+                >
+                  <ArrowDown size={14} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => deleteBucket(bucket.id)}
+                  className="rounded border p-1 text-red-500"
+                  style={{ borderColor: 'var(--border)' }}
+                  aria-label="Delete bucket"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {COLOR_SWATCHES.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => recolorBucket(bucket.id, color)}
+                    className={`h-6 w-6 rounded-full border-2 ${
+                      bucket.color === color ? 'border-gray-900 dark:border-white' : 'border-transparent'
+                    }`}
+                    style={{ backgroundColor: color }}
+                    aria-label={`Use ${color}`}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/investments/PortfolioBucketManager.tsx
+++ b/apps/web/src/pages/investments/PortfolioBucketManager.tsx
@@ -56,10 +56,7 @@ export function PortfolioBucketManager({ open, onClose }: PortfolioBucketManager
         className="w-full max-w-lg rounded-xl border bg-white shadow-xl dark:bg-gray-950"
         style={{ borderColor: 'var(--border)' }}
       >
-        <div
-          className="flex items-center justify-between border-b px-5 py-4"
-          style={{ borderColor: 'var(--border)' }}
-        >
+        <div className="flex items-center justify-between border-b px-5 py-4" style={{ borderColor: 'var(--border)' }}>
           <h2 className="font-serif text-lg text-gray-900 dark:text-white">Portfolio buckets</h2>
           <button
             type="button"
@@ -72,11 +69,7 @@ export function PortfolioBucketManager({ open, onClose }: PortfolioBucketManager
         </div>
         <div className="max-h-[65vh] space-y-3 overflow-y-auto p-5">
           {buckets.map((bucket, index) => (
-            <div
-              key={bucket.id}
-              className="rounded-lg border p-3"
-              style={{ borderColor: 'var(--border)' }}
-            >
+            <div key={bucket.id} className="rounded-lg border p-3" style={{ borderColor: 'var(--border)' }}>
               <div className="flex items-center gap-2">
                 <input
                   defaultValue={bucket.name}

--- a/apps/web/src/pages/investments/PortfolioBucketManager.tsx
+++ b/apps/web/src/pages/investments/PortfolioBucketManager.tsx
@@ -41,6 +41,12 @@ export function PortfolioBucketManager({ open, onClose }: PortfolioBucketManager
     })
   }
 
+  async function setTargetPct(id: string, raw: string) {
+    const parsed = raw === '' ? null : Math.min(100, Math.max(0, Number(raw)))
+    if (raw !== '' && Number.isNaN(parsed)) return
+    await db.portfolioBuckets.update(id, { targetPct: parsed, updatedAt: new Date().toISOString() })
+  }
+
   async function deleteBucket(id: string) {
     const confirmed = window.confirm('Delete this portfolio bucket? Affected holdings will become Unassigned.')
     if (!confirmed) return
@@ -68,6 +74,32 @@ export function PortfolioBucketManager({ open, onClose }: PortfolioBucketManager
           </button>
         </div>
         <div className="max-h-[65vh] space-y-3 overflow-y-auto p-5">
+          {(() => {
+            const totalTarget = buckets.reduce((sum, b) => sum + (b.targetPct ?? 0), 0)
+            const over = totalTarget > 100
+            const unallocated = 100 - totalTarget
+            if (totalTarget === 0) return null
+            return (
+              <div
+                className="flex items-center justify-between rounded-lg border px-3 py-2 text-xs"
+                style={{
+                  borderColor: over ? '#ef4444' : 'var(--border)',
+                  backgroundColor: over ? '#fef2f2' : 'var(--accent-subtle)',
+                  color: over ? '#ef4444' : 'var(--accent-text)',
+                }}
+              >
+                <span>Target total</span>
+                <span className="font-mono font-medium">
+                  {totalTarget}%{' '}
+                  {over
+                    ? `(${totalTarget - 100}% over)`
+                    : unallocated > 0
+                      ? `(${unallocated}% unallocated)`
+                      : '✓'}
+                </span>
+              </div>
+            )
+          })()}
           {buckets.map((bucket, index) => (
             <div key={bucket.id} className="rounded-lg border p-3" style={{ borderColor: 'var(--border)' }}>
               <div className="flex items-center gap-2">
@@ -107,19 +139,35 @@ export function PortfolioBucketManager({ open, onClose }: PortfolioBucketManager
                   <Trash2 size={14} />
                 </button>
               </div>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {COLOR_SWATCHES.map((color) => (
-                  <button
-                    key={color}
-                    type="button"
-                    onClick={() => recolorBucket(bucket.id, color)}
-                    className={`h-6 w-6 rounded-full border-2 ${
-                      bucket.color === color ? 'border-gray-900 dark:border-white' : 'border-transparent'
-                    }`}
-                    style={{ backgroundColor: color }}
-                    aria-label={`Use ${color}`}
+              <div className="mt-3 flex items-center gap-2">
+                <div className="flex flex-1 flex-wrap gap-2">
+                  {COLOR_SWATCHES.map((color) => (
+                    <button
+                      key={color}
+                      type="button"
+                      onClick={() => recolorBucket(bucket.id, color)}
+                      className={`h-6 w-6 rounded-full border-2 ${
+                        bucket.color === color ? 'border-gray-900 dark:border-white' : 'border-transparent'
+                      }`}
+                      style={{ backgroundColor: color }}
+                      aria-label={`Use ${color}`}
+                    />
+                  ))}
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <input
+                    type="number"
+                    min={0}
+                    max={100}
+                    step={1}
+                    defaultValue={bucket.targetPct ?? ''}
+                    placeholder="—"
+                    onBlur={(e) => setTargetPct(bucket.id, e.target.value)}
+                    className="w-16 rounded-md border bg-white px-2 py-1 text-right text-sm text-gray-900 dark:bg-gray-900 dark:text-white"
+                    style={{ borderColor: 'var(--border)' }}
                   />
-                ))}
+                  <span className="text-xs text-gray-400">% target</span>
+                </div>
               </div>
             </div>
           ))}

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -2,6 +2,13 @@ import { useLiveQuery } from 'dexie-react-hooks'
 import { AlertTriangle, Download, Trash2, Upload } from 'lucide-react'
 import { useBackupWarning } from '../../hooks/useBackupWarning'
 import { StorageManager } from '../../lib/db/StorageManager'
+import {
+  buildBackupPayload,
+  buildImportSummary,
+  importBackupPayload,
+  normalizeBackupForImport,
+  validateBackupShape,
+} from '../../lib/db/backup'
 import { db } from '../../lib/db/db'
 import type { DbCustomParserProfile } from '../../lib/db/db'
 
@@ -15,49 +22,7 @@ export function ProfilePage() {
   const customParsers = useLiveQuery(() => db.customParsers.orderBy('createdAt').toArray(), []) ?? []
 
   async function handleExport() {
-    const [
-      transactions,
-      rules,
-      categories,
-      customParsers,
-      budgets,
-      brokeragePositions,
-      brokeragePositionExtensions,
-      brokerageTransactions,
-      brokerageFundDetails,
-      brokerageAccounts,
-      brokerageSyncLog,
-      brokerageCredentials,
-    ] = await Promise.all([
-      db.transactions.toArray(),
-      db.rules.toArray(),
-      db.categories.toArray(),
-      db.customParsers.toArray(),
-      db.budgets.toArray(),
-      db.brokeragePositions.toArray(),
-      db.brokeragePositionExtensions.toArray(),
-      db.brokerageTransactions.toArray(),
-      db.brokerageFundDetails.toArray(),
-      db.brokerageAccounts.toArray(),
-      db.brokerageSyncLog.toArray(),
-      db.brokerageCredentials.toArray(),
-    ])
-    const data = {
-      version: 3,
-      exportedAt: new Date().toISOString(),
-      transactions,
-      rules,
-      categories,
-      customParsers,
-      budgets,
-      brokeragePositions,
-      brokeragePositionExtensions,
-      brokerageTransactions,
-      brokerageFundDetails,
-      brokerageAccounts,
-      brokerageSyncLog,
-      brokerageCredentials,
-    }
+    const data = await buildBackupPayload(db)
     const blob = new Blob([JSON.stringify(data, null, 2)], {
       type: 'application/json',
     })
@@ -92,130 +57,21 @@ export function ProfilePage() {
     const text = await file.text()
     try {
       const data = JSON.parse(text)
-      // Validate basic backup structure (version 1, 2, or 3)
-      if (
-        !data ||
-        typeof data !== 'object' ||
-        Array.isArray(data) ||
-        ![1, 2, 3].includes(data.version) ||
-        !Array.isArray(data.transactions) ||
-        !Array.isArray(data.rules) ||
-        !Array.isArray(data.categories) ||
-        !Array.isArray(data.customParsers) ||
-        !Array.isArray(data.budgets)
-      ) {
-        alert(
-          'Invalid backup file: expected a Lokfi backup JSON (v1, v2, or v3) with ' +
-            'transactions, rules, categories, customParsers, and budgets.'
-        )
-        e.target.value = ''
-        return
-      }
-      // Version 2 must include all brokerage arrays (except brokerageFundDetails which is new in v3)
-      if (
-        data.version === 2 &&
-        (!Array.isArray(data.brokeragePositions) ||
-          !Array.isArray(data.brokeragePositionExtensions) ||
-          !Array.isArray(data.brokerageTransactions) ||
-          !Array.isArray(data.brokerageAccounts) ||
-          !Array.isArray(data.brokerageSyncLog) ||
-          !Array.isArray(data.brokerageCredentials))
-      ) {
-        alert(
-          'Invalid v2 backup file: missing brokerage data arrays. ' +
-            'The backup appears to be incomplete or corrupted.'
-        )
+      const validation = validateBackupShape(data)
+      if (!validation.valid) {
+        alert(validation.message)
         e.target.value = ''
         return
       }
 
-      // Version 3 must include brokerageFundDetails
-      if (data.version === 3 && !Array.isArray(data.brokerageFundDetails)) {
-        alert(
-          'Invalid v3 backup file: missing brokerageFundDetails array. ' +
-            'The backup appears to be incomplete or corrupted.'
-        )
-        e.target.value = ''
-        return
-      }
-      const hasBrokerage = data.version >= 2
-      const fundDetailsCount = Array.isArray(data.brokerageFundDetails) ? data.brokerageFundDetails.length : 0
-      const confirmed = window.confirm(
-        `This will replace all current data with the backup:\n` +
-          `• ${data.transactions.length} transaction(s)\n` +
-          `• ${data.rules.length} rule(s)\n` +
-          `• ${data.categories.length} categor(ies)\n` +
-          `• ${data.customParsers.length} parser profile(s)\n` +
-          `• ${data.budgets.length} budget(s)\n` +
-          (hasBrokerage
-            ? `• ${data.brokeragePositions.length} brokerage position(s)\n` +
-              `• ${data.brokerageTransactions.length} brokerage trade(s)\n` +
-              `• ${data.brokerageAccounts.length} brokerage account(s)\n` +
-              (fundDetailsCount > 0 ? `• ${fundDetailsCount} fund detail(s)\n` : '') +
-              `• ${data.brokerageCredentials.length} credential(s) (encrypted)\n`
-            : `• (no brokerage data in backup)\n`) +
-          `Current data will be overwritten. Are you sure?`
-      )
+      const normalized = normalizeBackupForImport(data)
+      const confirmed = window.confirm(buildImportSummary(normalized))
       if (!confirmed) {
         e.target.value = ''
         return
       }
-      const tables = hasBrokerage
-        ? [
-            db.transactions,
-            db.rules,
-            db.categories,
-            db.customParsers,
-            db.budgets,
-            db.brokeragePositions,
-            db.brokeragePositionExtensions,
-            db.brokerageTransactions,
-            db.brokerageFundDetails,
-            db.brokerageAccounts,
-            db.brokerageSyncLog,
-            db.brokerageCredentials,
-          ]
-        : [db.transactions, db.rules, db.categories, db.customParsers, db.budgets]
-      // Clear existing data and import backup in a single transaction
-      await db.transaction('rw', tables, async () => {
-        await Promise.all([
-          db.transactions.clear(),
-          db.rules.clear(),
-          db.categories.clear(),
-          db.customParsers.clear(),
-          db.budgets.clear(),
-          ...(hasBrokerage
-            ? [
-                db.brokeragePositions.clear(),
-                db.brokeragePositionExtensions.clear(),
-                db.brokerageTransactions.clear(),
-                db.brokerageFundDetails.clear(),
-                db.brokerageAccounts.clear(),
-                db.brokerageSyncLog.clear(),
-                db.brokerageCredentials.clear(),
-              ]
-            : []),
-        ])
-        if (data.transactions.length) await db.transactions.bulkAdd(data.transactions)
-        if (data.rules.length) await db.rules.bulkAdd(data.rules)
-        if (data.categories.length) await db.categories.bulkAdd(data.categories)
-        if (data.customParsers.length) await db.customParsers.bulkAdd(data.customParsers)
-        if (data.budgets.length) await db.budgets.bulkAdd(data.budgets)
-        if (hasBrokerage) {
-          // Restore positions first (extensions depend on them via positionId)
-          if (data.brokeragePositions.length) await db.brokeragePositions.bulkAdd(data.brokeragePositions)
-          if (data.brokeragePositionExtensions.length)
-            await db.brokeragePositionExtensions.bulkAdd(data.brokeragePositionExtensions)
-          // Remaining brokerage tables have no dependencies — parallelize
-          await Promise.all([
-            data.brokerageTransactions.length && db.brokerageTransactions.bulkAdd(data.brokerageTransactions),
-            data.brokerageFundDetails?.length && db.brokerageFundDetails.bulkAdd(data.brokerageFundDetails),
-            data.brokerageAccounts.length && db.brokerageAccounts.bulkAdd(data.brokerageAccounts),
-            data.brokerageSyncLog.length && db.brokerageSyncLog.bulkAdd(data.brokerageSyncLog),
-            data.brokerageCredentials.length && db.brokerageCredentials.bulkAdd(data.brokerageCredentials),
-          ])
-        }
-      })
+
+      await importBackupPayload(db, normalized)
       alert('Backup imported successfully!')
     } catch {
       alert('Invalid backup file — could not parse JSON')

--- a/docs/superpowers/plans/2026-05-11-investment-portfolio-buckets.md
+++ b/docs/superpowers/plans/2026-05-11-investment-portfolio-buckets.md
@@ -1,0 +1,1569 @@
+# Investment Portfolio Buckets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Portfolio buckets so users can assign stock-like securities to one bucket, filter Holdings by bucket, see bucket allocation in Overview, and preserve bucket data in Profile backups.
+
+**Architecture:** Keep synced brokerage positions immutable and store user bucket metadata in dedicated Dexie tables. Put bucket identity, assignment, filtering, and aggregation logic in pure helpers so Holdings, Overview, and backup import/export reuse the same behavior. Refactor Profile backup handling into a small testable helper instead of expanding the current large component.
+
+**Tech Stack:** React 19, Vite, TypeScript, Dexie, dexie-react-hooks, Recharts, Vitest, Testing Library, Tailwind/CSS vars.
+
+---
+
+## File Structure
+
+- Create `apps/web/src/lib/investments/portfolioBuckets.ts`
+  - Owns default bucket definitions, stock-like detection, security key generation, assignment lookup, value aggregation, and bucket filtering helpers.
+- Create `apps/web/src/lib/investments/portfolioBuckets.test.ts`
+  - Unit tests for defaults, security keys, same-symbol assignment reuse, filtering, deletion helper behavior, and overview aggregation.
+- Create `apps/web/src/pages/investments/PortfolioBucketCombobox.tsx`
+  - Investment-specific combobox mirroring transaction category UX: select, clear, search, and create bucket inline.
+- Create `apps/web/src/pages/investments/PortfolioBucketManager.tsx`
+  - Compact modal for create, rename, recolor, reorder, and delete.
+- Create `apps/web/src/lib/db/backup.ts`
+  - Pure backup helpers for export/import normalization, validation, table clearing/restoring, and default bucket availability after older backup import.
+- Create `apps/web/src/lib/db/backup.test.ts`
+  - Tests for v4 export shape, v4 validation, v1-v3 compatibility, and default bucket restoration after older imports.
+- Modify `apps/web/src/lib/db/db.ts`
+  - Add `DbPortfolioBucket`, `DbPortfolioBucketAssignment`, Dexie tables, v9 stores, and populate seeding.
+- Modify `apps/web/src/pages/profile/ProfilePage.tsx`
+  - Use `backup.ts` helpers for export/import and keep the Profile UI behavior the same.
+- Modify `apps/web/src/pages/investments/HoldingsTab.tsx`
+  - Add Bucket column, combobox assignment, bucket filter, and manager modal.
+- Modify `apps/web/src/pages/investments/OverviewTab.tsx`
+  - Load buckets/assignments and add Portfolio by bucket card.
+
+---
+
+### Task 1: Portfolio Bucket Domain Helpers
+
+**Files:**
+- Create: `apps/web/src/lib/investments/portfolioBuckets.ts`
+- Test: `apps/web/src/lib/investments/portfolioBuckets.test.ts`
+
+- [ ] **Step 1: Write failing tests for bucket defaults, security keys, filtering, delete cleanup, and aggregation**
+
+Create `apps/web/src/lib/investments/portfolioBuckets.test.ts`:
+
+```ts
+import type { BrokeragePosition } from '@lokfi/brokerage-core'
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PORTFOLIO_BUCKETS,
+  buildBucketLookup,
+  buildBucketOptions,
+  filterPositionsByBucket,
+  getPortfolioBucketAggregation,
+  getSecurityKey,
+  isStockLikePosition,
+  removeAssignmentsForBucket,
+} from './portfolioBuckets'
+
+function position(overrides: Partial<BrokeragePosition> = {}): BrokeragePosition {
+  return {
+    id: overrides.id ?? 'pos-1',
+    source: overrides.source ?? 'test',
+    symbol: overrides.symbol ?? 'AAPL',
+    name: overrides.name ?? 'Apple Inc.',
+    quantity: overrides.quantity ?? 10,
+    avgCost: overrides.avgCost ?? 100,
+    currency: overrides.currency ?? 'USD',
+    secType: overrides.secType ?? 'STK',
+    marketValue: overrides.marketValue,
+    lastUpdatedAt: overrides.lastUpdatedAt ?? '2026-05-11T00:00:00.000Z',
+  }
+}
+
+describe('portfolioBuckets', () => {
+  it('defines sparse default portfolio buckets in display order', () => {
+    expect(DEFAULT_PORTFOLIO_BUCKETS.map((bucket) => bucket.name)).toEqual(['Growth', 'Income', 'Cash'])
+    expect(DEFAULT_PORTFOLIO_BUCKETS.map((bucket) => bucket.sortOrder)).toEqual([0, 1, 2])
+  })
+
+  it('builds a stock-like security key from secType and uppercased symbol', () => {
+    expect(getSecurityKey(position({ symbol: 'aapl', secType: 'STK' }))).toBe('STK:AAPL')
+    expect(getSecurityKey(position({ symbol: 'sgov', secType: undefined }))).toBe('STK:SGOV')
+    expect(getSecurityKey(position({ symbol: 'AAPL', secType: 'FUND' }))).toBe('FUND:AAPL')
+  })
+
+  it('identifies stock-like positions and excludes derivatives', () => {
+    expect(isStockLikePosition(position({ secType: 'STK' }))).toBe(true)
+    expect(isStockLikePosition(position({ secType: 'FUND' }))).toBe(true)
+    expect(isStockLikePosition(position({ secType: 'CASH' }))).toBe(true)
+    expect(isStockLikePosition(position({ secType: 'OPT' }))).toBe(false)
+    expect(isStockLikePosition(position({ secType: 'FUT' }))).toBe(false)
+  })
+
+  it('filters positions by assigned bucket and unassigned state', () => {
+    const apple = position({ id: 'p1', symbol: 'AAPL' })
+    const microsoft = position({ id: 'p2', symbol: 'MSFT' })
+    const appleOption = position({ id: 'p3', symbol: 'AAPL', secType: 'OPT' })
+    const assignments = [{ securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' }]
+
+    expect(filterPositionsByBucket([apple, microsoft, appleOption], assignments, 'all')).toEqual([
+      apple,
+      microsoft,
+      appleOption,
+    ])
+    expect(filterPositionsByBucket([apple, microsoft, appleOption], assignments, 'bucket_growth')).toEqual([apple])
+    expect(filterPositionsByBucket([apple, microsoft, appleOption], assignments, 'unassigned')).toEqual([microsoft])
+  })
+
+  it('removes assignments for a deleted bucket', () => {
+    const assignments = [
+      { securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' },
+      { securityKey: 'STK:MSFT', bucketId: 'bucket_income', createdAt: 'now', updatedAt: 'now' },
+    ]
+
+    expect(removeAssignmentsForBucket(assignments, 'bucket_growth')).toEqual([
+      { securityKey: 'STK:MSFT', bucketId: 'bucket_income', createdAt: 'now', updatedAt: 'now' },
+    ])
+  })
+
+  it('aggregates stock-like positions by bucket and excludes derivatives', () => {
+    const buckets = [
+      { id: 'bucket_growth', name: 'Growth', color: '#3b82f6', sortOrder: 0, isDefault: true, createdAt: 'now', updatedAt: 'now' },
+      { id: 'bucket_income', name: 'Income', color: '#22c55e', sortOrder: 1, isDefault: true, createdAt: 'now', updatedAt: 'now' },
+    ]
+    const positions = [
+      position({ id: 'p1', symbol: 'AAPL', marketValue: 1200 }),
+      position({ id: 'p2', symbol: 'AAPL', marketValue: 800 }),
+      position({ id: 'p3', symbol: 'SCHD', marketValue: 1000 }),
+      position({ id: 'p4', symbol: 'AAPL', secType: 'OPT', marketValue: 500 }),
+      position({ id: 'p5', symbol: 'MSFT', quantity: 2, avgCost: 300, marketValue: undefined }),
+    ]
+    const assignments = [
+      { securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' },
+      { securityKey: 'STK:SCHD', bucketId: 'bucket_income', createdAt: 'now', updatedAt: 'now' },
+    ]
+
+    expect(getPortfolioBucketAggregation({ positions, buckets, assignments, convertValue: (value) => value })).toEqual([
+      { bucketId: 'bucket_growth', name: 'Growth', color: '#3b82f6', value: 2000, pct: 55.55555555555556 },
+      { bucketId: 'bucket_income', name: 'Income', color: '#22c55e', value: 1000, pct: 27.77777777777778 },
+      { bucketId: 'unassigned', name: 'Unassigned', color: '#94a3b8', value: 600, pct: 16.666666666666664 },
+    ])
+  })
+
+  it('builds bucket options with Unassigned after user buckets', () => {
+    const lookup = buildBucketLookup(DEFAULT_PORTFOLIO_BUCKETS)
+    expect(lookup.get('bucket_growth')?.name).toBe('Growth')
+    expect(buildBucketOptions(DEFAULT_PORTFOLIO_BUCKETS).map((option) => option.label)).toEqual([
+      'All buckets',
+      'Growth',
+      'Income',
+      'Cash',
+      'Unassigned',
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test -- src/lib/investments/portfolioBuckets.test.ts
+```
+
+Expected: FAIL because `portfolioBuckets.ts` does not exist.
+
+- [ ] **Step 3: Implement pure bucket helpers**
+
+Create `apps/web/src/lib/investments/portfolioBuckets.ts`:
+
+```ts
+import type { BrokeragePosition } from '@lokfi/brokerage-core'
+import type { DbPortfolioBucket, DbPortfolioBucketAssignment } from '../db/db'
+
+export const UNASSIGNED_BUCKET_ID = 'unassigned'
+
+export const DEFAULT_PORTFOLIO_BUCKETS: DbPortfolioBucket[] = [
+  {
+    id: 'bucket_growth',
+    name: 'Growth',
+    color: '#3b82f6',
+    sortOrder: 0,
+    isDefault: true,
+    createdAt: '2026-05-11T00:00:00.000Z',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+  },
+  {
+    id: 'bucket_income',
+    name: 'Income',
+    color: '#22c55e',
+    sortOrder: 1,
+    isDefault: true,
+    createdAt: '2026-05-11T00:00:00.000Z',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+  },
+  {
+    id: 'bucket_cash',
+    name: 'Cash',
+    color: '#f59e0b',
+    sortOrder: 2,
+    isDefault: true,
+    createdAt: '2026-05-11T00:00:00.000Z',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+  },
+]
+
+const STOCK_LIKE_TYPES = new Set(['STK', 'CASH', 'FUND', 'MLEG'])
+
+export interface BucketAggregationRow {
+  bucketId: string
+  name: string
+  color: string
+  value: number
+  pct: number
+}
+
+export type BucketFilterValue = 'all' | 'unassigned' | string
+
+export function isStockLikePosition(position: BrokeragePosition): boolean {
+  return position.secType == null || STOCK_LIKE_TYPES.has(position.secType)
+}
+
+export function getSecurityKey(position: BrokeragePosition): string {
+  const secType = position.secType ?? 'STK'
+  return `${secType}:${position.symbol.trim().toUpperCase()}`
+}
+
+export function buildBucketLookup(buckets: DbPortfolioBucket[]): Map<string, DbPortfolioBucket> {
+  return new Map(buckets.map((bucket) => [bucket.id, bucket]))
+}
+
+export function buildAssignmentLookup(assignments: DbPortfolioBucketAssignment[]): Map<string, string> {
+  return new Map(assignments.map((assignment) => [assignment.securityKey, assignment.bucketId]))
+}
+
+export function getAssignedBucketId(
+  position: BrokeragePosition,
+  assignments: DbPortfolioBucketAssignment[]
+): string | null {
+  return buildAssignmentLookup(assignments).get(getSecurityKey(position)) ?? null
+}
+
+export function removeAssignmentsForBucket(
+  assignments: DbPortfolioBucketAssignment[],
+  bucketId: string
+): DbPortfolioBucketAssignment[] {
+  return assignments.filter((assignment) => assignment.bucketId !== bucketId)
+}
+
+export function filterPositionsByBucket(
+  positions: BrokeragePosition[],
+  assignments: DbPortfolioBucketAssignment[],
+  filter: BucketFilterValue
+): BrokeragePosition[] {
+  if (filter === 'all') return positions
+  const assignmentBySecurity = buildAssignmentLookup(assignments)
+  return positions.filter((position) => {
+    if (!isStockLikePosition(position)) return filter === 'all'
+    const assignedBucketId = assignmentBySecurity.get(getSecurityKey(position)) ?? null
+    if (filter === UNASSIGNED_BUCKET_ID) return assignedBucketId == null
+    return assignedBucketId === filter
+  })
+}
+
+export function buildBucketOptions(buckets: DbPortfolioBucket[]): Array<{ id: string; label: string }> {
+  return [
+    { id: 'all', label: 'All buckets' },
+    ...[...buckets].sort((a, b) => a.sortOrder - b.sortOrder).map((bucket) => ({ id: bucket.id, label: bucket.name })),
+    { id: UNASSIGNED_BUCKET_ID, label: 'Unassigned' },
+  ]
+}
+
+export function getPortfolioBucketAggregation({
+  positions,
+  buckets,
+  assignments,
+  convertValue,
+}: {
+  positions: BrokeragePosition[]
+  buckets: DbPortfolioBucket[]
+  assignments: DbPortfolioBucketAssignment[]
+  convertValue: (value: number, position: BrokeragePosition) => number
+}): BucketAggregationRow[] {
+  const bucketById = buildBucketLookup(buckets)
+  const assignmentBySecurity = buildAssignmentLookup(assignments)
+  const totals = new Map<string, number>()
+
+  for (const position of positions) {
+    if (!isStockLikePosition(position)) continue
+    const rawValue = position.marketValue ?? position.quantity * position.avgCost
+    if (rawValue <= 0) continue
+    const assignedBucketId = assignmentBySecurity.get(getSecurityKey(position))
+    const bucketId = assignedBucketId && bucketById.has(assignedBucketId) ? assignedBucketId : UNASSIGNED_BUCKET_ID
+    totals.set(bucketId, (totals.get(bucketId) ?? 0) + convertValue(rawValue, position))
+  }
+
+  const totalValue = [...totals.values()].reduce((sum, value) => sum + value, 0)
+  const rows: BucketAggregationRow[] = []
+  for (const bucket of [...buckets].sort((a, b) => a.sortOrder - b.sortOrder)) {
+    const value = totals.get(bucket.id) ?? 0
+    if (value <= 0) continue
+    rows.push({ bucketId: bucket.id, name: bucket.name, color: bucket.color, value, pct: totalValue > 0 ? (value / totalValue) * 100 : 0 })
+  }
+
+  const unassignedValue = totals.get(UNASSIGNED_BUCKET_ID) ?? 0
+  if (unassignedValue > 0) {
+    rows.push({
+      bucketId: UNASSIGNED_BUCKET_ID,
+      name: 'Unassigned',
+      color: '#94a3b8',
+      value: unassignedValue,
+      pct: totalValue > 0 ? (unassignedValue / totalValue) * 100 : 0,
+    })
+  }
+
+  return rows
+}
+```
+
+- [ ] **Step 4: Run tests to verify helpers pass**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test -- src/lib/investments/portfolioBuckets.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/investments/portfolioBuckets.ts apps/web/src/lib/investments/portfolioBuckets.test.ts
+git commit -m "feat(web): add portfolio bucket helpers"
+```
+
+---
+
+### Task 2: Dexie Schema And Default Bucket Seeding
+
+**Files:**
+- Modify: `apps/web/src/lib/db/db.ts`
+- Test: `apps/web/src/lib/investments/portfolioBuckets.test.ts`
+
+- [ ] **Step 1: Add failing test for timestamped default bucket seeding helper**
+
+Append to `apps/web/src/lib/investments/portfolioBuckets.test.ts`:
+
+```ts
+import { createDefaultPortfolioBuckets } from './portfolioBuckets'
+
+describe('createDefaultPortfolioBuckets', () => {
+  it('stamps default buckets at migration time while keeping stable ids', () => {
+    const buckets = createDefaultPortfolioBuckets('2026-05-11T12:00:00.000Z')
+
+    expect(buckets).toEqual([
+      { id: 'bucket_growth', name: 'Growth', color: '#3b82f6', sortOrder: 0, isDefault: true, createdAt: '2026-05-11T12:00:00.000Z', updatedAt: '2026-05-11T12:00:00.000Z' },
+      { id: 'bucket_income', name: 'Income', color: '#22c55e', sortOrder: 1, isDefault: true, createdAt: '2026-05-11T12:00:00.000Z', updatedAt: '2026-05-11T12:00:00.000Z' },
+      { id: 'bucket_cash', name: 'Cash', color: '#f59e0b', sortOrder: 2, isDefault: true, createdAt: '2026-05-11T12:00:00.000Z', updatedAt: '2026-05-11T12:00:00.000Z' },
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test -- src/lib/investments/portfolioBuckets.test.ts
+```
+
+Expected: FAIL because `createDefaultPortfolioBuckets` is not exported.
+
+- [ ] **Step 3: Add default bucket factory and Dexie types/tables**
+
+Modify `apps/web/src/lib/investments/portfolioBuckets.ts` to add:
+
+```ts
+export function createDefaultPortfolioBuckets(timestamp = new Date().toISOString()): DbPortfolioBucket[] {
+  return DEFAULT_PORTFOLIO_BUCKETS.map((bucket) => ({
+    ...bucket,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }))
+}
+```
+
+Modify `apps/web/src/lib/db/db.ts`:
+
+```ts
+import { createDefaultPortfolioBuckets } from '../investments/portfolioBuckets'
+```
+
+Add interfaces after `DbBudget`:
+
+```ts
+export interface DbPortfolioBucket {
+  id: string
+  name: string
+  color: string
+  sortOrder: number
+  isDefault: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface DbPortfolioBucketAssignment {
+  securityKey: string
+  bucketId: string
+  createdAt: string
+  updatedAt: string
+}
+```
+
+Add tables to `LokfiDatabase`:
+
+```ts
+  portfolioBuckets!: Table<DbPortfolioBucket>
+  portfolioBucketAssignments!: Table<DbPortfolioBucketAssignment>
+```
+
+Add schema version after v8:
+
+```ts
+    // v9 schema (adds user-defined investment portfolio buckets)
+    this.version(9)
+      .stores({
+        portfolioBuckets: 'id, sortOrder, name',
+        portfolioBucketAssignments: 'securityKey, bucketId',
+      })
+      .upgrade(async (trans) => {
+        const table = trans.table('portfolioBuckets')
+        const count = await table.count()
+        if (count === 0) {
+          await table.bulkAdd(createDefaultPortfolioBuckets())
+        }
+      })
+```
+
+Update populate handler:
+
+```ts
+    this.on('populate', () => {
+      this.categories.bulkAdd(defaultCategories)
+      this.portfolioBuckets.bulkAdd(createDefaultPortfolioBuckets())
+    })
+```
+
+- [ ] **Step 4: Run targeted tests and typecheck build**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test -- src/lib/investments/portfolioBuckets.test.ts
+pnpm --filter @lokfi/web build
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/db/db.ts apps/web/src/lib/investments/portfolioBuckets.ts apps/web/src/lib/investments/portfolioBuckets.test.ts
+git commit -m "feat(web): persist portfolio bucket tables"
+```
+
+---
+
+### Task 3: Backup Export And Import Compatibility
+
+**Files:**
+- Create: `apps/web/src/lib/db/backup.ts`
+- Create: `apps/web/src/lib/db/backup.test.ts`
+- Modify: `apps/web/src/pages/profile/ProfilePage.tsx`
+
+- [ ] **Step 1: Write failing backup helper tests**
+
+Create `apps/web/src/lib/db/backup.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  BACKUP_VERSION,
+  buildImportSummary,
+  normalizeBackupForImport,
+  validateBackupShape,
+} from './backup'
+
+const baseV3 = {
+  version: 3,
+  exportedAt: '2026-05-11T00:00:00.000Z',
+  transactions: [],
+  rules: [],
+  categories: [],
+  customParsers: [],
+  budgets: [],
+  brokeragePositions: [],
+  brokeragePositionExtensions: [],
+  brokerageTransactions: [],
+  brokerageFundDetails: [],
+  brokerageAccounts: [],
+  brokerageSyncLog: [],
+  brokerageCredentials: [],
+}
+
+describe('backup helpers', () => {
+  it('uses backup version 4 for portfolio buckets', () => {
+    expect(BACKUP_VERSION).toBe(4)
+  })
+
+  it('requires portfolio bucket arrays for v4 backups', () => {
+    expect(validateBackupShape({ ...baseV3, version: 4 }).valid).toBe(false)
+    expect(validateBackupShape({ ...baseV3, version: 4, portfolioBuckets: [], portfolioBucketAssignments: [] })).toEqual({
+      valid: true,
+    })
+  })
+
+  it('normalizes older v1-v3 backups with empty bucket arrays', () => {
+    const normalized = normalizeBackupForImport(baseV3)
+
+    expect(normalized.portfolioBuckets).toEqual([])
+    expect(normalized.portfolioBucketAssignments).toEqual([])
+  })
+
+  it('keeps v4 bucket arrays during normalization', () => {
+    const normalized = normalizeBackupForImport({
+      ...baseV3,
+      version: 4,
+      portfolioBuckets: [{ id: 'bucket_growth', name: 'Growth', color: '#3b82f6', sortOrder: 0, isDefault: true, createdAt: 'now', updatedAt: 'now' }],
+      portfolioBucketAssignments: [{ securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' }],
+    })
+
+    expect(normalized.portfolioBuckets).toHaveLength(1)
+    expect(normalized.portfolioBucketAssignments).toHaveLength(1)
+  })
+
+  it('includes bucket counts in import summary', () => {
+    const summary = buildImportSummary({
+      ...normalizeBackupForImport(baseV3),
+      portfolioBuckets: [{ id: 'bucket_growth', name: 'Growth', color: '#3b82f6', sortOrder: 0, isDefault: true, createdAt: 'now', updatedAt: 'now' }],
+      portfolioBucketAssignments: [{ securityKey: 'STK:AAPL', bucketId: 'bucket_growth', createdAt: 'now', updatedAt: 'now' }],
+    })
+
+    expect(summary).toContain('1 portfolio bucket(s)')
+    expect(summary).toContain('1 portfolio bucket assignment(s)')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test -- src/lib/db/backup.test.ts
+```
+
+Expected: FAIL because `backup.ts` does not exist.
+
+- [ ] **Step 3: Implement backup helpers**
+
+Create `apps/web/src/lib/db/backup.ts`:
+
+```ts
+import type { LokfiDatabase } from './db'
+import { createDefaultPortfolioBuckets } from '../investments/portfolioBuckets'
+
+export const BACKUP_VERSION = 4
+
+export interface LokfiBackup {
+  version: 1 | 2 | 3 | 4
+  exportedAt?: string
+  transactions: unknown[]
+  rules: unknown[]
+  categories: unknown[]
+  customParsers: unknown[]
+  budgets: unknown[]
+  brokeragePositions: unknown[]
+  brokeragePositionExtensions: unknown[]
+  brokerageTransactions: unknown[]
+  brokerageFundDetails: unknown[]
+  brokerageAccounts: unknown[]
+  brokerageSyncLog: unknown[]
+  brokerageCredentials: unknown[]
+  portfolioBuckets: unknown[]
+  portfolioBucketAssignments: unknown[]
+}
+
+function isArray(value: unknown): value is unknown[] {
+  return Array.isArray(value)
+}
+
+export function validateBackupShape(data: unknown): { valid: true } | { valid: false; message: string } {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { valid: false, message: 'Invalid backup file: expected an object.' }
+  }
+  const candidate = data as Record<string, unknown>
+  if (![1, 2, 3, 4].includes(Number(candidate.version))) {
+    return { valid: false, message: 'Invalid backup file: unsupported backup version.' }
+  }
+  for (const key of ['transactions', 'rules', 'categories', 'customParsers', 'budgets']) {
+    if (!isArray(candidate[key])) return { valid: false, message: `Invalid backup file: missing ${key} array.` }
+  }
+  if (Number(candidate.version) >= 2) {
+    for (const key of ['brokeragePositions', 'brokeragePositionExtensions', 'brokerageTransactions', 'brokerageAccounts', 'brokerageSyncLog', 'brokerageCredentials']) {
+      if (!isArray(candidate[key])) return { valid: false, message: `Invalid brokerage backup file: missing ${key} array.` }
+    }
+  }
+  if (Number(candidate.version) >= 3 && !isArray(candidate.brokerageFundDetails)) {
+    return { valid: false, message: 'Invalid v3 backup file: missing brokerageFundDetails array.' }
+  }
+  if (Number(candidate.version) === 4) {
+    if (!isArray(candidate.portfolioBuckets) || !isArray(candidate.portfolioBucketAssignments)) {
+      return { valid: false, message: 'Invalid v4 backup file: missing portfolio bucket arrays.' }
+    }
+  }
+  return { valid: true }
+}
+
+export function normalizeBackupForImport(data: Record<string, unknown>): LokfiBackup {
+  const version = Number(data.version) as 1 | 2 | 3 | 4
+  return {
+    version,
+    exportedAt: typeof data.exportedAt === 'string' ? data.exportedAt : undefined,
+    transactions: data.transactions as unknown[],
+    rules: data.rules as unknown[],
+    categories: data.categories as unknown[],
+    customParsers: data.customParsers as unknown[],
+    budgets: data.budgets as unknown[],
+    brokeragePositions: version >= 2 ? (data.brokeragePositions as unknown[]) : [],
+    brokeragePositionExtensions: version >= 2 ? (data.brokeragePositionExtensions as unknown[]) : [],
+    brokerageTransactions: version >= 2 ? (data.brokerageTransactions as unknown[]) : [],
+    brokerageFundDetails: version >= 3 ? (data.brokerageFundDetails as unknown[]) : [],
+    brokerageAccounts: version >= 2 ? (data.brokerageAccounts as unknown[]) : [],
+    brokerageSyncLog: version >= 2 ? (data.brokerageSyncLog as unknown[]) : [],
+    brokerageCredentials: version >= 2 ? (data.brokerageCredentials as unknown[]) : [],
+    portfolioBuckets: version === 4 ? (data.portfolioBuckets as unknown[]) : [],
+    portfolioBucketAssignments: version === 4 ? (data.portfolioBucketAssignments as unknown[]) : [],
+  }
+}
+
+export function buildImportSummary(data: LokfiBackup): string {
+  return (
+    `This will replace all current data with the backup:\n` +
+    `• ${data.transactions.length} transaction(s)\n` +
+    `• ${data.rules.length} rule(s)\n` +
+    `• ${data.categories.length} categor(ies)\n` +
+    `• ${data.customParsers.length} parser profile(s)\n` +
+    `• ${data.budgets.length} budget(s)\n` +
+    `• ${data.brokeragePositions.length} brokerage position(s)\n` +
+    `• ${data.brokerageTransactions.length} brokerage trade(s)\n` +
+    `• ${data.brokerageFundDetails.length} fund detail(s)\n` +
+    `• ${data.brokerageAccounts.length} brokerage account(s)\n` +
+    `• ${data.brokerageCredentials.length} credential(s) (encrypted)\n` +
+    `• ${data.portfolioBuckets.length} portfolio bucket(s)\n` +
+    `• ${data.portfolioBucketAssignments.length} portfolio bucket assignment(s)\n` +
+    `Current data will be overwritten. Are you sure?`
+  )
+}
+
+export async function buildBackupPayload(db: LokfiDatabase): Promise<LokfiBackup & { exportedAt: string }> {
+  const [
+    transactions,
+    rules,
+    categories,
+    customParsers,
+    budgets,
+    brokeragePositions,
+    brokeragePositionExtensions,
+    brokerageTransactions,
+    brokerageFundDetails,
+    brokerageAccounts,
+    brokerageSyncLog,
+    brokerageCredentials,
+    portfolioBuckets,
+    portfolioBucketAssignments,
+  ] = await Promise.all([
+    db.transactions.toArray(),
+    db.rules.toArray(),
+    db.categories.toArray(),
+    db.customParsers.toArray(),
+    db.budgets.toArray(),
+    db.brokeragePositions.toArray(),
+    db.brokeragePositionExtensions.toArray(),
+    db.brokerageTransactions.toArray(),
+    db.brokerageFundDetails.toArray(),
+    db.brokerageAccounts.toArray(),
+    db.brokerageSyncLog.toArray(),
+    db.brokerageCredentials.toArray(),
+    db.portfolioBuckets.toArray(),
+    db.portfolioBucketAssignments.toArray(),
+  ])
+  return {
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    transactions,
+    rules,
+    categories,
+    customParsers,
+    budgets,
+    brokeragePositions,
+    brokeragePositionExtensions,
+    brokerageTransactions,
+    brokerageFundDetails,
+    brokerageAccounts,
+    brokerageSyncLog,
+    brokerageCredentials,
+    portfolioBuckets,
+    portfolioBucketAssignments,
+  }
+}
+
+export async function importBackupPayload(db: LokfiDatabase, data: LokfiBackup): Promise<void> {
+  await db.transaction(
+    'rw',
+    [
+      db.transactions,
+      db.rules,
+      db.categories,
+      db.customParsers,
+      db.budgets,
+      db.brokeragePositions,
+      db.brokeragePositionExtensions,
+      db.brokerageTransactions,
+      db.brokerageFundDetails,
+      db.brokerageAccounts,
+      db.brokerageSyncLog,
+      db.brokerageCredentials,
+      db.portfolioBuckets,
+      db.portfolioBucketAssignments,
+    ],
+    async () => {
+      await Promise.all([
+        db.transactions.clear(),
+        db.rules.clear(),
+        db.categories.clear(),
+        db.customParsers.clear(),
+        db.budgets.clear(),
+        db.brokeragePositions.clear(),
+        db.brokeragePositionExtensions.clear(),
+        db.brokerageTransactions.clear(),
+        db.brokerageFundDetails.clear(),
+        db.brokerageAccounts.clear(),
+        db.brokerageSyncLog.clear(),
+        db.brokerageCredentials.clear(),
+        db.portfolioBuckets.clear(),
+        db.portfolioBucketAssignments.clear(),
+      ])
+      if (data.transactions.length) await db.transactions.bulkAdd(data.transactions as never[])
+      if (data.rules.length) await db.rules.bulkAdd(data.rules as never[])
+      if (data.categories.length) await db.categories.bulkAdd(data.categories as never[])
+      if (data.customParsers.length) await db.customParsers.bulkAdd(data.customParsers as never[])
+      if (data.budgets.length) await db.budgets.bulkAdd(data.budgets as never[])
+      if (data.brokeragePositions.length) await db.brokeragePositions.bulkAdd(data.brokeragePositions as never[])
+      if (data.brokeragePositionExtensions.length) await db.brokeragePositionExtensions.bulkAdd(data.brokeragePositionExtensions as never[])
+      if (data.brokerageTransactions.length) await db.brokerageTransactions.bulkAdd(data.brokerageTransactions as never[])
+      if (data.brokerageFundDetails.length) await db.brokerageFundDetails.bulkAdd(data.brokerageFundDetails as never[])
+      if (data.brokerageAccounts.length) await db.brokerageAccounts.bulkAdd(data.brokerageAccounts as never[])
+      if (data.brokerageSyncLog.length) await db.brokerageSyncLog.bulkAdd(data.brokerageSyncLog as never[])
+      if (data.brokerageCredentials.length) await db.brokerageCredentials.bulkAdd(data.brokerageCredentials as never[])
+      const buckets = data.portfolioBuckets.length ? data.portfolioBuckets : createDefaultPortfolioBuckets()
+      if (buckets.length) await db.portfolioBuckets.bulkAdd(buckets as never[])
+      if (data.portfolioBucketAssignments.length) {
+        await db.portfolioBucketAssignments.bulkAdd(data.portfolioBucketAssignments as never[])
+      }
+    }
+  )
+}
+```
+
+- [ ] **Step 4: Refactor `ProfilePage` to use backup helpers**
+
+In `apps/web/src/pages/profile/ProfilePage.tsx`, import:
+
+```ts
+import {
+  buildBackupPayload,
+  buildImportSummary,
+  importBackupPayload,
+  normalizeBackupForImport,
+  validateBackupShape,
+} from '../../lib/db/backup'
+```
+
+Replace `handleExport` body with:
+
+```ts
+    const data = await buildBackupPayload(db)
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'lokfi-backup.json'
+    a.click()
+    URL.revokeObjectURL(url)
+    await StorageManager.recordExportEvent()
+```
+
+Replace validation/import logic in `handleImportBackup` after `const data = JSON.parse(text)` with:
+
+```ts
+      const validation = validateBackupShape(data)
+      if (!validation.valid) {
+        alert(validation.message)
+        e.target.value = ''
+        return
+      }
+
+      const normalized = normalizeBackupForImport(data)
+      const confirmed = window.confirm(buildImportSummary(normalized))
+      if (!confirmed) {
+        e.target.value = ''
+        return
+      }
+
+      await importBackupPayload(db, normalized)
+      alert('Backup imported successfully!')
+```
+
+Remove the old manually enumerated validation, confirmation, transaction, clear, and bulk-add code.
+
+- [ ] **Step 5: Run backup tests and build**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test -- src/lib/db/backup.test.ts
+pnpm --filter @lokfi/web build
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/lib/db/backup.ts apps/web/src/lib/db/backup.test.ts apps/web/src/pages/profile/ProfilePage.tsx
+git commit -m "feat(web): include portfolio buckets in backups"
+```
+
+---
+
+### Task 4: Bucket Assignment UI And Holdings Filter
+
+**Files:**
+- Create: `apps/web/src/pages/investments/PortfolioBucketCombobox.tsx`
+- Create: `apps/web/src/pages/investments/PortfolioBucketManager.tsx`
+- Modify: `apps/web/src/pages/investments/HoldingsTab.tsx`
+
+- [ ] **Step 1: Create `PortfolioBucketCombobox` following transaction category behavior**
+
+Create `apps/web/src/pages/investments/PortfolioBucketCombobox.tsx`:
+
+```tsx
+import { Settings } from 'lucide-react'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { db } from '../../lib/db/db'
+import type { DbPortfolioBucket } from '../../lib/db/db'
+
+const CUSTOM_COLORS = ['#3b82f6', '#22c55e', '#f59e0b', '#06b6d4', '#8b5cf6', '#ec4899', '#64748b', '#ef4444']
+
+interface PortfolioBucketComboboxProps {
+  value: string | null
+  onChange: (id: string | null) => void
+  onManage: () => void
+  placeholder?: string
+}
+
+type ComboboxOption =
+  | { type: 'clear'; id: string }
+  | { type: 'bucket'; id: string; bucket: DbPortfolioBucket }
+  | { type: 'create'; name: string }
+  | { type: 'manage'; id: string }
+
+export function PortfolioBucketCombobox({
+  value,
+  onChange,
+  onManage,
+  placeholder = 'Unassigned',
+}: PortfolioBucketComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const [inputText, setInputText] = useState('')
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), []) ?? []
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const creatingRef = useRef(false)
+
+  const selectedBucket = buckets.find((bucket) => bucket.id === value) ?? null
+  const filtered = buckets.filter((bucket) => bucket.name.toLowerCase().includes(inputText.toLowerCase()))
+  const showCreate =
+    inputText.trim().length > 0 &&
+    !buckets.some((bucket) => bucket.name.toLowerCase() === inputText.trim().toLowerCase())
+
+  const options = useMemo(() => {
+    const opts: ComboboxOption[] = [{ type: 'clear', id: '' }]
+    filtered.forEach((bucket) => opts.push({ type: 'bucket', id: bucket.id, bucket }))
+    if (showCreate) opts.push({ type: 'create', name: inputText.trim() })
+    opts.push({ type: 'manage', id: 'manage' })
+    return opts
+  }, [filtered, showCreate, inputText])
+
+  useEffect(() => {
+    if (open) setTimeout(() => inputRef.current?.focus(), 0)
+  }, [open])
+
+  useEffect(() => {
+    function handleMouseDown(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleMouseDown)
+      return () => document.removeEventListener('mousedown', handleMouseDown)
+    }
+  }, [open])
+
+  async function handleCreateBucket() {
+    const name = inputText.trim()
+    if (!name || creatingRef.current) return
+    creatingRef.current = true
+    try {
+      const now = new Date().toISOString()
+      const id = 'bucket_' + crypto.randomUUID()
+      const color = CUSTOM_COLORS[buckets.length % CUSTOM_COLORS.length]
+      const sortOrder = buckets.length
+      await db.portfolioBuckets.put({ id, name, color, sortOrder, isDefault: false, createdAt: now, updatedAt: now })
+      onChange(id)
+      setOpen(false)
+    } finally {
+      creatingRef.current = false
+    }
+  }
+
+  function selectBucket(id: string | null) {
+    onChange(id)
+    setOpen(false)
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open) return
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setHighlightedIndex((index) => (index + 1) % Math.max(1, options.length))
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setHighlightedIndex((index) => (index - 1 + options.length) % Math.max(1, options.length))
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      const option = options[highlightedIndex]
+      if (!option) return
+      if (option.type === 'clear') selectBucket(null)
+      if (option.type === 'bucket') selectBucket(option.id)
+      if (option.type === 'create') handleCreateBucket()
+      if (option.type === 'manage') {
+        setOpen(false)
+        onManage()
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative inline-block text-left">
+      <button
+        type="button"
+        onClick={() => {
+          setInputText('')
+          setHighlightedIndex(0)
+          setOpen((current) => !current)
+        }}
+        className="inline-flex min-w-[8rem] max-w-[12rem] items-center gap-1.5 rounded-full border bg-white px-3 py-1.5 text-sm text-gray-900 focus:outline-none dark:bg-gray-900 dark:text-white"
+        style={{ borderColor: 'var(--border)' }}
+      >
+        {selectedBucket ? (
+          <>
+            <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: selectedBucket.color }} />
+            <span className="truncate">{selectedBucket.name}</span>
+          </>
+        ) : (
+          <span className="truncate text-gray-400 dark:text-gray-500">{placeholder}</span>
+        )}
+        <span className="ml-auto text-xs text-gray-400">⌄</span>
+      </button>
+
+      {open && (
+        <div
+          className="absolute left-0 top-full z-[1000] mt-1 w-60 rounded-lg border bg-white py-1 shadow-lg dark:bg-gray-900"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          <div className="px-2 pb-1">
+            <input
+              ref={inputRef}
+              value={inputText}
+              onChange={(event) => {
+                setInputText(event.target.value)
+                setHighlightedIndex(0)
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Search or create bucket..."
+              className="w-full rounded-md border bg-white px-2 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 dark:bg-gray-800 dark:text-white"
+              style={{ borderColor: 'var(--border)', '--tw-ring-color': 'var(--accent)' } as React.CSSProperties}
+            />
+          </div>
+
+          <div className="max-h-40 overflow-y-auto">
+            {options.map((option, index) => {
+              const highlighted = index === highlightedIndex
+              const baseClass = 'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors '
+              const activeClass = highlighted
+                ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                : 'text-gray-800 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800'
+
+              if (option.type === 'clear') {
+                return (
+                  <button key="clear" type="button" data-highlighted={highlighted} onClick={() => selectBucket(null)} className={baseClass + activeClass}>
+                    Unassigned
+                  </button>
+                )
+              }
+              if (option.type === 'bucket') {
+                return (
+                  <button key={option.id} type="button" data-highlighted={highlighted} onClick={() => selectBucket(option.id)} className={baseClass + activeClass}>
+                    <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: option.bucket.color }} />
+                    <span className="truncate">{option.bucket.name}</span>
+                  </button>
+                )
+              }
+              if (option.type === 'create') {
+                return (
+                  <button key="create" type="button" data-highlighted={highlighted} onClick={handleCreateBucket} className={baseClass + activeClass} style={{ color: 'var(--accent)' }}>
+                    + Create "{option.name}"
+                  </button>
+                )
+              }
+              return (
+                <button
+                  key="manage"
+                  type="button"
+                  data-highlighted={highlighted}
+                  onClick={() => {
+                    setOpen(false)
+                    onManage()
+                  }}
+                  className={baseClass + activeClass}
+                >
+                  <Settings size={14} />
+                  Manage buckets...
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Create bucket manager modal**
+
+Create `apps/web/src/pages/investments/PortfolioBucketManager.tsx`:
+
+```tsx
+import { ArrowDown, ArrowUp, Trash2, X } from 'lucide-react'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { db } from '../../lib/db/db'
+
+interface PortfolioBucketManagerProps {
+  open: boolean
+  onClose: () => void
+}
+
+const COLOR_SWATCHES = ['#3b82f6', '#22c55e', '#f59e0b', '#06b6d4', '#8b5cf6', '#ec4899', '#64748b', '#ef4444']
+
+export function PortfolioBucketManager({ open, onClose }: PortfolioBucketManagerProps) {
+  const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), []) ?? []
+
+  if (!open) return null
+
+  async function renameBucket(id: string, name: string) {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    await db.portfolioBuckets.update(id, { name: trimmed, updatedAt: new Date().toISOString() })
+  }
+
+  async function recolorBucket(id: string, color: string) {
+    await db.portfolioBuckets.update(id, { color, updatedAt: new Date().toISOString() })
+  }
+
+  async function moveBucket(id: string, direction: -1 | 1) {
+    const index = buckets.findIndex((bucket) => bucket.id === id)
+    const swap = buckets[index + direction]
+    const current = buckets[index]
+    if (!current || !swap) return
+    await db.transaction('rw', [db.portfolioBuckets], async () => {
+      await db.portfolioBuckets.update(current.id, { sortOrder: swap.sortOrder, updatedAt: new Date().toISOString() })
+      await db.portfolioBuckets.update(swap.id, { sortOrder: current.sortOrder, updatedAt: new Date().toISOString() })
+    })
+  }
+
+  async function deleteBucket(id: string) {
+    const confirmed = window.confirm('Delete this portfolio bucket? Affected holdings will become Unassigned.')
+    if (!confirmed) return
+    await db.transaction('rw', [db.portfolioBuckets, db.portfolioBucketAssignments], async () => {
+      await db.portfolioBuckets.delete(id)
+      await db.portfolioBucketAssignments.where('bucketId').equals(id).delete()
+    })
+  }
+
+  return (
+    <div className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-xl border bg-white shadow-xl dark:bg-gray-950" style={{ borderColor: 'var(--border)' }}>
+        <div className="flex items-center justify-between border-b px-5 py-4" style={{ borderColor: 'var(--border)' }}>
+          <h2 className="font-serif text-lg text-gray-900 dark:text-white">Portfolio buckets</h2>
+          <button type="button" onClick={onClose} className="rounded p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200" aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+        <div className="max-h-[65vh] space-y-3 overflow-y-auto p-5">
+          {buckets.map((bucket, index) => (
+            <div key={bucket.id} className="rounded-lg border p-3" style={{ borderColor: 'var(--border)' }}>
+              <div className="flex items-center gap-2">
+                <input
+                  defaultValue={bucket.name}
+                  onBlur={(event) => renameBucket(bucket.id, event.target.value)}
+                  className="min-w-0 flex-1 rounded-md border bg-white px-2 py-1.5 text-sm text-gray-900 dark:bg-gray-900 dark:text-white"
+                  style={{ borderColor: 'var(--border)' }}
+                />
+                <button type="button" onClick={() => moveBucket(bucket.id, -1)} disabled={index === 0} className="rounded border p-1 disabled:opacity-30" style={{ borderColor: 'var(--border)' }} aria-label="Move up">
+                  <ArrowUp size={14} />
+                </button>
+                <button type="button" onClick={() => moveBucket(bucket.id, 1)} disabled={index === buckets.length - 1} className="rounded border p-1 disabled:opacity-30" style={{ borderColor: 'var(--border)' }} aria-label="Move down">
+                  <ArrowDown size={14} />
+                </button>
+                <button type="button" onClick={() => deleteBucket(bucket.id)} className="rounded border p-1 text-red-500" style={{ borderColor: 'var(--border)' }} aria-label="Delete bucket">
+                  <Trash2 size={14} />
+                </button>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {COLOR_SWATCHES.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => recolorBucket(bucket.id, color)}
+                    className={`h-6 w-6 rounded-full border-2 ${bucket.color === color ? 'border-gray-900 dark:border-white' : 'border-transparent'}`}
+                    style={{ backgroundColor: color }}
+                    aria-label={`Use ${color}`}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Wire Holdings tab bucket assignment and filtering**
+
+Modify `apps/web/src/pages/investments/HoldingsTab.tsx`:
+
+Add imports:
+
+```ts
+import { PortfolioBucketCombobox } from './PortfolioBucketCombobox'
+import { PortfolioBucketManager } from './PortfolioBucketManager'
+import {
+  buildAssignmentLookup,
+  buildBucketOptions,
+  filterPositionsByBucket,
+  getSecurityKey,
+  isStockLikePosition,
+  UNASSIGNED_BUCKET_ID,
+} from '../../lib/investments/portfolioBuckets'
+```
+
+Add state in `HoldingsTab`:
+
+```ts
+  const [bucketFilter, setBucketFilter] = useState('all')
+  const [bucketManagerOpen, setBucketManagerOpen] = useState(false)
+  const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), []) ?? []
+  const assignments = useLiveQuery(() => db.portfolioBucketAssignments.toArray(), []) ?? []
+```
+
+Before splitting into row arrays, filter stock-like positions:
+
+```ts
+  const bucketFilteredPositions = filterPositionsByBucket(allPositions ?? [], assignments, bucketFilter)
+```
+
+Then iterate `bucketFilteredPositions` instead of `allPositions ?? []` when building `stockRows` and `derivativeRows`.
+
+Inside `HoldingsTable`, add props:
+
+```ts
+  buckets: DbPortfolioBucket[]
+  assignments: DbPortfolioBucketAssignment[]
+  onAssignBucket: (position: BrokeragePosition, bucketId: string | null) => void
+  onManageBuckets: () => void
+```
+
+Add a `bucket` sort key only for stock rows if desired, or keep the Bucket column unsorted for v1.
+
+Add a `Bucket` header in the stock-like branch and render a cell in stock-like rows:
+
+```tsx
+                    <td className="px-3 py-2.5 text-left">
+                      <PortfolioBucketCombobox
+                        value={assignmentBySecurity.get(getSecurityKey(position)) ?? null}
+                        onChange={(bucketId) => onAssignBucket(position, bucketId)}
+                        onManage={onManageBuckets}
+                      />
+                    </td>
+```
+
+Create `assignmentBySecurity` inside `HoldingsTable`:
+
+```ts
+  const assignmentBySecurity = buildAssignmentLookup(assignments)
+```
+
+Implement assignment in `HoldingsTab`:
+
+```ts
+  async function handleAssignBucket(position: BrokeragePosition, bucketId: string | null) {
+    const securityKey = getSecurityKey(position)
+    if (bucketId == null) {
+      await db.portfolioBucketAssignments.delete(securityKey)
+      return
+    }
+    const now = new Date().toISOString()
+    await db.portfolioBucketAssignments.put({
+      securityKey,
+      bucketId,
+      createdAt: now,
+      updatedAt: now,
+    })
+  }
+```
+
+Add filter control under the search input:
+
+```tsx
+      <div className="flex items-center gap-2 overflow-x-auto pb-1">
+        {buildBucketOptions(buckets).map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => setBucketFilter(option.id)}
+            className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+              bucketFilter === option.id ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'
+            }`}
+            style={{
+              borderColor: bucketFilter === option.id ? 'var(--accent)' : 'var(--border)',
+              backgroundColor: bucketFilter === option.id ? 'var(--accent-subtle)' : 'transparent',
+            }}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+```
+
+Render manager:
+
+```tsx
+      <PortfolioBucketManager open={bucketManagerOpen} onClose={() => setBucketManagerOpen(false)} />
+```
+
+Pass new props into `PositionSection` and `HoldingsTable` for stock-like rows. For derivative rows, do not render the bucket column and do not pass assignment controls.
+
+- [ ] **Step 4: Run build**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/pages/investments/HoldingsTab.tsx apps/web/src/pages/investments/PortfolioBucketCombobox.tsx apps/web/src/pages/investments/PortfolioBucketManager.tsx
+git commit -m "feat(web): assign portfolio buckets to holdings"
+```
+
+---
+
+### Task 5: Overview Portfolio By Bucket Card
+
+**Files:**
+- Modify: `apps/web/src/pages/investments/OverviewTab.tsx`
+- Test: `apps/web/src/lib/investments/portfolioBuckets.test.ts`
+
+- [ ] **Step 1: Confirm aggregation test covers overview behavior**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test -- src/lib/investments/portfolioBuckets.test.ts
+```
+
+Expected: PASS from Task 1. This is the coverage for Overview bucket totals, including fallback market value and derivative exclusion.
+
+- [ ] **Step 2: Add Portfolio by bucket card component**
+
+Modify `apps/web/src/pages/investments/OverviewTab.tsx`:
+
+Add imports:
+
+```ts
+import type { DbPortfolioBucket, DbPortfolioBucketAssignment } from '../../lib/db/db'
+import { getPortfolioBucketAggregation } from '../../lib/investments/portfolioBuckets'
+```
+
+Add component before `CurrencyBreakdown`:
+
+```tsx
+function PortfolioBucketBreakdown({
+  positions,
+  buckets,
+  assignments,
+  preferredCurrency,
+  fxRates,
+}: {
+  positions: import('@lokfi/brokerage-core').BrokeragePosition[]
+  buckets: DbPortfolioBucket[]
+  assignments: DbPortfolioBucketAssignment[]
+  preferredCurrency: CurrencyOption
+  fxRates: Record<string, number> | null
+}) {
+  const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+  const rows = getPortfolioBucketAggregation({
+    positions,
+    buckets,
+    assignments,
+    convertValue: (value, position) =>
+      shouldConvert ? convertAmount(value, position.currency, preferredCurrency, fxRates) : value,
+  })
+
+  if (rows.length === 0) return null
+
+  return (
+    <div className="rounded-xl border p-5" style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}>
+      <h3 className="mb-4 font-serif text-sm font-medium text-gray-900 dark:text-white">Portfolio by bucket</h3>
+      <ResponsiveContainer width="100%" height={260}>
+        <PieChart>
+          <Pie data={rows} cx="50%" cy="50%" innerRadius={55} outerRadius={75} dataKey="value" labelLine={false} label={({ name, percent }) => `${name} ${(percent * 100).toFixed(1)}%`}>
+            {rows.map((row) => (
+              <Cell key={row.bucketId} fill={row.color} />
+            ))}
+          </Pie>
+          <Tooltip
+            contentStyle={TOOLTIP_STYLE}
+            formatter={(value: number) => [
+              value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+              'Value',
+            ]}
+          />
+          <Legend formatter={(value: string) => value} />
+        </PieChart>
+      </ResponsiveContainer>
+      <div className="mt-3 space-y-2">
+        {rows.map((row) => (
+          <div key={row.bucketId} className="flex items-center justify-between text-xs">
+            <span className="flex min-w-0 items-center gap-2 text-gray-700 dark:text-gray-300">
+              <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: row.color }} />
+              <span className="truncate">{row.name}</span>
+            </span>
+            <span className="font-mono text-gray-500 dark:text-gray-400">
+              {row.value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ({row.pct.toFixed(1)}%)
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+Load data in `OverviewTab`:
+
+```ts
+  const buckets = useLiveQuery(() => db.portfolioBuckets.orderBy('sortOrder').toArray(), [])
+  const assignments = useLiveQuery(() => db.portfolioBucketAssignments.toArray(), [])
+```
+
+Update loading state:
+
+```ts
+  const isLoading =
+    positions === undefined ||
+    accounts === undefined ||
+    fundDetails === undefined ||
+    buckets === undefined ||
+    assignments === undefined
+```
+
+Render after Asset Allocation:
+
+```tsx
+      {!isLoading && hasData && (
+        <PortfolioBucketBreakdown
+          positions={positions!}
+          buckets={buckets!}
+          assignments={assignments!}
+          preferredCurrency={preferredCurrency}
+          fxRates={fxRates}
+        />
+      )}
+```
+
+- [ ] **Step 3: Run tests and build**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test -- src/lib/investments/portfolioBuckets.test.ts
+pnpm --filter @lokfi/web build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/investments/OverviewTab.tsx apps/web/src/lib/investments/portfolioBuckets.test.ts
+git commit -m "feat(web): show portfolio bucket allocation"
+```
+
+---
+
+### Task 6: Manual UI Verification
+
+**Files:**
+- No source files expected. If verification reveals defects, modify the smallest affected source file and commit the fix in Step 5.
+
+- [ ] **Step 1: Run full package tests**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run lint/build**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web build
+pnpm --filter @lokfi/web lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Start local dev server**
+
+Run:
+
+```bash
+pnpm --filter @lokfi/web dev
+```
+
+Expected: Vite prints a localhost URL, commonly `http://localhost:5173/`.
+
+- [ ] **Step 4: Browser verification**
+
+Open `/investments?tab=holdings` and verify:
+
+- Existing holdings render.
+- Stock-like rows show a `Bucket` selector.
+- Derivative rows do not show a bucket selector.
+- Selecting `Growth`, `Income`, or `Cash` persists after refresh.
+- Creating a new bucket from the selector assigns it to the security.
+- Clearing returns the security to `Unassigned`.
+- Bucket filter narrows visible stock-like holdings.
+- Manage buckets can rename, recolor, reorder, and delete a bucket.
+- Deleted bucket assignments become `Unassigned`.
+
+Open `/investments?tab=overview` and verify:
+
+- `Portfolio by bucket` card renders when holdings exist.
+- Unassigned holdings appear as `Unassigned`.
+- Values respond to the existing display-currency selector.
+- Existing Asset Allocation, Currency Breakdown, and Performance sections still render.
+
+Open `/profile` and verify:
+
+- Exported JSON has `version: 4`.
+- Exported JSON includes `portfolioBuckets` and `portfolioBucketAssignments`.
+- Importing a v4 backup restores buckets and assignments.
+- Importing an older v3 backup still succeeds and leaves default buckets available.
+
+- [ ] **Step 5: Commit verification fixes if needed**
+
+If verification required fixes:
+
+```bash
+git add apps/web/src
+git commit -m "fix(web): polish portfolio bucket workflow"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+---
+
+### Task 7: Final Whole-Repo Verification
+
+**Files:**
+- No source files expected. If final verification reveals defects, return to the affected task, fix the source file, and rerun that task's verification.
+
+- [ ] **Step 1: Run root test command**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run root lint command**
+
+Run:
+
+```bash
+pnpm lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Check git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional committed changes are present. `.superpowers/` may remain untracked visual brainstorming scratch and should not be committed.
+
+- [ ] **Step 4: Prepare final summary**
+
+Summarize:
+
+- New Dexie tables and migration.
+- Holdings assignment/filtering.
+- Overview bucket allocation.
+- Profile backup/import v4 compatibility.
+- Tests and verification commands run.

--- a/docs/superpowers/plans/2026-05-12-portfolio-performance-card.md
+++ b/docs/superpowers/plans/2026-05-12-portfolio-performance-card.md
@@ -1,0 +1,888 @@
+# Portfolio Performance Card Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a snapshot-based portfolio performance card to the investments overview tab, with daily deduplicating snapshot capture on sync, an area chart with time-range filtering, return summary, and full backup/restore support.
+
+**Architecture:** On every brokerage sync, `usePortfolioSnapshot` (a React hook) computes `totalValue` from live positions + accounts + FX rates and upserts a `portfolioSnapshots` row keyed by today's date. `PerformanceCard` queries snapshots, converts each to the current preferred currency via `convertAmount`, filters by selected range, and renders a Recharts `AreaChart` with a `+X.XX% / +CUR N` return summary.
+
+**Tech Stack:** React, Dexie (IndexedDB), Recharts, Vitest
+
+---
+
+## File Map
+
+| Action | File |
+|---|---|
+| Modify | `apps/web/src/lib/db/db.ts` |
+| Modify | `apps/web/src/lib/db/backup.ts` |
+| Modify | `apps/web/src/lib/db/backup.test.ts` |
+| Create | `apps/web/src/lib/investments/portfolioPerformance.ts` |
+| Create | `apps/web/src/lib/investments/portfolioPerformance.test.ts` |
+| Create | `apps/web/src/lib/investments/usePortfolioSnapshot.ts` |
+| Create | `apps/web/src/lib/investments/usePortfolioSnapshot.test.ts` |
+| Modify | `apps/web/src/pages/investments/OverviewTab.tsx` |
+
+---
+
+## Task 1: Add `portfolioSnapshots` Dexie table (v10)
+
+**Files:**
+- Modify: `apps/web/src/lib/db/db.ts`
+
+- [ ] **Step 1: Add `DbPortfolioSnapshot` interface and table property**
+
+  In `apps/web/src/lib/db/db.ts`, add the interface after `DbBudget` (around line 67) and the table property inside `LokfiDatabase`:
+
+  ```ts
+  export interface DbPortfolioSnapshot {
+    date: string       // YYYY-MM-DD, primary key
+    totalValue: number
+    currency: string   // preferred currency used at snapshot time
+  }
+  ```
+
+  Add the table property after the `portfolioBucketAssignments` line:
+
+  ```ts
+  // Portfolio performance snapshots (v10)
+  portfolioSnapshots!: Table<DbPortfolioSnapshot>
+  ```
+
+- [ ] **Step 2: Add Dexie v10 schema**
+
+  After the `this.version(9)` block (around line 163), add:
+
+  ```ts
+  // v10 schema (adds daily portfolio value snapshots for performance chart)
+  this.version(10).stores({
+    portfolioSnapshots: 'date',
+  })
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add apps/web/src/lib/db/db.ts
+  git commit -m "feat(db): add portfolioSnapshots table (v10)"
+  ```
+
+---
+
+## Task 2: Backup v5 — tests first, then implementation
+
+**Files:**
+- Modify: `apps/web/src/lib/db/backup.test.ts`
+- Modify: `apps/web/src/lib/db/backup.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+  Open `apps/web/src/lib/db/backup.test.ts`. The existing `baseV3` fixture and the `describe('backup helpers')` block are already there.
+
+  First, **replace** the existing test `'uses backup version 4 for portfolio buckets'` with:
+  ```ts
+  it('uses backup version 5 for portfolio snapshots', () => {
+    expect(BACKUP_VERSION).toBe(5)
+  })
+  ```
+
+  Then add a `baseV4` fixture after `baseV3` and add four more new test cases at the end of the `describe` block:
+
+  ```ts
+  const baseV4 = {
+    ...baseV3,
+    version: 4,
+    portfolioBuckets: [],
+    portfolioBucketAssignments: [],
+  }
+
+  // — add inside describe('backup helpers') —
+
+  it('requires portfolioSnapshots array for v5 backups', () => {
+    expect(validateBackupShape({ ...baseV4, version: 5 }).valid).toBe(false)
+    expect(
+      validateBackupShape({ ...baseV4, version: 5, portfolioSnapshots: [] })
+    ).toEqual({ valid: true })
+  })
+
+  it('normalizes v4 and older backups with empty portfolioSnapshots', () => {
+    const normalizedV3 = normalizeBackupForImport(baseV3)
+    expect(normalizedV3.portfolioSnapshots).toEqual([])
+
+    const normalizedV4 = normalizeBackupForImport(baseV4)
+    expect(normalizedV4.portfolioSnapshots).toEqual([])
+  })
+
+  it('keeps portfolioSnapshots during v5 normalization', () => {
+    const snapshot = { date: '2026-05-01', totalValue: 10000, currency: 'SGD' }
+    const normalized = normalizeBackupForImport({
+      ...baseV4,
+      version: 5,
+      portfolioSnapshots: [snapshot],
+    })
+    expect(normalized.portfolioSnapshots).toHaveLength(1)
+    expect(normalized.portfolioSnapshots[0]).toEqual(snapshot)
+  })
+
+  it('includes snapshot count in import summary', () => {
+    const summary = buildImportSummary({
+      ...normalizeBackupForImport({ ...baseV4, version: 5, portfolioSnapshots: [] }),
+      portfolioSnapshots: [
+        { date: '2026-05-01', totalValue: 10000, currency: 'SGD' },
+        { date: '2026-05-02', totalValue: 10200, currency: 'SGD' },
+      ],
+    })
+    expect(summary).toContain('2 portfolio snapshot(s)')
+  })
+  ```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+  ```bash
+  cd apps/web && npx vitest run src/lib/db/backup.test.ts
+  ```
+
+  Expected: 4 new tests FAIL (BACKUP_VERSION still 4, v5 logic missing).
+
+- [ ] **Step 3: Implement backup v5 changes in `apps/web/src/lib/db/backup.ts`**
+
+  Replace the entire file with the following:
+
+  ```ts
+  import { createDefaultPortfolioBuckets } from '../investments/portfolioBuckets'
+  import type { LokfiDatabase } from './db'
+
+  export const BACKUP_VERSION = 5
+
+  export interface LokfiBackup {
+    version: 1 | 2 | 3 | 4 | 5
+    exportedAt?: string
+    transactions: unknown[]
+    rules: unknown[]
+    categories: unknown[]
+    customParsers: unknown[]
+    budgets: unknown[]
+    brokeragePositions: unknown[]
+    brokeragePositionExtensions: unknown[]
+    brokerageTransactions: unknown[]
+    brokerageFundDetails: unknown[]
+    brokerageAccounts: unknown[]
+    brokerageSyncLog: unknown[]
+    brokerageCredentials: unknown[]
+    portfolioBuckets: unknown[]
+    portfolioBucketAssignments: unknown[]
+    portfolioSnapshots: unknown[]
+  }
+
+  function isArray(value: unknown): value is unknown[] {
+    return Array.isArray(value)
+  }
+
+  export function validateBackupShape(data: unknown): { valid: true } | { valid: false; message: string } {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return { valid: false, message: 'Invalid backup file: expected an object.' }
+    }
+    const candidate = data as Record<string, unknown>
+    const version = Number(candidate.version)
+    if (![1, 2, 3, 4, 5].includes(version)) {
+      return { valid: false, message: 'Invalid backup file: unsupported backup version.' }
+    }
+    for (const key of ['transactions', 'rules', 'categories', 'customParsers', 'budgets']) {
+      if (!isArray(candidate[key])) {
+        return { valid: false, message: `Invalid backup file: missing ${key} array.` }
+      }
+    }
+    if (version >= 2) {
+      for (const key of [
+        'brokeragePositions',
+        'brokeragePositionExtensions',
+        'brokerageTransactions',
+        'brokerageAccounts',
+        'brokerageSyncLog',
+        'brokerageCredentials',
+      ]) {
+        if (!isArray(candidate[key])) {
+          return { valid: false, message: `Invalid brokerage backup file: missing ${key} array.` }
+        }
+      }
+    }
+    if (version >= 3 && !isArray(candidate.brokerageFundDetails)) {
+      return { valid: false, message: 'Invalid v3 backup file: missing brokerageFundDetails array.' }
+    }
+    if (version >= 4) {
+      if (!isArray(candidate.portfolioBuckets) || !isArray(candidate.portfolioBucketAssignments)) {
+        return { valid: false, message: 'Invalid v4 backup file: missing portfolio bucket arrays.' }
+      }
+    }
+    if (version >= 5 && !isArray(candidate.portfolioSnapshots)) {
+      return { valid: false, message: 'Invalid v5 backup file: missing portfolioSnapshots array.' }
+    }
+    return { valid: true }
+  }
+
+  export function normalizeBackupForImport(data: Record<string, unknown>): LokfiBackup {
+    const version = Number(data.version) as 1 | 2 | 3 | 4 | 5
+    return {
+      version,
+      exportedAt: typeof data.exportedAt === 'string' ? data.exportedAt : undefined,
+      transactions: data.transactions as unknown[],
+      rules: data.rules as unknown[],
+      categories: data.categories as unknown[],
+      customParsers: data.customParsers as unknown[],
+      budgets: data.budgets as unknown[],
+      brokeragePositions: version >= 2 ? (data.brokeragePositions as unknown[]) : [],
+      brokeragePositionExtensions: version >= 2 ? (data.brokeragePositionExtensions as unknown[]) : [],
+      brokerageTransactions: version >= 2 ? (data.brokerageTransactions as unknown[]) : [],
+      brokerageFundDetails: version >= 3 ? (data.brokerageFundDetails as unknown[]) : [],
+      brokerageAccounts: version >= 2 ? (data.brokerageAccounts as unknown[]) : [],
+      brokerageSyncLog: version >= 2 ? (data.brokerageSyncLog as unknown[]) : [],
+      brokerageCredentials: version >= 2 ? (data.brokerageCredentials as unknown[]) : [],
+      portfolioBuckets: version >= 4 ? (data.portfolioBuckets as unknown[]) : [],
+      portfolioBucketAssignments: version >= 4 ? (data.portfolioBucketAssignments as unknown[]) : [],
+      portfolioSnapshots: version >= 5 ? (data.portfolioSnapshots as unknown[]) : [],
+    }
+  }
+
+  export function buildImportSummary(data: LokfiBackup): string {
+    return (
+      `This will replace all current data with the backup:\n` +
+      `• ${data.transactions.length} transaction(s)\n` +
+      `• ${data.rules.length} rule(s)\n` +
+      `• ${data.categories.length} categor(ies)\n` +
+      `• ${data.customParsers.length} parser profile(s)\n` +
+      `• ${data.budgets.length} budget(s)\n` +
+      `• ${data.brokeragePositions.length} brokerage position(s)\n` +
+      `• ${data.brokerageTransactions.length} brokerage trade(s)\n` +
+      `• ${data.brokerageFundDetails.length} fund detail(s)\n` +
+      `• ${data.brokerageAccounts.length} brokerage account(s)\n` +
+      `• ${data.brokerageCredentials.length} credential(s) (encrypted)\n` +
+      `• ${data.portfolioBuckets.length} portfolio bucket(s)\n` +
+      `• ${data.portfolioBucketAssignments.length} portfolio bucket assignment(s)\n` +
+      `• ${data.portfolioSnapshots.length} portfolio snapshot(s)\n` +
+      `Current data will be overwritten. Are you sure?`
+    )
+  }
+
+  export async function buildBackupPayload(db: LokfiDatabase): Promise<LokfiBackup & { exportedAt: string }> {
+    const [
+      transactions,
+      rules,
+      categories,
+      customParsers,
+      budgets,
+      brokeragePositions,
+      brokeragePositionExtensions,
+      brokerageTransactions,
+      brokerageFundDetails,
+      brokerageAccounts,
+      brokerageSyncLog,
+      brokerageCredentials,
+      portfolioBuckets,
+      portfolioBucketAssignments,
+      portfolioSnapshots,
+    ] = await Promise.all([
+      db.transactions.toArray(),
+      db.rules.toArray(),
+      db.categories.toArray(),
+      db.customParsers.toArray(),
+      db.budgets.toArray(),
+      db.brokeragePositions.toArray(),
+      db.brokeragePositionExtensions.toArray(),
+      db.brokerageTransactions.toArray(),
+      db.brokerageFundDetails.toArray(),
+      db.brokerageAccounts.toArray(),
+      db.brokerageSyncLog.toArray(),
+      db.brokerageCredentials.toArray(),
+      db.portfolioBuckets.toArray(),
+      db.portfolioBucketAssignments.toArray(),
+      db.portfolioSnapshots.toArray(),
+    ])
+    return {
+      version: BACKUP_VERSION,
+      exportedAt: new Date().toISOString(),
+      transactions,
+      rules,
+      categories,
+      customParsers,
+      budgets,
+      brokeragePositions,
+      brokeragePositionExtensions,
+      brokerageTransactions,
+      brokerageFundDetails,
+      brokerageAccounts,
+      brokerageSyncLog,
+      brokerageCredentials,
+      portfolioBuckets,
+      portfolioBucketAssignments,
+      portfolioSnapshots,
+    }
+  }
+
+  export async function importBackupPayload(db: LokfiDatabase, data: LokfiBackup): Promise<void> {
+    await db.transaction(
+      'rw',
+      [
+        db.transactions,
+        db.rules,
+        db.categories,
+        db.customParsers,
+        db.budgets,
+        db.brokeragePositions,
+        db.brokeragePositionExtensions,
+        db.brokerageTransactions,
+        db.brokerageFundDetails,
+        db.brokerageAccounts,
+        db.brokerageSyncLog,
+        db.brokerageCredentials,
+        db.portfolioBuckets,
+        db.portfolioBucketAssignments,
+        db.portfolioSnapshots,
+      ],
+      async () => {
+        await Promise.all([
+          db.transactions.clear(),
+          db.rules.clear(),
+          db.categories.clear(),
+          db.customParsers.clear(),
+          db.budgets.clear(),
+          db.brokeragePositions.clear(),
+          db.brokeragePositionExtensions.clear(),
+          db.brokerageTransactions.clear(),
+          db.brokerageFundDetails.clear(),
+          db.brokerageAccounts.clear(),
+          db.brokerageSyncLog.clear(),
+          db.brokerageCredentials.clear(),
+          db.portfolioBuckets.clear(),
+          db.portfolioBucketAssignments.clear(),
+          db.portfolioSnapshots.clear(),
+        ])
+        if (data.transactions.length) await db.transactions.bulkAdd(data.transactions as never[])
+        if (data.rules.length) await db.rules.bulkAdd(data.rules as never[])
+        if (data.categories.length) await db.categories.bulkAdd(data.categories as never[])
+        if (data.customParsers.length) await db.customParsers.bulkAdd(data.customParsers as never[])
+        if (data.budgets.length) await db.budgets.bulkAdd(data.budgets as never[])
+        if (data.brokeragePositions.length) await db.brokeragePositions.bulkAdd(data.brokeragePositions as never[])
+        if (data.brokeragePositionExtensions.length) {
+          await db.brokeragePositionExtensions.bulkAdd(data.brokeragePositionExtensions as never[])
+        }
+        if (data.brokerageTransactions.length)
+          await db.brokerageTransactions.bulkAdd(data.brokerageTransactions as never[])
+        if (data.brokerageFundDetails.length) await db.brokerageFundDetails.bulkAdd(data.brokerageFundDetails as never[])
+        if (data.brokerageAccounts.length) await db.brokerageAccounts.bulkAdd(data.brokerageAccounts as never[])
+        if (data.brokerageSyncLog.length) await db.brokerageSyncLog.bulkAdd(data.brokerageSyncLog as never[])
+        if (data.brokerageCredentials.length) await db.brokerageCredentials.bulkAdd(data.brokerageCredentials as never[])
+        const buckets = data.portfolioBuckets.length ? data.portfolioBuckets : createDefaultPortfolioBuckets()
+        if (buckets.length) await db.portfolioBuckets.bulkAdd(buckets as never[])
+        if (data.portfolioBucketAssignments.length) {
+          await db.portfolioBucketAssignments.bulkAdd(data.portfolioBucketAssignments as never[])
+        }
+        if (data.portfolioSnapshots.length) await db.portfolioSnapshots.bulkAdd(data.portfolioSnapshots as never[])
+      }
+    )
+  }
+  ```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+  ```bash
+  cd apps/web && npx vitest run src/lib/db/backup.test.ts
+  ```
+
+  Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add apps/web/src/lib/db/backup.ts apps/web/src/lib/db/backup.test.ts
+  git commit -m "feat(backup): bump to v5, add portfolioSnapshots to export/import"
+  ```
+
+---
+
+## Task 3: Portfolio performance pure helpers
+
+**Files:**
+- Create: `apps/web/src/lib/investments/portfolioPerformance.ts`
+- Create: `apps/web/src/lib/investments/portfolioPerformance.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+  Create `apps/web/src/lib/investments/portfolioPerformance.test.ts`:
+
+  ```ts
+  import { describe, expect, it } from 'vitest'
+  import { computeReturn, filterSnapshotsByRange } from './portfolioPerformance'
+
+  const snap = (date: string, value: number) => ({ date, value })
+
+  describe('filterSnapshotsByRange', () => {
+    const snapshots = [
+      snap('2025-05-12', 10000),
+      snap('2025-08-12', 11000),
+      snap('2025-11-12', 11500),
+      snap('2026-02-12', 12000),
+      snap('2026-05-11', 12500),
+    ]
+    const now = new Date('2026-05-12T00:00:00Z')
+
+    it('returns all snapshots for All', () => {
+      expect(filterSnapshotsByRange(snapshots, 'All', now)).toHaveLength(5)
+    })
+
+    it('filters to last 1 month', () => {
+      const result = filterSnapshotsByRange(snapshots, '1M', now)
+      expect(result.every((s) => s.date >= '2026-04-12')).toBe(true)
+      expect(result).toHaveLength(1)
+    })
+
+    it('filters to last 3 months', () => {
+      const result = filterSnapshotsByRange(snapshots, '3M', now)
+      expect(result.every((s) => s.date >= '2026-02-12')).toBe(true)
+      expect(result).toHaveLength(2)
+    })
+
+    it('filters to last 6 months', () => {
+      const result = filterSnapshotsByRange(snapshots, '6M', now)
+      expect(result.every((s) => s.date >= '2025-11-12')).toBe(true)
+      expect(result).toHaveLength(3)
+    })
+
+    it('filters to last 12 months (1Y)', () => {
+      const result = filterSnapshotsByRange(snapshots, '1Y', now)
+      expect(result.every((s) => s.date >= '2025-05-12')).toBe(true)
+      expect(result).toHaveLength(5)
+    })
+
+    it('filters YTD from Jan 1 of current year', () => {
+      const result = filterSnapshotsByRange(snapshots, 'YTD', now)
+      expect(result.every((s) => s.date >= '2026-01-01')).toBe(true)
+      expect(result).toHaveLength(2)
+    })
+  })
+
+  describe('computeReturn', () => {
+    it('returns null for fewer than 2 points', () => {
+      expect(computeReturn([])).toBeNull()
+      expect(computeReturn([snap('2026-01-01', 10000)])).toBeNull()
+    })
+
+    it('returns null if first value is zero', () => {
+      expect(computeReturn([snap('2026-01-01', 0), snap('2026-01-02', 100)])).toBeNull()
+    })
+
+    it('computes positive return', () => {
+      const result = computeReturn([snap('2026-01-01', 10000), snap('2026-05-01', 11000)])
+      expect(result).not.toBeNull()
+      expect(result!.pct).toBeCloseTo(10, 5)
+      expect(result!.abs).toBeCloseTo(1000, 5)
+    })
+
+    it('computes negative return', () => {
+      const result = computeReturn([snap('2026-01-01', 10000), snap('2026-05-01', 9000)])
+      expect(result!.pct).toBeCloseTo(-10, 5)
+      expect(result!.abs).toBeCloseTo(-1000, 5)
+    })
+
+    it('uses first and last points only, ignoring middle values', () => {
+      const result = computeReturn([
+        snap('2026-01-01', 10000),
+        snap('2026-03-01', 999999),
+        snap('2026-05-01', 12000),
+      ])
+      expect(result!.pct).toBeCloseTo(20, 5)
+      expect(result!.abs).toBeCloseTo(2000, 5)
+    })
+  })
+  ```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+  ```bash
+  cd apps/web && npx vitest run src/lib/investments/portfolioPerformance.test.ts
+  ```
+
+  Expected: all tests FAIL (module not found).
+
+- [ ] **Step 3: Implement helpers**
+
+  Create `apps/web/src/lib/investments/portfolioPerformance.ts`:
+
+  ```ts
+  export type RangeKey = '1M' | '3M' | '6M' | '1Y' | 'YTD' | 'All'
+
+  export interface SnapshotPoint {
+    date: string  // YYYY-MM-DD
+    value: number
+  }
+
+  export function filterSnapshotsByRange(
+    snapshots: SnapshotPoint[],
+    range: RangeKey,
+    now: Date,
+  ): SnapshotPoint[] {
+    if (range === 'All') return [...snapshots]
+
+    let cutoff: Date
+    if (range === 'YTD') {
+      cutoff = new Date(now.getFullYear(), 0, 1)
+    } else {
+      const monthsBack = { '1M': 1, '3M': 3, '6M': 6, '1Y': 12 }[range]
+      cutoff = new Date(now)
+      cutoff.setMonth(cutoff.getMonth() - monthsBack)
+    }
+
+    const cutoffStr = cutoff.toISOString().slice(0, 10)
+    return snapshots.filter((s) => s.date >= cutoffStr)
+  }
+
+  export function computeReturn(points: SnapshotPoint[]): { pct: number; abs: number } | null {
+    if (points.length < 2) return null
+    const first = points[0].value
+    const last = points[points.length - 1].value
+    if (first === 0) return null
+    return { pct: ((last - first) / first) * 100, abs: last - first }
+  }
+  ```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+  ```bash
+  cd apps/web && npx vitest run src/lib/investments/portfolioPerformance.test.ts
+  ```
+
+  Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add apps/web/src/lib/investments/portfolioPerformance.ts apps/web/src/lib/investments/portfolioPerformance.test.ts
+  git commit -m "feat(investments): add portfolio performance helpers (filterSnapshotsByRange, computeReturn)"
+  ```
+
+---
+
+## Task 4: `usePortfolioSnapshot` hook
+
+**Files:**
+- Create: `apps/web/src/lib/investments/usePortfolioSnapshot.ts`
+- Create: `apps/web/src/lib/investments/usePortfolioSnapshot.test.ts`
+
+- [ ] **Step 1: Write failing test for `computePortfolioTotalValue`**
+
+  Create `apps/web/src/lib/investments/usePortfolioSnapshot.test.ts`:
+
+  ```ts
+  import { describe, expect, it } from 'vitest'
+  import { computePortfolioTotalValue } from './usePortfolioSnapshot'
+  import type { BrokerageAccount, BrokeragePosition } from '@lokfi/brokerage-core'
+
+  const pos = (currency: string, marketValue: number): BrokeragePosition =>
+    ({ currency, marketValue, quantity: 0, avgCost: 0 } as unknown as BrokeragePosition)
+
+  const acc = (currency: string, cashBalance: number): BrokerageAccount =>
+    ({ currency, cashBalance } as unknown as BrokerageAccount)
+
+  const rates = { SGD: 1.35, USD: 1 }
+
+  describe('computePortfolioTotalValue', () => {
+    it('sums position market values without conversion when Original', () => {
+      const result = computePortfolioTotalValue(
+        [pos('USD', 1000), pos('SGD', 500)],
+        [],
+        'Original',
+        rates,
+      )
+      expect(result).toBeCloseTo(1500, 5)
+    })
+
+    it('converts positions and accounts to preferred currency', () => {
+      // 1000 USD → 1350 SGD, 500 SGD stays 500 SGD, 200 USD cash → 270 SGD
+      const result = computePortfolioTotalValue(
+        [pos('USD', 1000), pos('SGD', 500)],
+        [acc('USD', 200)],
+        'SGD',
+        rates,
+      )
+      expect(result).toBeCloseTo(1000 * 1.35 + 500 + 200 * 1.35, 2)
+    })
+
+    it('falls back to quantity * avgCost when marketValue is null', () => {
+      const position = { currency: 'USD', marketValue: null, quantity: 10, avgCost: 50 } as unknown as BrokeragePosition
+      const result = computePortfolioTotalValue([position], [], 'Original', null)
+      expect(result).toBeCloseTo(500, 5)
+    })
+
+    it('returns 0 for empty positions and accounts', () => {
+      expect(computePortfolioTotalValue([], [], 'SGD', rates)).toBe(0)
+    })
+  })
+  ```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+  ```bash
+  cd apps/web && npx vitest run src/lib/investments/usePortfolioSnapshot.test.ts
+  ```
+
+  Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `computePortfolioTotalValue` and `usePortfolioSnapshot`**
+
+  Create `apps/web/src/lib/investments/usePortfolioSnapshot.ts`:
+
+  ```ts
+  import type { BrokerageAccount, BrokeragePosition } from '@lokfi/brokerage-core'
+  import { useLiveQuery } from 'dexie-react-hooks'
+  import { useEffect } from 'react'
+  import { convertAmount } from '../fx/convert'
+  import { db } from '../db/db'
+  import type { CurrencyOption } from '../../pages/investments/currencyPreference'
+
+  export function computePortfolioTotalValue(
+    positions: BrokeragePosition[],
+    accounts: BrokerageAccount[],
+    preferredCurrency: CurrencyOption,
+    fxRates: Record<string, number> | null,
+  ): number {
+    const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+    let sum = 0
+    for (const p of positions) {
+      const v = p.marketValue ?? p.quantity * p.avgCost
+      sum += shouldConvert ? convertAmount(v, p.currency, preferredCurrency, fxRates) : v
+    }
+    for (const a of accounts) {
+      sum += shouldConvert ? convertAmount(a.cashBalance, a.currency, preferredCurrency, fxRates) : a.cashBalance
+    }
+    return sum
+  }
+
+  export function usePortfolioSnapshot(
+    preferredCurrency: CurrencyOption,
+    fxRates: Record<string, number> | null,
+  ): void {
+    const positions = useLiveQuery(() => db.brokeragePositions.toArray(), [])
+    const accounts = useLiveQuery(() => db.brokerageAccounts.toArray(), [])
+
+    useEffect(() => {
+      // Skip if data not loaded or currency is mixed-original (not comparable across currencies)
+      if (!positions || !accounts || preferredCurrency === 'Original') return
+      const totalValue = computePortfolioTotalValue(positions, accounts, preferredCurrency, fxRates)
+      const date = new Date().toISOString().slice(0, 10)
+      db.portfolioSnapshots.put({ date, totalValue, currency: preferredCurrency })
+    }, [positions, accounts, preferredCurrency, fxRates])
+  }
+  ```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+  ```bash
+  cd apps/web && npx vitest run src/lib/investments/usePortfolioSnapshot.test.ts
+  ```
+
+  Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add apps/web/src/lib/investments/usePortfolioSnapshot.ts apps/web/src/lib/investments/usePortfolioSnapshot.test.ts
+  git commit -m "feat(investments): add usePortfolioSnapshot hook and computePortfolioTotalValue helper"
+  ```
+
+---
+
+## Task 5: `PerformanceCard` UI + wire up in `OverviewTab`
+
+**Files:**
+- Modify: `apps/web/src/pages/investments/OverviewTab.tsx`
+
+- [ ] **Step 1: Update imports**
+
+  At the top of `apps/web/src/pages/investments/OverviewTab.tsx`, make these changes:
+
+  Add `Area`, `AreaChart`, `XAxis` to the recharts import:
+  ```ts
+  import { Area, AreaChart, Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
+  ```
+
+  Add `AXIS_TICK` to the chartTheme import:
+  ```ts
+  import { AXIS_TICK, TOOLTIP_STYLE } from '../../lib/charts/chartTheme'
+  ```
+
+  Add new imports after the existing imports:
+  ```ts
+  import { type RangeKey, type SnapshotPoint, computeReturn, filterSnapshotsByRange } from '../../lib/investments/portfolioPerformance'
+  import { usePortfolioSnapshot } from '../../lib/investments/usePortfolioSnapshot'
+  import type { DbPortfolioSnapshot } from '../../lib/db/db'
+  ```
+
+- [ ] **Step 2: Delete `PerformanceSparkline` and add `PerformanceCard`**
+
+  Remove the entire `PerformanceSparkline` function (the placeholder with the TODO comment) and replace it with `PerformanceCard`:
+
+  ```tsx
+  const PERFORMANCE_RANGES: RangeKey[] = ['1M', '3M', '6M', '1Y', 'YTD', 'All']
+
+  function PerformanceCard({
+    snapshots,
+    preferredCurrency,
+    fxRates,
+  }: {
+    snapshots: DbPortfolioSnapshot[]
+    preferredCurrency: CurrencyOption
+    fxRates: Record<string, number> | null
+  }) {
+    const [range, setRange] = useState<RangeKey>('1Y')
+
+    const shouldConvert = preferredCurrency !== 'Original' && fxRates != null
+
+    const points: SnapshotPoint[] = snapshots.map((s) => ({
+      date: s.date,
+      value:
+        shouldConvert && s.currency !== preferredCurrency
+          ? convertAmount(s.totalValue, s.currency, preferredCurrency, fxRates)
+          : s.totalValue,
+    }))
+
+    const filtered = filterSnapshotsByRange(points, range, new Date())
+    const ret = computeReturn(filtered)
+
+    const fmt = (v: number) => v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    const currencyLabel = preferredCurrency === 'Original' ? '' : `${preferredCurrency} `
+
+    const returnColor =
+      ret === null || ret.pct === 0
+        ? 'text-gray-900 dark:text-white'
+        : ret.pct > 0
+          ? 'text-emerald-600 dark:text-emerald-400'
+          : 'text-red-600 dark:text-red-400'
+
+    return (
+      <div
+        className="rounded-xl border p-5"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-sidebar)' }}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="font-serif text-sm font-medium text-gray-900 dark:text-white">Performance</h3>
+          <div className="flex gap-1">
+            {PERFORMANCE_RANGES.map((r) => (
+              <button
+                key={r}
+                type="button"
+                onClick={() => setRange(r)}
+                className={`rounded px-2 py-0.5 text-xs transition-colors ${
+                  r === range
+                    ? 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100'
+                    : 'text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800'
+                }`}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {ret !== null && (
+          <div className="mb-4">
+            <div className={`font-mono text-2xl font-semibold tabular-nums ${returnColor}`}>
+              {ret.pct >= 0 ? '+' : ''}
+              {ret.pct.toFixed(2)}%
+            </div>
+            <div className="text-xs text-gray-400">
+              {ret.abs >= 0 ? '+' : ''}
+              {currencyLabel}
+              {fmt(ret.abs)}
+            </div>
+          </div>
+        )}
+
+        {filtered.length < 2 ? (
+          <div className="flex h-40 items-center justify-center text-sm text-gray-400">
+            Sync again to start building history
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={160}>
+            <AreaChart data={filtered} margin={{ top: 4, right: 0, left: 0, bottom: 0 }}>
+              <defs>
+                <linearGradient id="perfGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--accent)" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="var(--accent)" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <XAxis dataKey="date" tick={AXIS_TICK} tickLine={false} axisLine={false} minTickGap={40} />
+              <Tooltip
+                contentStyle={TOOLTIP_STYLE}
+                formatter={(value: number) => [`${currencyLabel}${fmt(value)}`, 'Value']}
+              />
+              <Area
+                type="monotone"
+                dataKey="value"
+                stroke="var(--accent)"
+                strokeWidth={2}
+                fill="url(#perfGradient)"
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    )
+  }
+  ```
+
+- [ ] **Step 3: Update `OverviewTab` — add snapshot query, call hook, update loading check, replace render**
+
+  In the `OverviewTab` function body:
+
+  **Add snapshot query** after the existing `useLiveQuery` calls:
+  ```ts
+  const snapshots = useLiveQuery(() => db.portfolioSnapshots.orderBy('date').toArray(), [])
+  ```
+
+  **Add `snapshots === undefined` to the `isLoading` check:**
+  ```ts
+  const isLoading =
+    positions === undefined ||
+    accounts === undefined ||
+    fundDetails === undefined ||
+    buckets === undefined ||
+    assignments === undefined ||
+    snapshots === undefined
+  ```
+
+  **Call the snapshot hook** after the `isLoading` declaration:
+  ```ts
+  usePortfolioSnapshot(preferredCurrency, fxRates)
+  ```
+
+  **Replace the Performance sparkline render block** (the `{!isLoading && hasData && ...}` block at the bottom of the return) with:
+  ```tsx
+  {/* Performance card */}
+  {!isLoading && (
+    <div className="md:col-span-2 lg:col-span-3">
+      <PerformanceCard
+        snapshots={snapshots!}
+        preferredCurrency={preferredCurrency}
+        fxRates={fxRates}
+      />
+    </div>
+  )}
+  ```
+
+  Note: `PerformanceCard` is shown even when `!hasData` because it has its own empty state ("Sync again to start building history").
+
+- [ ] **Step 4: Run the full test suite**
+
+  ```bash
+  cd apps/web && npx vitest run
+  ```
+
+  Expected: all tests PASS with no regressions.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add apps/web/src/pages/investments/OverviewTab.tsx
+  git commit -m "feat(investments): add PerformanceCard with area chart and snapshot-based returns"
+  ```

--- a/docs/superpowers/specs/2026-05-11-investment-portfolio-buckets-design.md
+++ b/docs/superpowers/specs/2026-05-11-investment-portfolio-buckets-design.md
@@ -1,0 +1,183 @@
+# Investment Portfolio Buckets Design
+
+## Summary
+
+Add **Portfolio buckets** to Investments so users can assign each security to one user-defined investment grouping, such as `Growth`, `Income`, or `Cash`. Buckets are distinct from transaction categories and do not interact with transaction rules or `manualCategory`.
+
+The first version focuses on three outcomes:
+
+- Assign one bucket per security-level holding.
+- Filter holdings by bucket.
+- Show a pure bucket-total allocation breakdown in Investment Overview.
+
+Custom overview visualisations are intentionally deferred, but the aggregation model should be reusable by a later configurable-widget system.
+
+## Product Decisions
+
+- Use the UI term **Portfolio bucket**.
+- A security has exactly one bucket assignment.
+- Assignments are **security-level**, not brokerage-position-level. If `AAPL` appears in multiple synced rows, all `AAPL` stock positions share one bucket.
+- Default buckets are `Growth`, `Income`, and `Cash`.
+- Holdings without an assignment appear as `Unassigned`.
+- Bucket allocation is a pure bucket total view. It does not split buckets by listing market, holding currency, or display currency.
+- Currency remains a separate lens through the existing currency selector and currency breakdown card.
+- Custom visualisations are a later phase.
+
+## Existing Context
+
+Investment holdings are synced brokerage positions stored in Dexie:
+
+- `packages/brokerage-core/src/types.ts` defines `BrokeragePosition`.
+- `apps/web/src/lib/db/db.ts` defines `brokeragePositions`, `brokeragePositionExtensions`, `brokerageTransactions`, `brokerageFundDetails`, `brokerageAccounts`, and related stores.
+- `apps/web/src/lib/brokerage/dexie-sync-adapter.ts` replaces positions during sync, so user metadata must not be stored directly on `BrokeragePosition`.
+- `apps/web/src/pages/investments/OverviewTab.tsx` renders KPI cards, asset allocation, currency breakdown, and performance placeholder.
+- `apps/web/src/pages/investments/HoldingsTab.tsx` renders the holdings table and computes derived holding metrics.
+- Transaction category assignment uses `apps/web/src/pages/transactions/CategoryCombobox.tsx`, which provides the interaction pattern to mirror for bucket assignment: search, select, create inline, and colored labels.
+
+## Data Model
+
+Add dedicated user-owned Dexie tables.
+
+```ts
+interface DbPortfolioBucket {
+  id: string
+  name: string
+  color: string
+  sortOrder: number
+  isDefault: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+interface DbPortfolioBucketAssignment {
+  securityKey: string
+  bucketId: string
+  createdAt: string
+  updatedAt: string
+}
+```
+
+Suggested Dexie indexes:
+
+- `portfolioBuckets`: `id, sortOrder, name`
+- `portfolioBucketAssignments`: `securityKey, bucketId`
+
+Use a stable security-level key instead of position id. For stock-like v1 holdings, use a normalized key shaped like:
+
+```ts
+`${secType ?? 'STK'}:${symbol.toUpperCase()}`
+```
+
+This keeps `AAPL` stock assignments stable across brokerage sync replacement and across multiple position rows. Derivatives are excluded from v1 bucket assignment and bucket totals.
+
+Seed default buckets through a database migration so existing users receive `Growth`, `Income`, and `Cash`. Initial database population should also create the same defaults for new users.
+
+Profile backup export/import must include `portfolioBuckets` and `portfolioBucketAssignments`.
+
+`apps/web/src/pages/profile/ProfilePage.tsx` currently builds backup JSON by manually reading each Dexie table and validates imports by backup `version`. Implementation must update this path explicitly:
+
+- Increment the backup format from `version: 3` to `version: 4`.
+- Export `portfolioBuckets` and `portfolioBucketAssignments` arrays in the backup JSON.
+- Treat both arrays as required for v4 imports.
+- Include both tables in the import confirmation summary.
+- Include both tables in the destructive import transaction table list.
+- Clear and restore both tables during v4 import.
+- Continue accepting older v1-v3 backups by defaulting missing portfolio bucket arrays to empty arrays.
+- After importing an older backup that has no bucket tables, ensure default buckets exist so the Investments UI still has `Growth`, `Income`, and `Cash`.
+
+## Holdings UX
+
+Add a `Bucket` column to the stock-like holdings table. Each row shows a compact colored selector for the security's assigned bucket, or `Unassigned`.
+
+The selector should follow the transaction category assignment behavior:
+
+- Search existing buckets.
+- Select a bucket.
+- Create a new bucket inline from typed text.
+- Show colored bucket indicators.
+- Commit assignment immediately.
+- Allow clearing the assignment, returning the security to `Unassigned`.
+
+The UI should say `bucket` or `Portfolio bucket`, not `category`, to avoid confusion with transaction categories.
+
+Add a bucket filter near the existing holdings search:
+
+- `All buckets`
+- Each user bucket in sort order
+- `Unassigned`
+
+Filtering applies to the visible holdings table. Grouping can remain currency-based for v1; the bucket filter satisfies the core need to narrow holdings by user-defined investment grouping.
+
+## Bucket Management
+
+Bucket management should be available from the bucket selector and/or the Overview bucket card. It can be a compact modal or drawer rather than a dedicated tab.
+
+Users can:
+
+- Create a bucket.
+- Rename a bucket.
+- Change its color.
+- Reorder buckets.
+- Delete a bucket.
+
+Delete behavior:
+
+- Deleting a bucket removes its assignment rows.
+- Affected securities become `Unassigned`.
+- Default buckets are treated like normal user buckets after seeding, so they can be renamed or deleted.
+
+## Overview UX
+
+Add a **Portfolio by bucket** card to `OverviewTab`.
+
+The card aggregates current stock-like holdings by bucket. Derivatives are excluded from v1 bucket totals and remain visible in their existing Holdings section.
+
+- Use `marketValue` when present.
+- Fall back to `quantity * avgCost`.
+- Convert values using the existing preferred display currency and FX conversion behavior.
+- Include unassigned holdings as `Unassigned`.
+- Display value and percentage for each bucket.
+
+The existing asset allocation and currency breakdown cards can remain. The bucket card becomes the user-defined allocation view, while the existing cards continue to answer built-in asset type and currency questions.
+
+If no holdings exist, keep the current empty state. If holdings exist but no bucket assignments exist, the bucket card shows `Unassigned` as 100%.
+
+## Error Handling And Edge Cases
+
+- Missing bucket assignment: show `Unassigned`.
+- Missing bucket record for an assignment: treat as `Unassigned` and allow cleanup on next write.
+- Deleted bucket: remove assignment rows during delete.
+- Missing `marketValue`: use the current fallback calculation.
+- FX unavailable: follow existing overview warning/fallback behavior.
+- Same stock symbol across multiple brokerage rows: use the same bucket assignment.
+- Same symbol with different security type: keep separate via `secType:symbol`.
+- Derivatives: exclude from v1 bucket assignment and bucket totals.
+
+## Testing
+
+Add focused tests for:
+
+- Default bucket seeding/migration.
+- Security key generation and same-symbol assignment reuse.
+- Bucket creation and assignment persistence.
+- Clearing an assignment.
+- Deleting a bucket and returning holdings to `Unassigned`.
+- Holdings filtering by bucket.
+- Overview bucket aggregation.
+- Overview aggregation respecting preferred currency conversion and fallback market value behavior.
+- Profile backup export/import including buckets and assignments.
+- Older v1-v3 backup imports preserving compatibility and leaving default buckets available.
+
+## Later Phase: Custom Overview Visualisations
+
+Do not build custom visualisations in this version.
+
+The later phase can reuse bucket aggregation as one data source for configurable overview widgets. Candidate future widgets include:
+
+- Bucket allocation donut or bar chart.
+- Bucket x market matrix.
+- Bucket x currency matrix.
+- Custom cards selected by the user.
+- Reorderable overview layout.
+
+This design should avoid hard-coding bucket aggregation only inside one React component so future widgets can reuse the same calculation.

--- a/docs/superpowers/specs/2026-05-12-portfolio-performance-card-design.md
+++ b/docs/superpowers/specs/2026-05-12-portfolio-performance-card-design.md
@@ -1,0 +1,121 @@
+# Portfolio Performance Card
+
+**Date:** 2026-05-12
+**Status:** Approved
+
+## Overview
+
+Replace the placeholder `PerformanceSparkline` component in the investments Overview tab with a real performance card that plots portfolio value over time using daily snapshots captured on every brokerage sync.
+
+---
+
+## 1. Database Schema
+
+### New table: `portfolioSnapshots`
+
+| Field | Type | Notes |
+|---|---|---|
+| `date` | string (YYYY-MM-DD) | Primary key — one row per calendar day |
+| `totalValue` | number | Total portfolio value at time of snapshot |
+| `currency` | string | Currency used (e.g. `"SGD"`) |
+
+Using `date` as primary key means `db.portfolioSnapshots.put(snapshot)` deduplicates automatically — the latest sync of the day overwrites earlier ones.
+
+**Dexie version:** bump from v9 → v10, adding `portfolioSnapshots` with index `date`.
+
+---
+
+## 2. Snapshot Capture
+
+### `usePortfolioSnapshot` hook
+
+A new React hook that writes a snapshot after every sync.
+
+**Location:** `apps/web/src/lib/investments/usePortfolioSnapshot.ts`
+
+**Behaviour:**
+- Reads `positions` and `accounts` via `useLiveQuery`
+- Accepts `fxRates` and `preferredCurrency` as parameters (passed down from the investments page, same as today)
+- Computes `totalValue` using the same logic as `OverviewTab` (positions `marketValue ?? qty×avgCost` + account `cashBalance`, all converted to `preferredCurrency`)
+- On change, writes `db.portfolioSnapshots.put({ date: today, totalValue, currency: preferredCurrency })`
+- Today's date is `new Date().toISOString().slice(0, 10)`
+- No debounce needed — Dexie `put` is idempotent and the same-day value will simply overwrite
+
+**Called from:** `OverviewTab` (or the parent investments page), where `fxRates` and `preferredCurrency` are already available.
+
+---
+
+## 3. Performance Card UI
+
+### Component: `PerformanceCard`
+
+Replaces the existing `PerformanceSparkline` placeholder in `OverviewTab.tsx`.
+
+**Location:** inline in `OverviewTab.tsx` (same file as other chart components).
+
+**Layout:**
+
+```
+┌─────────────────────────────────────────────────┐
+│ Performance          1M · 3M · 6M · 1Y · YTD · All │
+│                                                 │
+│  +12.4%                                         │
+│  +SGD 4,200                                     │
+│                                                 │
+│  [area chart — portfolio value over time]       │
+└─────────────────────────────────────────────────┘
+```
+
+**Time range options:** `1M`, `3M`, `6M`, `1Y`, `YTD`, `All`. Default: `1Y`.
+
+**Return summary:**
+- `returnPct = (latest - first) / first * 100`
+- `returnAbs = latest - first`
+- Displayed in green (`text-emerald-*`) if positive, red (`text-red-*`) if negative
+
+**Chart:**
+- Recharts `AreaChart` with `ResponsiveContainer`
+- x-axis: date labels (auto-thinned by Recharts)
+- y-axis: hidden (value readable from tooltip)
+- Tooltip: uses `TOOLTIP_STYLE`, shows date + formatted value
+- Area fill: accent colour with low opacity
+
+**Currency conversion:**
+- At render time, each snapshot value is converted to `preferredCurrency` using current `fxRates` via `convertAmount(snapshot.totalValue, snapshot.currency, preferredCurrency, fxRates)`
+- If `preferredCurrency === 'Original'` or `fxRates` is null, values are used as-is
+
+**Empty / insufficient data state:**
+- Fewer than 2 snapshots in the selected range: show "Sync again to start building history" (no chart rendered)
+- The time range pills are still shown so users can explore
+
+---
+
+## 4. Backup / Export / Import
+
+### Version bump: v4 → v5
+
+**`LokfiBackup` interface** — add field:
+```ts
+portfolioSnapshots: unknown[]
+```
+
+**`BACKUP_VERSION`** — change from `4` to `5`.
+
+**`validateBackupShape`** — v5 requires `portfolioSnapshots` to be a present, non-null array.
+
+**`normalizeBackup`** — v4 and older backups default `portfolioSnapshots` to `[]`.
+
+**`buildBackupPayload`** — include `db.portfolioSnapshots.toArray()` in the `Promise.all`.
+
+**`importBackupPayload`** — if `data.portfolioSnapshots.length`, call `db.portfolioSnapshots.bulkAdd(...)`.
+
+**`buildImportSummary`** — add line: `• N portfolio snapshot(s)`.
+
+---
+
+## 5. Out of Scope
+
+- Retroactive snapshot reconstruction from transaction history
+- Per-account performance breakdown
+- Benchmark comparison (e.g. S&P 500)
+- Annualised return (XIRR / TWR)


### PR DESCRIPTION
## Summary

This PR adds two major features to the investments module: **portfolio bucket allocation** (categorizing holdings into strategy buckets with target percentages) and a **portfolio performance card** (tracking portfolio value over time via periodic snapshots).

### Portfolio Buckets
- New `portfolioBuckets` Dexie table (schema v9) with helpers (`portfolioBuckets.ts`)
- Bucket manager UI: create/edit/delete buckets, set target allocation percentages
- Bucket combobox on holdings: assign a bucket to each holding
- Portfolio bucket overview: per-holding slices with target vs actual comparison
- Bucket filter support in holdings search empty states
- Buckets included in backup/restore (v5)

### Portfolio Performance Card
- New `portfolioSnapshots` Dexie table (schema v10) for tracking portfolio value over time
- Helpers: `filterSnapshotsByRange`, `computeReturn`, `computePortfolioTotalValue`
- `usePortfolioSnapshot` hook for snapshot management (add/edit/delete)
- `PerformanceCard` component with an area chart showing portfolio value history and return metrics
- Snapshots included in backup/restore (v5)

### Other
- Fixed local date usage in brokerage sync
- Added `brokerageSyncLog` to clear-data stores
- Improved holdings empty states for search and bucket filter
- Applied Biome formatting to portfolio bucket files
- Documentation: design specs and implementation plans for both features