### PR TITLE
Add derivative unrealised P/L percent to holdings and fix broker percent scaling

### DIFF
--- a/apps/web/src/lib/brokerage/tiger/tiger-adapter.ts
+++ b/apps/web/src/lib/brokerage/tiger/tiger-adapter.ts
@@ -45,6 +45,7 @@ export function adaptPosition(raw: TigerPosition): BrokeragePosition {
     avgCost: raw.averageCost,
     marketValue: raw.marketValue,
     unrealizedPnl: raw.unrealizedPnl,
+    unrealizedPnlPercent: raw.unrealizedPnlPercent,
     // Option/derivative fields (only present for OPT, FUT, etc.)
     identifier: raw.identifier,
     multiplier: raw.multiplier,

--- a/apps/web/src/pages/investments/HoldingsTab.tsx
+++ b/apps/web/src/pages/investments/HoldingsTab.tsx
@@ -15,7 +15,7 @@ import {
 import { PortfolioBucketCombobox } from './PortfolioBucketCombobox'
 import { PortfolioBucketManager } from './PortfolioBucketManager'
 import type { CurrencyOption } from './currencyPreference'
-import { getAdjustedMetrics } from './holdingCalculations'
+import { computeDerivativeUnrealisedPnlPct, getAdjustedMetrics } from './holdingCalculations'
 import type { HoldingMetrics } from './holdingCalculations'
 
 interface HoldingsTabProps {
@@ -35,6 +35,7 @@ interface PositionRow {
   totalDividends: number
   adjCostBasisPerShare: number | null
   totalReturnPct: number | null
+  unrealisedPnlPct: number | null
   realisedPnl: number
   unrealisedPnl: number
   totalPnl: number
@@ -65,6 +66,11 @@ function getFormatter(currency: string): Intl.NumberFormat {
 
 function formatCurrency(amount: number, currency: string): string {
   return getFormatter(currency).format(amount)
+}
+
+function formatPercent(amount: number): string {
+  const sign = amount > 0 ? '+' : ''
+  return `${sign}${amount.toFixed(1)}%`
 }
 
 function HoldingDetailRow({ row, variant = 'stock' }: HoldingDetailRowProps) {
@@ -560,6 +566,11 @@ function HoldingsTable({
                     {showConverted && (
                       <div className="text-xs font-normal">{formatCurrency(row.pnl, position.currency)}</div>
                     )}
+                    {isDerivative && row.unrealisedPnlPct != null && (
+                      <div className={`text-xs font-normal ${pnClass(row.unrealisedPnlPct)}`}>
+                        {formatPercent(row.unrealisedPnlPct)}
+                      </div>
+                    )}
                   </div>
                 </td>
                 {!isDerivative && (
@@ -696,6 +707,7 @@ function toRow(position: BrokeragePosition, metrics?: HoldingMetrics): PositionR
     totalDividends: metrics?.totalDividends ?? 0,
     adjCostBasisPerShare: metrics?.adjCostBasisPerShare ?? null,
     totalReturnPct: metrics?.totalReturnPct ?? null,
+    unrealisedPnlPct: isDerivative(position) ? computeDerivativeUnrealisedPnlPct(position, pnl) : null,
     realisedPnl: metrics?.realisedStockPnl ?? 0,
     unrealisedPnl: metrics?.unrealisedPnl ?? pnl,
     totalPnl: metrics?.totalPnl ?? pnl,
@@ -929,7 +941,6 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
     )
   }
 
-
   // ── Main render ────────────────────────────────────────────────────────
 
   return (
@@ -1019,7 +1030,11 @@ export function HoldingsTab({ preferredCurrency, fxRates, fxLastUpdated, fxError
                 type="button"
                 onClick={() => setBucketFilter('all')}
                 className="mt-4 rounded-full border px-4 py-1.5 text-xs font-medium transition-colors hover:opacity-80"
-                style={{ borderColor: 'var(--accent)', color: 'var(--accent)', backgroundColor: 'var(--accent-subtle)' }}
+                style={{
+                  borderColor: 'var(--accent)',
+                  color: 'var(--accent)',
+                  backgroundColor: 'var(--accent-subtle)',
+                }}
               >
                 Show all holdings
               </button>

--- a/apps/web/src/pages/investments/holdingCalculations.test.ts
+++ b/apps/web/src/pages/investments/holdingCalculations.test.ts
@@ -1,6 +1,6 @@
 import type { BrokerageFundDetail, BrokerageTransaction } from '@lokfi/brokerage-core'
 import { describe, expect, it } from 'vitest'
-import { computeStockSalePnL, getDividends } from './holdingCalculations'
+import { computeDerivativeUnrealisedPnlPct, computeStockSalePnL, getDividends } from './holdingCalculations'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,6 +41,65 @@ function fundDetail(id: string, symbol: string, amount: number): BrokerageFundDe
     businessDate: '2025-01-15',
   }
 }
+
+// ---------------------------------------------------------------------------
+// computeDerivativeUnrealisedPnlPct
+// ---------------------------------------------------------------------------
+
+describe('computeDerivativeUnrealisedPnlPct', () => {
+  it('converts broker-provided unrealised P&L ratio to percentage points', () => {
+    expect(
+      computeDerivativeUnrealisedPnlPct({
+        id: 'CRWV_OPT_test',
+        source: 'test',
+        symbol: 'CRWV',
+        secType: 'OPT',
+        currency: 'USD',
+        quantity: -1,
+        avgCost: 1.2,
+        marketValue: -80,
+        unrealizedPnl: 40,
+        unrealizedPnlPercent: 0.3333,
+        multiplier: 100,
+        updatedAt: '2025-01-15T00:00:00Z',
+      })
+    ).toBeCloseTo(33.33, 5)
+  })
+
+  it('computes fallback percentage from unrealised P&L and absolute derivative cost basis', () => {
+    expect(
+      computeDerivativeUnrealisedPnlPct({
+        id: 'CRWV_OPT_test',
+        source: 'test',
+        symbol: 'CRWV',
+        secType: 'OPT',
+        currency: 'USD',
+        quantity: -2,
+        avgCost: 1.5,
+        unrealizedPnl: 90,
+        multiplier: 100,
+        updatedAt: '2025-01-15T00:00:00Z',
+      })
+    ).toBe(30)
+  })
+
+  it('returns null when derivative cost basis is zero', () => {
+    expect(
+      computeDerivativeUnrealisedPnlPct({
+        id: 'CRWV_OPT_test',
+        source: 'test',
+        symbol: 'CRWV',
+        secType: 'OPT',
+        currency: 'USD',
+        quantity: 0,
+        avgCost: 1.5,
+        unrealizedPnl: 90,
+        multiplier: 100,
+        updatedAt: '2025-01-15T00:00:00Z',
+      })
+    ).toBeNull()
+  })
+})
 
 // ---------------------------------------------------------------------------
 // computeStockSalePnL

--- a/apps/web/src/pages/investments/holdingCalculations.ts
+++ b/apps/web/src/pages/investments/holdingCalculations.ts
@@ -123,6 +123,19 @@ export function getTotalOptionPremiums(
   return getOptionPremiums(stockSymbol, optionPositions)
 }
 
+export function computeDerivativeUnrealisedPnlPct(position: BrokeragePosition, unrealisedPnl?: number): number | null {
+  if (position.unrealizedPnlPercent != null) return position.unrealizedPnlPercent * 100
+
+  const multiplier = position.multiplier ?? 1
+  const costBasis = Math.abs(position.quantity * position.avgCost * multiplier)
+  if (costBasis <= 0) return null
+
+  const pnl = unrealisedPnl ?? position.unrealizedPnl
+  if (pnl == null) return null
+
+  return (pnl / costBasis) * 100
+}
+
 /**
  * Compute realised P&L from partial stock sales.
  *

--- a/packages/brokerage-core/src/types.ts
+++ b/packages/brokerage-core/src/types.ts
@@ -49,6 +49,7 @@ export interface BrokeragePosition {
   avgCost: number
   marketValue?: number
   unrealizedPnl?: number
+  unrealizedPnlPercent?: number
   /** ISO-8601 timestamp of when this position was last fetched */
   updatedAt: string
   /** Option/derivative: OCC option symbol (e.g. "CRWV  260508P00106000") */


### PR DESCRIPTION
## Summary
- Surface unrealised P/L percent for derivative holdings inside the existing `Unreal. P&L` column, so the table stays compact.
- Preserve Tiger’s raw `unrealizedPnlPercent` on positions and normalize it correctly for display.
- Add focused tests for broker-provided percent, fallback calculation, and zero-basis handling.

## Testing
- `pnpm --filter @lokfi/web test`
- `pnpm --filter @lokfi/web build`
- `pnpm --filter @lokfi/brokerage-core test`
- `pnpm --filter @lokfi/brokerage-core build`
- Targeted Biome checks on touched files passed